### PR TITLE
fix(local_cache): remove erroneous delete on cache hit in get()

### DIFF
--- a/cache/local_cache/cache.go
+++ b/cache/local_cache/cache.go
@@ -149,7 +149,6 @@ func (c *cache) get(k string) (interface{}, bool) {
 			c._delete(k)
 			return nil, false
 		}
-		c._delete(k)
 		return v.Val, true
 	}
 }


### PR DESCRIPTION
## Summary
- Internal `get()` called `_delete(k)` even on valid, non-expired keys
- This caused `Add()` and `Replace()` to silently remove existing keys during existence checks, breaking their semantics

## Test plan
- [ ] `go test -race ./cache/local_cache/...`
- [ ] Verify: `Set("k",v)` then `Add("k",v2)` correctly returns CacheExist error