### PR TITLE
fix(log): preserve parent prefix in With() chain

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -49,11 +49,11 @@ func (l *logger) Log(lever Lever, kvs ...interface{}) error {
 func With(l Logger, kvs ...interface{}) Logger {
 	if c, ok := l.(*logger); ok {
 		nKvs := make([]interface{}, 0, len(c.prefix)+len(kvs))
-		nKvs = append(kvs, kvs...)
-		nKvs = append(kvs, c.prefix...)
+		nKvs = append(nKvs, c.prefix...)
+		nKvs = append(nKvs, kvs...)
 		return &logger{
 			logs:      c.logs,
-			prefix:    kvs,
+			prefix:    nKvs,
 			hasValuer: containsValuer(nKvs),
 			ctx:       c.ctx,
 		}


### PR DESCRIPTION
## Summary
Three bugs in `With()`:
1. `append(kvs, kvs...)` instead of `append(nKvs, c.prefix...)` — appended to wrong slice
2. `append(kvs, c.prefix...)` instead of `append(nKvs, kvs...)` — wrong order
3. `prefix: kvs` instead of `prefix: nKvs` — discarded the merged result

Result: `With(With(l, "a", 1), "b", 2)` only kept `"b", 2`, losing `"a", 1`.

## Test plan
- [ ] `go test ./log/...`
- [ ] Verify chained With preserves all prefixes