### PR TITLE
fix(goroutine): correct CAS direction in Shutdown

### DIFF
--- a/goroutine/goroutine.go
+++ b/goroutine/goroutine.go
@@ -134,7 +134,7 @@ func (g *Goroutine) ChangeMax(m int64) {
 // Shutdown 优雅关闭
 // 符合幂等性
 func (g *Goroutine) Shutdown() error {
-	if atomic.CompareAndSwapInt32(&g.close, 0, 1) {
+	if !atomic.CompareAndSwapInt32(&g.close, 0, 1) {
 		return ErrRepeatClose
 	}
 	g.cancel()


### PR DESCRIPTION
## Summary
- `CompareAndSwapInt32(&g.close, 0, 1)` succeeding means first close, but the code returned `ErrRepeatClose` on success
- First `Shutdown()` call was a complete no-op: channel never closed, cancel never called, all goroutines leaked
- Added `!` to negate the CAS check

## Test plan
- [ ] `go test -race ./goroutine/...`
- [ ] Verify first Shutdown() actually closes the pool