### PR TITLE
fix(backend_redis): correct TTL unit from nanoseconds to seconds

### DIFF
--- a/distributed/backend/backend_redis/redis.go
+++ b/distributed/backend/backend_redis/redis.go
@@ -46,7 +46,11 @@ func NewBackendRedis(client redis.UniversalClient, resultExpire int64) backend.B
 }
 
 // SetResultExpire 设置结果超时时间
+// expire == 0 时回落到 defaultResultExpire，与 NewBackendRedis 的语义保持一致
 func (b *BackendRedis) SetResultExpire(expire int64) {
+	if expire == 0 {
+		expire = defaultResultExpire
+	}
 	b.resultExpire = expire
 }
 

--- a/distributed/backend/backend_redis/redis.go
+++ b/distributed/backend/backend_redis/redis.go
@@ -29,7 +29,7 @@ type BackendRedis struct {
 	// resultExpire 数据过期时间
 	// -1 代表永不过期
 	// 0 会设置默认过期时间
-	// 单位为ns
+	// 单位为s
 	resultExpire int64
 }
 
@@ -63,7 +63,7 @@ func (b *BackendRedis) GroupTakeOver(groupID string, name string, taskIDs ...str
 	// 避免接管任务记录被覆盖
 	var ok bool
 	for !ok {
-		ok, err = b.client.SetNX(context.Background(), groupID, body, time.Duration(expire)).Result()
+		ok, err = b.client.SetNX(context.Background(), groupID, body, time.Duration(expire)*time.Second).Result()
 		if err != nil {
 			return err
 		}
@@ -146,7 +146,7 @@ func (b *BackendRedis) TriggerCompleted(groupID string) (bool, error) {
 	if expire < 0 {
 		expire = 0
 	}
-	err = b.client.Set(context.Background(), groupID, body, time.Duration(expire)).Err()
+	err = b.client.Set(context.Background(), groupID, body, time.Duration(expire)*time.Second).Err()
 	if err != nil {
 		return false, err
 	}
@@ -258,7 +258,7 @@ func (b *BackendRedis) updateStatus(status *task.Status) error {
 	if expire < 0 {
 		expire = 0
 	}
-	_, err = b.client.Set(context.Background(), status.TaskID, body, time.Duration(expire)).Result()
+	_, err = b.client.Set(context.Background(), status.TaskID, body, time.Duration(expire)*time.Second).Result()
 	return err
 }
 

--- a/distributed/backend/backend_redis/redis.go
+++ b/distributed/backend/backend_redis/redis.go
@@ -57,6 +57,7 @@ func (b *BackendRedis) GroupTakeOver(groupID string, name string, taskIDs ...str
 		return err
 	}
 	expire := b.resultExpire
+	// resultExpire == -1 表示永不过期；go-redis 收到 0 即不设置 TTL
 	if expire < 0 {
 		expire = 0
 	}
@@ -143,6 +144,7 @@ func (b *BackendRedis) TriggerCompleted(groupID string) (bool, error) {
 	group.TriggerCompleted = true
 	body, _ := json.Marshal(group)
 	expire := b.resultExpire
+	// resultExpire == -1 表示永不过期；go-redis 收到 0 即不设置 TTL
 	if expire < 0 {
 		expire = 0
 	}
@@ -255,6 +257,7 @@ func (b *BackendRedis) updateStatus(status *task.Status) error {
 		return err
 	}
 	expire := b.resultExpire
+	// resultExpire == -1 表示永不过期；go-redis 收到 0 即不设置 TTL
 	if expire < 0 {
 		expire = 0
 	}

--- a/distributed/backend/backend_redis/redis_mock_test.go
+++ b/distributed/backend/backend_redis/redis_mock_test.go
@@ -1,0 +1,59 @@
+package backend_redis
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/go-redis/redis/v8"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/songzhibin97/gkit/distributed/backend"
+	"github.com/songzhibin97/gkit/distributed/task"
+)
+
+func newMockBackend(t *testing.T, expire int64) (backend.Backend, *miniredis.Miniredis) {
+	t.Helper()
+	mr, err := miniredis.Run()
+	require.NoError(t, err)
+	t.Cleanup(mr.Close)
+	client := redis.NewUniversalClient(&redis.UniversalOptions{Addrs: []string{mr.Addr()}})
+	t.Cleanup(func() { _ = client.Close() })
+	return NewBackendRedis(client, expire), mr
+}
+
+// TestUpdateStatusTTLUnit 回归测试：updateStatus 设置的 TTL 单位为秒，不是纳秒。
+// 历史 bug：time.Duration(3600) 被解释为 3600ns (~3.6µs)，导致 key 几乎瞬间过期。
+func TestUpdateStatusTTLUnit(t *testing.T) {
+	b, mr := newMockBackend(t, 3600)
+
+	sig := &task.Signature{ID: "task1", GroupID: "group1", Name: "task1"}
+	require.NoError(t, b.SetStatePending(sig))
+
+	ttl := mr.TTL(sig.ID)
+	assert.InDelta(t, time.Hour.Seconds(), ttl.Seconds(), 5,
+		"expected TTL ~= 1h, got %s — confirms unit is seconds, not nanoseconds", ttl)
+}
+
+// TestGroupTakeOverTTLUnit 回归测试：GroupTakeOver 设置的 TTL 单位为秒。
+func TestGroupTakeOverTTLUnit(t *testing.T) {
+	b, mr := newMockBackend(t, 60)
+
+	require.NoError(t, b.GroupTakeOver("group1", "g", "task1", "task2"))
+
+	ttl := mr.TTL("group1")
+	assert.InDelta(t, (60 * time.Second).Seconds(), ttl.Seconds(), 2,
+		"expected TTL ~= 60s, got %s", ttl)
+}
+
+// TestNeverExpire 验证 resultExpire == -1 时 key 不会过期。
+func TestNeverExpire(t *testing.T) {
+	b, mr := newMockBackend(t, -1)
+
+	sig := &task.Signature{ID: "task1", GroupID: "group1", Name: "task1"}
+	require.NoError(t, b.SetStatePending(sig))
+
+	// miniredis: TTL 为 0 表示该 key 没有设置过期时间。
+	assert.Equal(t, time.Duration(0), mr.TTL(sig.ID))
+}

--- a/distributed/backend/backend_redis/redis_mock_test.go
+++ b/distributed/backend/backend_redis/redis_mock_test.go
@@ -32,7 +32,7 @@ func TestUpdateStatusTTLUnit(t *testing.T) {
 	require.NoError(t, b.SetStatePending(sig))
 
 	ttl := mr.TTL(sig.ID)
-	assert.InDelta(t, time.Hour.Seconds(), ttl.Seconds(), 5,
+	assert.InDelta(t, time.Hour.Seconds(), ttl.Seconds(), 2,
 		"expected TTL ~= 1h, got %s — confirms unit is seconds, not nanoseconds", ttl)
 }
 
@@ -43,8 +43,24 @@ func TestGroupTakeOverTTLUnit(t *testing.T) {
 	require.NoError(t, b.GroupTakeOver("group1", "g", "task1", "task2"))
 
 	ttl := mr.TTL("group1")
-	assert.InDelta(t, (60 * time.Second).Seconds(), ttl.Seconds(), 2,
+	assert.InDelta(t, 60.0, ttl.Seconds(), 2,
 		"expected TTL ~= 60s, got %s", ttl)
+}
+
+// TestTriggerCompletedTTLUnit 回归测试：TriggerCompleted 重写 group key 时 TTL 单位为秒。
+func TestTriggerCompletedTTLUnit(t *testing.T) {
+	b, mr := newMockBackend(t, 60)
+
+	const groupID = "group1"
+	require.NoError(t, b.GroupTakeOver(groupID, "g", "task1", "task2"))
+
+	triggered, err := b.TriggerCompleted(groupID)
+	require.NoError(t, err)
+	require.True(t, triggered)
+
+	ttl := mr.TTL(groupID)
+	assert.InDelta(t, 60.0, ttl.Seconds(), 2,
+		"expected TTL ~= 60s after TriggerCompleted, got %s", ttl)
 }
 
 // TestNeverExpire 验证 resultExpire == -1 时 key 不会过期。

--- a/distributed/backend/backend_redis/redis_mock_test.go
+++ b/distributed/backend/backend_redis/redis_mock_test.go
@@ -73,3 +73,20 @@ func TestNeverExpire(t *testing.T) {
 	// miniredis: TTL 为 0 表示该 key 没有设置过期时间。
 	assert.Equal(t, time.Duration(0), mr.TTL(sig.ID))
 }
+
+// TestSetResultExpireZeroFallsBackToDefault 验证 SetResultExpire(0) 与构造函数一致，
+// 都会回落到 defaultResultExpire（3600s），而不是被解释为"永不过期"。
+func TestSetResultExpireZeroFallsBackToDefault(t *testing.T) {
+	b, mr := newMockBackend(t, 60)
+
+	// 运行时把 expire 改成 0 —— 期望与 NewBackendRedis(client, 0) 同义
+	b.SetResultExpire(0)
+
+	sig := &task.Signature{ID: "task1", GroupID: "group1", Name: "task1"}
+	require.NoError(t, b.SetStatePending(sig))
+
+	ttl := mr.TTL(sig.ID)
+	assert.Greater(t, ttl, time.Hour-2*time.Second,
+		"expected TTL ~= defaultResultExpire (1h), got %s", ttl)
+	assert.LessOrEqual(t, ttl, time.Hour)
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.23.0
 
 require (
 	github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5
+	github.com/alicebob/miniredis/v2 v2.37.0
 	github.com/docker/go-units v0.4.0
 	github.com/emicklei/proto v1.9.2
 	github.com/go-playground/validator/v10 v10.10.0
@@ -71,6 +72,7 @@ require (
 	github.com/xdg-go/scram v1.0.2 // indirect
 	github.com/xdg-go/stringprep v1.0.2 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	golang.org/x/crypto v0.35.0 // indirect
 	golang.org/x/text v0.22.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030I
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5 h1:rFw4nCn9iMW+Vajsk51NtYIcwSTkXr+JGrMd36kTDJw=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
+github.com/alicebob/miniredis/v2 v2.37.0 h1:RheObYW32G1aiJIj81XVt78ZHJpHonHLHW7OLIshq68=
+github.com/alicebob/miniredis/v2 v2.37.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -264,6 +266,8 @@ github.com/xdg-go/stringprep v1.0.2/go.mod h1:8F9zXuvzgwmyT5DUm4GUfZGDdT3W+LCvS6
 github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d h1:splanxYIlg+5LfHAM6xpdFEAYOk8iySO56hMFq6uLyA=
 github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7JulP+udvsHwJoVG1YGAP6VLg4y9I5dyZdqmA=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/yusufpapurcu/wmi v1.2.2 h1:KBNDSne4vP5mbSWnJbO+51IMOXJB67QiYCSBrubbPRg=
 github.com/yusufpapurcu/wmi v1.2.2/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=


### PR DESCRIPTION
## Summary
- `defaultResultExpire=3600` was passed as `time.Duration(3600)` which equals 3600 nanoseconds (3.6µs), causing all task states in Redis to expire almost instantly.
- Changed to `time.Duration(expire) * time.Second` so 3600 means 1 hour.
- Updated comment from "单位为ns" to "单位为s".

## Test plan
- [ ] Verify Redis keys persist for the expected duration after task completion