### PR TITLE
Revise test cases to ensure correct results even on high-performance …

### DIFF
--- a/concurrent/stream_test.go
+++ b/concurrent/stream_test.go
@@ -35,7 +35,7 @@ func TestStream(t *testing.T) {
 	ret = nil
 	for v := range c {
 		ret = append(ret, v.(int))
-		time.Sleep(time.Second)
+		time.Sleep(time.Second + time.Millisecond)
 	}
 	assert.Equal(t, []int{0, 1, 2}, ret)
 }
@@ -56,7 +56,7 @@ func TestTaskN(t *testing.T) {
 	ret = nil
 	for v := range taskN {
 		ret = append(ret, v.(int))
-		time.Sleep(time.Second)
+		time.Sleep(time.Second + time.Millisecond)
 	}
 	assert.Equal(t, []int{0, 1, 2}, ret)
 }


### PR DESCRIPTION
    stream_test.go:61: 
        	Error Trace:	E:/work/gkit/concurrent/stream_test.go:61
        	Error:      	Not equal: 
        	            	expected: []int{0, 1, 2}
        	            	actual  : []int{0, 1, 2, 3}
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,5 +1,6 @@
        	            	-([]int) (len=3) {
        	            	+([]int) (len=4) {
        	            	  (int) 0,
        	            	  (int) 1,
        	            	- (int) 2
        	            	+ (int) 2,
        	            	+ (int) 3
        	            	 }
        	Test:       	TestTaskN
--- FAIL: TestTaskN (4.00s)

Expected :[]int{0, 1, 2}
Actual   :[]int{0, 1, 2, 3}
<Click to see difference>