### PR TITLE
fix(distributed): correct nil check in PreConsumeHandler to prevent panic

### DIFF
--- a/distributed/worker.go
+++ b/distributed/worker.go
@@ -244,7 +244,7 @@ func (w *Worker) ConsumeQueue() string {
 }
 
 func (w *Worker) PreConsumeHandler() bool {
-	if w.preConsumeHandler != nil {
+	if w.preConsumeHandler == nil {
 		return true
 	}
 	return w.preConsumeHandler(w)


### PR DESCRIPTION
## Summary
- Nil check was inverted (`!= nil` should be `== nil`): non-nil handler was skipped, nil handler was called → guaranteed panic
- Changed `!= nil` to `== nil`

## Test plan
- [ ] `go test ./distributed/...`