### PR TITLE
fix(ratelimite): correct reversed return values and token leak

### DIFF
--- a/restrictor/ratelimite/ratelimite.go
+++ b/restrictor/ratelimite/ratelimite.go
@@ -15,7 +15,7 @@ var ErrTimeOut = errors.New("restrictor/ratelimit: 超时")
 
 func NewRateLimit(bucket *ratelimit.Bucket) (restrictor.AllowFunc, restrictor.WaitFunc) {
 	return func(now time.Time, n int) bool {
-			return bucket.Available() >= int64(n) && bucket.TakeAvailable(int64(n)) >= int64(n)
+			return bucket.TakeAvailable(int64(n)) >= int64(n)
 		},
 		func(ctx context.Context, n int) error {
 			// 获取超时时间

--- a/restrictor/ratelimite/ratelimite.go
+++ b/restrictor/ratelimite/ratelimite.go
@@ -15,7 +15,7 @@ var ErrTimeOut = errors.New("restrictor/ratelimit: 超时")
 
 func NewRateLimit(bucket *ratelimit.Bucket) (restrictor.AllowFunc, restrictor.WaitFunc) {
 	return func(now time.Time, n int) bool {
-			return bucket.TakeAvailable(int64(n)) >= int64(n)
+			return bucket.Available() >= int64(n) && bucket.TakeAvailable(int64(n)) >= int64(n)
 		},
 		func(ctx context.Context, n int) error {
 			// 获取超时时间
@@ -26,7 +26,7 @@ func NewRateLimit(bucket *ratelimit.Bucket) (restrictor.AllowFunc, restrictor.Wa
 				return nil
 			}
 			// 表示context没有设置超时时间
-			if bucket.WaitMaxDuration(int64(n), 100*time.Millisecond) {
+			if !bucket.WaitMaxDuration(int64(n), 100*time.Millisecond) {
 				return ErrTimeOut
 			}
 			return nil


### PR DESCRIPTION
## Summary
- `WaitMaxDuration` returns true on success, but the no-deadline path returned `ErrTimeOut` on success and `nil` on timeout (completely reversed)
- `AllowFunc` used `TakeAvailable` which consumes partial tokens even when insufficient. Added `Available()` pre-check.

## Test plan
- [ ] `go test ./restrictor/ratelimite/...`