### PR TITLE
fix(backend_db): remove Debug() and fix SQL quoting for PostgreSQL

### DIFF
--- a/distributed/backend/backend_db/db.go
+++ b/distributed/backend/backend_db/db.go
@@ -82,7 +82,7 @@ func (b *BackendSQLDB) GroupTaskStatus(groupID string) ([]*task.Status, error) {
 }
 
 func (b *BackendSQLDB) TriggerCompleted(groupID string) (bool, error) {
-	result := b.gClient.Debug().Model(&task.GroupMeta{}).Where("id = ? and `lock` = false", groupID).Update("`lock`", true)
+	result := b.gClient.Model(&task.GroupMeta{}).Where("id = ? and lock = false", groupID).Update("lock", true)
 	if result.Error != nil {
 		return false, result.Error
 	}

--- a/distributed/backend/backend_db/db.go
+++ b/distributed/backend/backend_db/db.go
@@ -82,7 +82,7 @@ func (b *BackendSQLDB) GroupTaskStatus(groupID string) ([]*task.Status, error) {
 }
 
 func (b *BackendSQLDB) TriggerCompleted(groupID string) (bool, error) {
-	result := b.gClient.Model(&task.GroupMeta{}).Where("id = ? and lock = false", groupID).Update("lock", true)
+	result := b.gClient.Model(&task.GroupMeta{}).Where(map[string]interface{}{"id": groupID, "lock": false}).Update("lock", true)
 	if result.Error != nil {
 		return false, result.Error
 	}


### PR DESCRIPTION
## Summary
- Removed `.Debug()` call that printed all SQL to stdout in production
- Removed MySQL-specific backtick quoting around `lock` column — GORM v2 handles dialect-specific quoting automatically

## Test plan
- [ ] `go test ./distributed/backend/backend_db/...`
- [ ] Verify works with both MySQL and PostgreSQL