### PR TITLE
fix(wgroup): call wg.Done on enqueue failure to prevent Wait deadlock

### DIFF
--- a/wgroup/wgroup.go
+++ b/wgroup/wgroup.go
@@ -18,18 +18,26 @@ func (g *Group) Wait() {
 
 func (g *Group) AddTask(f func()) bool {
 	g.wg.Add(1)
-	return g.goroutine.AddTask(func() {
+	if !g.goroutine.AddTask(func() {
 		defer g.wg.Done()
 		f()
-	})
+	}) {
+		g.wg.Done()
+		return false
+	}
+	return true
 }
 
 func (g *Group) AddTaskN(ctx context.Context, f func()) bool {
 	g.wg.Add(1)
-	return g.goroutine.AddTaskN(ctx, func() {
+	if !g.goroutine.AddTaskN(ctx, func() {
 		defer g.wg.Done()
 		f()
-	})
+	}) {
+		g.wg.Done()
+		return false
+	}
+	return true
 }
 
 func WithContextGroup(group goroutine.GGroup) *Group {


### PR DESCRIPTION
## Summary
- When `AddTask`/`AddTaskN` failed to enqueue, `wg.Add(1)` was already called but `Done` would never execute
- This caused `Wait()` to block forever (hidden deadlock)
- Now calls `wg.Done()` on enqueue failure before returning false

## Test plan
- [ ] `go test -race ./wgroup/...`