### PR TITLE
fix(errors): check se != nil instead of err != nil in Code/Reason

### DIFF
--- a/errors/error.go
+++ b/errors/error.go
@@ -98,7 +98,7 @@ func Code(err error) int {
 	if err == nil {
 		return 0
 	}
-	if se := FromError(err); err != nil {
+	if se := FromError(err); se != nil {
 		return int(se.Code)
 	}
 	return UnknownCode
@@ -106,7 +106,7 @@ func Code(err error) int {
 
 // Reason 返回err的reason
 func Reason(err error) string {
-	if se := FromError(err); err != nil {
+	if se := FromError(err); se != nil {
 		return se.Reason
 	}
 	return UnknownReason


### PR DESCRIPTION
## Summary
- Both `Code()` and `Reason()` checked `err != nil` (always true at that point) instead of `se != nil`
- When `FromError` returns nil, this caused nil pointer dereference accessing `se.Code`/`se.Reason`

## Test plan
- [ ] `go test ./errors/...`
- [ ] Verify `Code(someNonGkitError)` returns `UnknownCode` instead of panicking