### PR TITLE
fix(log): call bindValues after appending kvs to resolve all Valuers

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -29,12 +29,9 @@ type logger struct {
 func (l *logger) Log(lever Lever, kvs ...interface{}) error {
 	nKvs := make([]interface{}, 0, len(l.prefix)+len(kvs))
 	nKvs = append(nKvs, l.prefix...)
-	if l.hasValuer && len(kvs) > 0 {
-		// 特殊处理
+	nKvs = append(nKvs, kvs...)
+	if l.hasValuer {
 		bindValues(l.ctx, nKvs)
-	}
-	if len(kvs) > 0 {
-		nKvs = append(nKvs, kvs...)
 	}
 
 	for _, log := range l.logs {


### PR DESCRIPTION
## Summary
- `bindValues` was called before `kvs` were appended, so `Valuer` functions passed directly to `Log()` were never resolved
- Moved kvs append before `bindValues` call

## Test plan
- [ ] `go test ./log/...`