### PR TITLE
fix(delayed): fix data race, invalid check, blocking refresh, and index panic

### DIFF
--- a/delayed/do.go
+++ b/delayed/do.go
@@ -78,7 +78,7 @@ func (d *DispatchingDelayed) delDelayed(i int) Delayed {
 	}
 	d.delays[last] = nil
 	d.delays = d.delays[:last]
-	if i != last && last > 0 {
+	if i != last {
 		siftupDelayed(d.delays, i)
 		siftdownDelayed(d.delays, i)
 	}
@@ -119,6 +119,32 @@ func (d *DispatchingDelayed) getTopDelayed() Delayed {
 	return d.delays[0]
 }
 
+// popIfReady 在持锁状态下检查 top 是否已到达执行时间；
+// 是则 pop 并返回，否则返回 BadDelayed。
+// 把"判断 + pop"合到同一把锁里，避免 sentinel 中无锁读 len(d.delays)
+// 以及 getTopDelayed/delDelayedTop 分离造成的 TOCTOU。
+func (d *DispatchingDelayed) popIfReady(now int64) Delayed {
+	d.Lock()
+	defer d.Unlock()
+	if len(d.delays) == 0 {
+		return BadDelayed
+	}
+	if d.delays[0].ExecTime() > now {
+		return BadDelayed
+	}
+	ret := d.delays[0]
+	last := len(d.delays) - 1
+	if last > 0 {
+		d.delays[0] = d.delays[last]
+	}
+	d.delays[last] = nil
+	d.delays = d.delays[:last]
+	if last > 0 {
+		siftdownDelayed(d.delays, 0)
+	}
+	return ret
+}
+
 // IsInvalid 判断任务是否有效
 func (d *DispatchingDelayed) IsInvalid(delayed Delayed) bool {
 	return delayed == BadDelayed
@@ -150,27 +176,22 @@ func (d *DispatchingDelayed) sentinel() {
 			case <-timer.C:
 			case <-d.refresh:
 			case <-d.close:
-				// 关闭流程
-				ln := len(d.delays)
-				for i := 0; i < ln; i++ {
+				// 关闭流程：pop 驱动，避免无锁读 len(d.delays)
+				for {
 					pop := d.delDelayedTop()
 					if d.IsInvalid(pop) {
-						continue
+						break
 					}
 					d.pool.AddTask(pop.Do)
 				}
 				return
 			}
 			now := time.Now().Unix()
-			for i := 0; i < len(d.delays); i++ {
-				top := d.getTopDelayed()
-
-				// 还没到达执行时间
-				if top.ExecTime() > now {
+			for {
+				top := d.popIfReady(now)
+				if d.IsInvalid(top) {
 					break
 				}
-
-				d.delDelayedTop()
 				d.pool.AddTask(top.Do)
 			}
 		}

--- a/delayed/do.go
+++ b/delayed/do.go
@@ -71,20 +71,19 @@ func (d *DispatchingDelayed) delDelayed(i int) Delayed {
 		return BadDelayed
 	}
 
+	ret := d.delays[i]
 	last := len(d.delays) - 1
 	if i != last {
 		d.delays[i] = d.delays[last]
 	}
 	d.delays[last] = nil
 	d.delays = d.delays[:last]
-	smallestChanged := i
-	if i != last {
-		// Moving to i may have moved the last timer to a new parent,
-		// so sift up to preserve the heap guarantee.
-		smallestChanged = siftupDelayed(d.delays, i)
+	if i != last && last > 0 {
+		siftupDelayed(d.delays, i)
+		siftdownDelayed(d.delays, i)
 	}
 
-	return d.delays[smallestChanged]
+	return ret
 }
 
 // delDelayedTop pop最小时间
@@ -113,7 +112,7 @@ func (d *DispatchingDelayed) delDelayedTop() Delayed {
 // getTopDelayed 获取下一个需要执行的任务
 func (d *DispatchingDelayed) getTopDelayed() Delayed {
 	d.RLock()
-	d.RUnlock()
+	defer d.RUnlock()
 	if len(d.delays) == 0 {
 		return BadDelayed
 	}
@@ -122,7 +121,7 @@ func (d *DispatchingDelayed) getTopDelayed() Delayed {
 
 // IsInvalid 判断任务是否有效
 func (d *DispatchingDelayed) IsInvalid(delayed Delayed) bool {
-	return delayed == badDelayed{}
+	return delayed == BadDelayed
 }
 
 // Close 关闭
@@ -138,6 +137,7 @@ func (d *DispatchingDelayed) Close() error {
 func (d *DispatchingDelayed) Refresh() {
 	select {
 	case d.refresh <- struct{}{}:
+	default:
 	}
 }
 

--- a/delayed/do_test.go
+++ b/delayed/do_test.go
@@ -205,3 +205,29 @@ func TestGetTopDelayed_Race(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+// TestSentinel_NoRaceOnDelays 在 -race 下覆盖 sentinel 主循环对 d.delays 的访问：
+// 早先 `for i := 0; i < len(d.delays); i++` 与 close 流程的 `ln := len(d.delays)`
+// 都是无锁读，与 AddDelayed 加锁写并发会触发 data race。
+// 修复后 sentinel 改为 popIfReady（锁内 pop）/ pop 驱动循环，并发场景应通过。
+func TestSentinel_NoRaceOnDelays(t *testing.T) {
+	n := NewDispatchingDelayed(
+		SetCheckTime(time.Millisecond),
+		SetSingle(), // 关闭 signal handler，避免污染全局信号
+	)
+	defer func() { _ = n.Close() }()
+
+	var wg sync.WaitGroup
+	now := time.Now().Unix()
+	for i := 0; i < 200; i++ {
+		wg.Add(1)
+		go func(v int64) {
+			defer wg.Done()
+			n.AddDelayed(mockDelayed{exec: v})
+			n.Refresh()
+		}(now + int64(i%5))
+	}
+	wg.Wait()
+	// 让 sentinel 跑几个 tick，触发与 AddDelayed 的窗口重叠
+	time.Sleep(50 * time.Millisecond)
+}

--- a/delayed/do_test.go
+++ b/delayed/do_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/stretchr/testify/assert"
 	"os"
+	"sync"
 	"testing"
 	"time"
 )
@@ -131,4 +132,76 @@ func TestDispatchingDelayed_AddDelayed3(t *testing.T) {
 	}
 	// print 0...9
 	time.Sleep(time.Minute)
+}
+
+// TestIsInvalid 锁定 IsInvalid 必须基于哨兵指针单例 BadDelayed 比较；
+// 早先 `delayed == badDelayed{}`（值类型）的写法对 *badDelayed 指针恒为 false。
+func TestIsInvalid(t *testing.T) {
+	d := &DispatchingDelayed{}
+	assert.True(t, d.IsInvalid(BadDelayed))
+	assert.False(t, d.IsInvalid(mockDelayed{exec: 1}))
+}
+
+// TestRefresh_NonBlocking 验证 Refresh 在 sentinel 未消费时不阻塞。
+// refresh 通道 buffer=1，第一次写入后再次调用必须走 default 分支。
+func TestRefresh_NonBlocking(t *testing.T) {
+	d := &DispatchingDelayed{refresh: make(chan struct{}, 1)}
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 100; i++ {
+			d.Refresh()
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Refresh blocked when channel buffer was full")
+	}
+}
+
+// TestDelDelayed_LastIndex 覆盖 i == last 边界：
+// 早先在末尾元素截断后访问 d.delays[last] 会触发 index out of range panic。
+func TestDelDelayed_LastIndex(t *testing.T) {
+	d := &DispatchingDelayed{}
+	d.AddDelayed(mockDelayed{exec: 1})
+	d.AddDelayed(mockDelayed{exec: 2})
+	d.AddDelayed(mockDelayed{exec: 3})
+
+	last := len(d.delays) - 1
+	expected := d.delays[last]
+
+	assert.NotPanics(t, func() {
+		ret := d.delDelayed(last)
+		assert.Equal(t, expected, ret)
+	})
+	assert.Equal(t, 2, len(d.delays))
+}
+
+// TestDelDelayed_OutOfRange 越界索引返回 BadDelayed，不修改堆。
+func TestDelDelayed_OutOfRange(t *testing.T) {
+	d := &DispatchingDelayed{}
+	d.AddDelayed(mockDelayed{exec: 1})
+	ret := d.delDelayed(10)
+	assert.True(t, d.IsInvalid(ret))
+	assert.Equal(t, 1, len(d.delays))
+}
+
+// TestGetTopDelayed_Race 在 -race 下应触发既往的数据竞争（修复前 RUnlock 立即调用，
+// d.delays 读取无锁保护）。修复后 (defer d.RUnlock()) 应通过。
+func TestGetTopDelayed_Race(t *testing.T) {
+	d := &DispatchingDelayed{}
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(2)
+		go func(v int64) {
+			defer wg.Done()
+			d.AddDelayed(mockDelayed{exec: v})
+		}(int64(i + 1))
+		go func() {
+			defer wg.Done()
+			_ = d.getTopDelayed()
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
## Summary
- **getTopDelayed**: `RUnlock()` was called immediately after `RLock()` without `defer`, leaving `d.delays` reads unprotected (data race)
- **IsInvalid**: compared against `badDelayed{}` (value) instead of `BadDelayed` (pointer), so it always returned false — sentinel shutdown could not detect the bad-delayed sentinel
- **Refresh**: missing `default` branch caused caller to block indefinitely when sentinel goroutine was busy
- **delDelayed**: when `i == last`, accessed `d.delays[smallestChanged]` after truncation → index out of range panic. Now returns the deleted element directly.

## Test plan
- [ ] `go test -race ./delayed/...`
- [ ] Verify IsInvalid correctly detects BadDelayed
- [ ] Verify Refresh does not block when sentinel is processing