### PR TITLE
fix(bbr): call done callback after next() to fix inflight tracking

### DIFF
--- a/overload/bbr/middle.go
+++ b/overload/bbr/middle.go
@@ -27,12 +27,17 @@ func NewLimiter(options ...options.Option) middleware.MiddleWare {
 				defaultOp = v.(overload.Op)
 			}
 			limiter := g.Get(defaultKey)
-			if f, err := limiter.Allow(ctx); err != nil {
+			f, err := limiter.Allow(ctx)
+			if err != nil {
 				return nil, err
+			}
+			resp, err := next(ctx, i)
+			if err != nil {
+				f(overload.DoneInfo{Op: overload.Drop})
 			} else {
 				f(overload.DoneInfo{Op: defaultOp})
-				return next(ctx, i)
 			}
+			return resp, err
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Done callback was called **before** `next()`, so inflight was immediately decremented and RT was always 0
- This made BBR's `maxFlight` estimation completely wrong, degrading it to CPU-only throttling
- Now `done` is called **after** `next()` completes, with `Op=Drop` on error

## Test plan
- [ ] `go test -race ./overload/bbr/...`
- [ ] Verify BBR correctly tracks inflight requests and response times