### PR TITLE
fix(egroup): correct CAS direction in Shutdown

### DIFF
--- a/egroup/errgroup.go
+++ b/egroup/errgroup.go
@@ -53,7 +53,7 @@ func (g *Group) Wait() error {
 }
 
 func (g *Group) Shutdown() error {
-	if atomic.CompareAndSwapInt32(&g.close, 0, 1) {
+	if !atomic.CompareAndSwapInt32(&g.close, 0, 1) {
 		return nil
 	}
 	g.wg.Wait()


### PR DESCRIPTION
## Summary
- Same CAS inversion bug as goroutine.Shutdown: first call returned nil without cleanup, subsequent calls performed the actual shutdown
- Added `!` to negate so the first Shutdown call does the work

## Test plan
- [ ] `go test -race ./egroup/...`