### PR TITLE
fix(sys/cpu): correct cgroup path case from cGroup to cgroup

### DIFF
--- a/internal/sys/cpu/cgroup.go
+++ b/internal/sys/cpu/cgroup.go
@@ -11,7 +11,7 @@ import (
 )
 
 // cGroupRootDir 目录位置
-const cGroupRootDir = "/sys/fs/cGroup"
+const cGroupRootDir = "/sys/fs/cgroup"
 
 // cGroup LinuxCGroup
 type cGroup struct {
@@ -84,7 +84,7 @@ func (c *cGroup) CPUSetCPUs() ([]uint64, error) {
 // currentcGroup 获取当当前进程的 cGroup
 func currentcGroup() (*cGroup, error) {
 	pid := os.Getpid()
-	cgroupFile := fmt.Sprintf("/proc/%d/cGroup", pid)
+	cgroupFile := fmt.Sprintf("/proc/%d/cgroup", pid)
 	cgroupSet := make(map[string]string)
 	fp, err := os.Open(cgroupFile)
 	if err != nil {

--- a/sys/cpu/cgroup.go
+++ b/sys/cpu/cgroup.go
@@ -11,7 +11,7 @@ import (
 )
 
 // cGroupRootDir 目录位置
-const cGroupRootDir = "/sys/fs/cGroup"
+const cGroupRootDir = "/sys/fs/cgroup"
 
 // cGroup LinuxCGroup
 type cGroup struct {
@@ -84,7 +84,7 @@ func (c *cGroup) CPUSetCPUs() ([]uint64, error) {
 // currentcGroup 获取当当前进程的 cGroup
 func currentcGroup() (*cGroup, error) {
 	pid := os.Getpid()
-	cgroupFile := fmt.Sprintf("/proc/%d/cGroup", pid)
+	cgroupFile := fmt.Sprintf("/proc/%d/cgroup", pid)
 	cgroupSet := make(map[string]string)
 	fp, err := os.Open(cgroupFile)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Linux cgroup paths are lowercase (`/sys/fs/cgroup`, `/proc/PID/cgroup`)
- The uppercase 'G' caused cgroup detection to always fail, making container CPU quota completely ignored
- All modules depending on CPU metrics (BBR, watching, gctuner) were affected in containerized environments
- Fixed in both `sys/cpu` and `internal/sys/cpu`

## Test plan
- [ ] Verify on Linux container: cgroup CPU quota is correctly detected