### PR TITLE
fix(coding/proto): return error instead of panic on wrong type

### DIFF
--- a/coding/proto/proto.go
+++ b/coding/proto/proto.go
@@ -1,6 +1,8 @@
 package proto
 
 import (
+	"fmt"
+
 	"github.com/songzhibin97/gkit/coding"
 	"google.golang.org/protobuf/proto"
 )
@@ -14,11 +16,19 @@ func init() {
 type code struct{}
 
 func (c code) Marshal(v interface{}) ([]byte, error) {
-	return proto.Marshal(v.(proto.Message))
+	m, ok := v.(proto.Message)
+	if !ok {
+		return nil, fmt.Errorf("proto: Marshal expects proto.Message, got %T", v)
+	}
+	return proto.Marshal(m)
 }
 
 func (c code) Unmarshal(data []byte, v interface{}) error {
-	return proto.Unmarshal(data, v.(proto.Message))
+	m, ok := v.(proto.Message)
+	if !ok {
+		return fmt.Errorf("proto: Unmarshal expects proto.Message, got %T", v)
+	}
+	return proto.Unmarshal(data, m)
 }
 
 func (c code) Name() string {


### PR DESCRIPTION
## Summary
- `Marshal`/`Unmarshal` used direct type assertion `v.(proto.Message)` which panics when wrong type is passed
- Changed to comma-ok assertion with descriptive error message

## Test plan
- [ ] `go test ./coding/proto/...`