### PR TITLE
fix(timeout): correct month/year constants in HumanDurationFormat

### DIFF
--- a/timeout/human.go
+++ b/timeout/human.go
@@ -25,13 +25,13 @@ func HumanDurationFormat(stamp int64, designation ...time.Time) string {
 		return fmt.Sprintf("%d天前", now/(24*time.Hour))
 	}
 
-	if now < 30*7*24*time.Hour {
+	if now < 30*24*time.Hour {
 		return fmt.Sprintf("%d周前", now/(7*24*time.Hour))
 	}
 
-	if now < 12*30*7*24*time.Hour {
-		return fmt.Sprintf("%d月前", now/(30*7*24*time.Hour))
+	if now < 12*30*24*time.Hour {
+		return fmt.Sprintf("%d月前", now/(30*24*time.Hour))
 	}
 
-	return fmt.Sprintf("%d年前", now/(12*30*7*24*time.Hour))
+	return fmt.Sprintf("%d年前", now/(12*30*24*time.Hour))
 }

--- a/timeout/human_test.go
+++ b/timeout/human_test.go
@@ -1,0 +1,49 @@
+package timeout
+
+import (
+	"testing"
+	"time"
+)
+
+func TestHumanDurationFormat(t *testing.T) {
+	base := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name string
+		ago  time.Duration
+		want string
+	}{
+		{"小于一分钟", 30 * time.Second, "刚刚"},
+		{"分钟边界-1分钟", time.Minute, "1分钟前"},
+		{"分钟边界-59分钟", 59 * time.Minute, "59分钟前"},
+		{"小时边界-1小时", time.Hour, "1小时前"},
+		{"小时边界-23小时", 23 * time.Hour, "23小时前"},
+		{"天边界-1天", 24 * time.Hour, "1天前"},
+		{"天边界-6天", 6 * 24 * time.Hour, "6天前"},
+		{"周边界-7天", 7 * 24 * time.Hour, "1周前"},
+		{"周边界-29天", 29 * 24 * time.Hour, "4周前"},
+		{"月边界-30天", 30 * 24 * time.Hour, "1月前"},
+		{"月边界-60天", 60 * 24 * time.Hour, "2月前"},
+		{"月边界-359天", 359 * 24 * time.Hour, "11月前"},
+		{"年边界-360天", 360 * 24 * time.Hour, "1年前"},
+		{"年边界-400天", 400 * 24 * time.Hour, "1年前"},
+		{"年边界-720天", 720 * 24 * time.Hour, "2年前"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stamp := base.Add(-tt.ago).Unix()
+			got := HumanDurationFormat(stamp, base)
+			if got != tt.want {
+				t.Errorf("HumanDurationFormat(ago=%v) = %q, want %q", tt.ago, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHumanDurationFormat_DefaultNow(t *testing.T) {
+	stamp := time.Now().Add(-30 * time.Second).Unix()
+	if got := HumanDurationFormat(stamp); got != "刚刚" {
+		t.Errorf("HumanDurationFormat() = %q, want %q", got, "刚刚")
+	}
+}


### PR DESCRIPTION
## Summary
- Month threshold was `30*7*24h` = 210 days instead of `30*24h` = 30 days
- Year threshold was `12*30*7*24h` = 2520 days instead of `12*30*24h` = 360 days
- This caused "周前" to display for up to 210 days; "月前"/"年前" were nearly unreachable

## Test plan
- [ ] `go test ./timeout/...`
- [ ] Verify: 60 days ago → "2月前", 400 days ago → "1年前"