### PR TITLE
fix(registry): copy instances slice in Subset to avoid mutating caller data

### DIFF
--- a/registry/subset.go
+++ b/registry/subset.go
@@ -13,15 +13,16 @@ func Subset(instances []interface{}, clientID int, size int) []interface{} {
 	if len(instances) <= size {
 		return instances
 	}
-	count := len(instances) / size
-	// 将客户端划分为多轮,每一轮计算使用同样的随机排列的列表
+	cp := make([]interface{}, len(instances))
+	copy(cp, instances)
+	count := len(cp) / size
 	round := clientID / count
 	s := rand.NewSource(int64(round))
 	ra := rand.New(s)
-	ra.Shuffle(len(instances), func(i, j int) {
-		instances[i], instances[j] = instances[j], instances[i]
+	ra.Shuffle(len(cp), func(i, j int) {
+		cp[i], cp[j] = cp[j], cp[i]
 	})
 	// clientID 代表目前的客户端
 	start := (clientID % count) * size
-	return instances[start : start+size]
+	return cp[start : start+size]
 }


### PR DESCRIPTION
## Summary
- `Subset` called `Shuffle` directly on the input slice, reordering the caller's data as a side effect
- Now copies the slice before shuffling

## Test plan
- [ ] `go test ./registry/...`