### PR TITLE
fix(parser): use tType.Value instead of tType.Key for map value type

### DIFF
--- a/parser/parse_go/model.go
+++ b/parser/parse_go/model.go
@@ -182,7 +182,7 @@ func (g *GoParsePB) parseStruct(st *ast.GenDecl) {
 							if !ok {
 								continue
 							}
-							mValue, ok := tType.Key.(*ast.Ident)
+							mValue, ok := tType.Value.(*ast.Ident)
 							if !ok {
 								continue
 							}


### PR DESCRIPTION
## Summary
- Map value type extraction used `tType.Key` twice (copy-paste error), causing all map fields to have their value type resolved as the key type

## Test plan
- [ ] `go test ./parser/...`
- [ ] Verify `map[string]int` generates correct proto `map<string,int32>` instead of `map<string,string>`