### PR TITLE
update goroutine panic wrong stack text formate.

### DIFF
--- a/goroutine/goroutine.go
+++ b/goroutine/goroutine.go
@@ -50,7 +50,7 @@ func (g *Goroutine) _go() {
 				defer buffer.PutBytes(buf)
 				// recover panic
 				if g.logger == nil {
-					fmt.Println("recover go func,", "panic err:", err, "panic stack:", string((*buf)[:n]))
+					fmt.Println("\nrecover go func,", "panic:", err, "\n\npanic stack:\n", string((*buf)[:n]))
 					return
 				}
 				g.logger.Log(log.LevelError, "panic err:", err, "panic stack:", string((*buf)[:n]))


### PR DESCRIPTION
Similar to the native panic error output format, the error message of the panic and the corresponding function stack of the panic are output in a separate line, which is more intuitive.