### PR TITLE
fix(encrypt/aes): use random IV, return errors, validate padding [BREAKING]

### DIFF
--- a/encrypt/aes/aes.go
+++ b/encrypt/aes/aes.go
@@ -124,8 +124,13 @@ func PKCS7UnPadding(origData []byte) ([]byte, error) {
 		return nil, errors.New("empty data")
 	}
 	unPadding := int(origData[length-1])
-	if unPadding > length || unPadding == 0 {
+	if unPadding == 0 || unPadding > length {
 		return nil, errors.New("invalid padding")
+	}
+	for i := length - unPadding; i < length; i++ {
+		if int(origData[i]) != unPadding {
+			return nil, errors.New("invalid padding")
+		}
 	}
 	return origData[:(length - unPadding)], nil
 }

--- a/encrypt/aes/aes.go
+++ b/encrypt/aes/aes.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/rand"
 	"encoding/base64"
-	"unsafe"
+	"errors"
+	"io"
 )
 
 const defaultKey = "gkit"
@@ -36,12 +38,10 @@ func PadKeyToLength(s string, targetLength int) string {
 	ps := []byte(s)
 	ls := len(ps)
 
-	// If input is longer than target length, truncate it
 	if ls > targetLength {
 		return string(ps[:targetLength])
 	}
 
-	// Pad the string by repeating the input until reaching target length
 	idx := 0
 	for len(ps) < targetLength {
 		ps = append(ps, s[idx])
@@ -51,69 +51,66 @@ func PadKeyToLength(s string, targetLength int) string {
 	return string(ps)
 }
 
-func Encrypt(orig string, key string) string {
-	defer func() {
-		if err := recover(); err != nil {
-			//fmt.Println("Encrypt Err", orig, err)
-			return
-		}
-	}()
-	// 转成字节数组
+func Encrypt(orig string, key string) (string, error) {
 	origData := []byte(orig)
 	k := []byte(key)
-	// 分组秘钥
-	// NewCipher该函数限制了输入k的长度必须为16, 24或者32
-	block, _ := aes.NewCipher(k)
-	// 获取秘钥块的长度
+
+	block, err := aes.NewCipher(k)
+	if err != nil {
+		return "", err
+	}
 	blockSize := block.BlockSize()
-	// 补全码
 	origData = PKCS7Padding(origData, blockSize)
-	// 加密模式
-	blockMode := cipher.NewCBCEncrypter(block, k[:blockSize])
-	// 创建数组
+
+	iv := make([]byte, blockSize)
+	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
+		return "", err
+	}
+
+	blockMode := cipher.NewCBCEncrypter(block, iv)
 	cryted := make([]byte, len(origData))
-	// 加密
 	blockMode.CryptBlocks(cryted, origData)
-	return base64.StdEncoding.EncodeToString(cryted)
+
+	// Prepend IV to ciphertext
+	result := append(iv, cryted...)
+	return base64.StdEncoding.EncodeToString(result), nil
 }
 
-func Decrypt(cryted string, key string) string {
-	defer func() {
-		if err := recover(); err != nil {
-			//fmt.Println("Decrypt Err", cryted, err)
-			return
-		}
-	}()
-	// 转成字节数组
-	crytedByte, _ := base64.StdEncoding.DecodeString(cryted)
+func Decrypt(cryted string, key string) (string, error) {
+	crytedByte, err := base64.StdEncoding.DecodeString(cryted)
+	if err != nil {
+		return "", err
+	}
 	k := []byte(key)
-	// 分组秘钥
-	block, _ := aes.NewCipher(k)
-	// 获取秘钥块的长度
+
+	block, err := aes.NewCipher(k)
+	if err != nil {
+		return "", err
+	}
 	blockSize := block.BlockSize()
-	// 加密模式
-	blockMode := cipher.NewCBCDecrypter(block, k[:blockSize])
-	// 创建数组
-	orig := make([]byte, len(crytedByte))
-	// 解密
-	if len(crytedByte)%block.BlockSize() != 0 {
-		return ""
+
+	if len(crytedByte) < blockSize {
+		return "", errors.New("ciphertext too short")
 	}
-	if len(orig) < len(crytedByte) {
-		return ""
-	}
-	if InexactOverlap(orig[:len(crytedByte)], crytedByte) {
-		return ""
+	iv := crytedByte[:blockSize]
+	crytedByte = crytedByte[blockSize:]
+
+	if len(crytedByte)%blockSize != 0 {
+		return "", errors.New("ciphertext is not a multiple of the block size")
 	}
 
+	blockMode := cipher.NewCBCDecrypter(block, iv)
+	orig := make([]byte, len(crytedByte))
 	blockMode.CryptBlocks(orig, crytedByte)
-	// 去补全码
-	orig = PKCS7UnPadding(orig)
-	return string(orig)
+
+	orig, err = PKCS7UnPadding(orig)
+	if err != nil {
+		return "", err
+	}
+	return string(orig), nil
 }
 
 // PKCS7Padding 补码
-// AES加密数据块分组长度必须为128bit(byte[16])，密钥长度可以是128bit(byte[16])、192bit(byte[24])、256bit(byte[32])中的任意一个。
 func PKCS7Padding(ciphertext []byte, blocksize int) []byte {
 	padding := blocksize - len(ciphertext)%blocksize
 	padText := bytes.Repeat([]byte{byte(padding)}, padding)
@@ -121,21 +118,14 @@ func PKCS7Padding(ciphertext []byte, blocksize int) []byte {
 }
 
 // PKCS7UnPadding 去码
-func PKCS7UnPadding(origData []byte) []byte {
+func PKCS7UnPadding(origData []byte) ([]byte, error) {
 	length := len(origData)
-	unPadding := int(origData[length-1])
-	return origData[:(length - unPadding)]
-}
-
-func InexactOverlap(x, y []byte) bool {
-	if len(x) == 0 || len(y) == 0 || &x[0] == &y[0] {
-		return false
+	if length == 0 {
+		return nil, errors.New("empty data")
 	}
-	return AnyOverlap(x, y)
-}
-
-func AnyOverlap(x, y []byte) bool {
-	return len(x) > 0 && len(y) > 0 &&
-		uintptr(unsafe.Pointer(&x[0])) <= uintptr(unsafe.Pointer(&y[len(y)-1])) &&
-		uintptr(unsafe.Pointer(&y[0])) <= uintptr(unsafe.Pointer(&x[len(x)-1]))
+	unPadding := int(origData[length-1])
+	if unPadding > length || unPadding == 0 {
+		return nil, errors.New("invalid padding")
+	}
+	return origData[:(length - unPadding)], nil
 }

--- a/encrypt/aes/aes_test.go
+++ b/encrypt/aes/aes_test.go
@@ -1,6 +1,10 @@
 package aes
 
-import "testing"
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+)
 
 func TestPadKeyToLength(t *testing.T) {
 	tests := []struct {
@@ -54,5 +58,114 @@ func TestPadKeyToLength(t *testing.T) {
 				t.Errorf("expected %q, got %q", tt.expected, result)
 			}
 		})
+	}
+}
+
+func TestEncryptDecryptRoundtrip(t *testing.T) {
+	cases := []struct {
+		name string
+		text string
+		key  string
+	}{
+		{"empty", "", "0123456789abcdef"},
+		{"short", "hello", "0123456789abcdef"},
+		{"block-aligned", "0123456789abcdef", "0123456789abcdef"},
+		{"long", strings.Repeat("ab", 200), "0123456789abcdef0123456789abcdef"},
+		{"utf8", "你好,世界 🌍", "0123456789abcdef"},
+		{"key24", "payload", PadKeyToLength("k", 24)},
+		{"key32", "payload", PadKeyToLength("k", 32)},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			enc, err := Encrypt(c.text, c.key)
+			if err != nil {
+				t.Fatalf("Encrypt: %v", err)
+			}
+			dec, err := Decrypt(enc, c.key)
+			if err != nil {
+				t.Fatalf("Decrypt: %v", err)
+			}
+			if dec != c.text {
+				t.Fatalf("roundtrip mismatch: got %q, want %q", dec, c.text)
+			}
+		})
+	}
+}
+
+func TestEncryptRandomIV(t *testing.T) {
+	const text = "same plaintext"
+	const key = "0123456789abcdef"
+	first, err := Encrypt(text, key)
+	if err != nil {
+		t.Fatalf("Encrypt 1: %v", err)
+	}
+	second, err := Encrypt(text, key)
+	if err != nil {
+		t.Fatalf("Encrypt 2: %v", err)
+	}
+	if first == second {
+		t.Fatalf("two encryptions of the same plaintext/key produced identical ciphertext; IV is not random")
+	}
+}
+
+func TestEncryptInvalidKey(t *testing.T) {
+	if _, err := Encrypt("data", "shortkey"); err == nil {
+		t.Fatal("expected error for invalid key length")
+	}
+}
+
+func TestDecryptInvalidInputs(t *testing.T) {
+	const key = "0123456789abcdef"
+
+	if _, err := Decrypt("!!!not-base64!!!", key); err == nil {
+		t.Error("expected error for invalid base64")
+	}
+
+	tooShort := base64.StdEncoding.EncodeToString([]byte("short"))
+	if _, err := Decrypt(tooShort, key); err == nil {
+		t.Error("expected error for ciphertext shorter than block size")
+	}
+
+	notBlockMultiple := base64.StdEncoding.EncodeToString(make([]byte, 16+5))
+	if _, err := Decrypt(notBlockMultiple, key); err == nil {
+		t.Error("expected error for ciphertext not a multiple of block size")
+	}
+
+	enc, err := Encrypt("hello", key)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	raw, err := base64.StdEncoding.DecodeString(enc)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	raw[len(raw)-1] ^= 0xff
+	tampered := base64.StdEncoding.EncodeToString(raw)
+	if _, err := Decrypt(tampered, key); err == nil {
+		t.Error("expected error when padding is corrupted")
+	}
+}
+
+func TestPKCS7UnPadding(t *testing.T) {
+	if _, err := PKCS7UnPadding(nil); err == nil {
+		t.Error("expected error for empty input")
+	}
+	if _, err := PKCS7UnPadding([]byte{0x05}); err == nil {
+		t.Error("expected error when unPadding exceeds length")
+	}
+	if _, err := PKCS7UnPadding([]byte{0x00}); err == nil {
+		t.Error("expected error for zero padding byte")
+	}
+	bad := []byte{1, 2, 3, 4, 0xff, 0xff, 0x04}
+	if _, err := PKCS7UnPadding(bad); err == nil {
+		t.Error("expected error when interior pad bytes do not match")
+	}
+	good := []byte{1, 2, 3, 4, 4, 4, 4, 4}
+	out, err := PKCS7UnPadding(good)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(out) != string([]byte{1, 2, 3, 4}) {
+		t.Fatalf("got %v", out)
 	}
 }

--- a/page_token/token.go
+++ b/page_token/token.go
@@ -1,7 +1,6 @@
 package page_token
 
 import (
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"strconv"
@@ -36,24 +35,25 @@ type token struct {
 }
 
 func (t *token) ForIndex(i int) string {
-	v := aes.Encrypt(fmt.Sprintf("%s%s:%d", t.resourceIdentification, time.Now().Format(layout), i), t.salt)
-	return base64.StdEncoding.EncodeToString(
-		[]byte(v))
+	v, err := aes.Encrypt(fmt.Sprintf("%s%s:%d", t.resourceIdentification, time.Now().Format(layout), i), t.salt)
+	if err != nil {
+		return ""
+	}
+	return v
 }
 
 func (t *token) GetIndex(s string) (int, error) {
 	if s == "" {
 		return 0, nil
 	}
-	bs, err := base64.StdEncoding.DecodeString(s)
+	decrypted, err := aes.Decrypt(s, t.salt)
 	if err != nil {
 		return -1, ErrInvalidToken
 	}
-	decrypted := aes.Decrypt(string(bs), t.salt)
 	if decrypted == "" {
 		return -1, ErrInvalidToken
 	}
-	parseToken := strings.Split(strings.TrimPrefix(string(decrypted), t.resourceIdentification), ":")
+	parseToken := strings.Split(strings.TrimPrefix(decrypted, t.resourceIdentification), ":")
 	if len(parseToken) != 2 {
 		return -1, ErrInvalidToken
 	}


### PR DESCRIPTION
## Summary

**BREAKING CHANGE**: `Encrypt`/`Decrypt` now return `(string, error)` instead of `string`.

Security fixes:
- **Random IV**: uses `crypto/rand` IV prepended to ciphertext instead of using the key as IV (which made encryption deterministic — same plaintext always produced same ciphertext)
- **Error propagation**: returns errors instead of silently recovering from panics and returning empty string
- **Padding validation**: PKCS7UnPadding now validates padding to detect corruption
- **Removed dead code**: `InexactOverlap`/`AnyOverlap` with `unsafe` were never needed

Updated `page_token` (only internal caller) to use the new API. Also removed the redundant double-base64 encoding in page_token.

## Test plan
- [ ] `go test ./encrypt/aes/...`
- [ ] `go test ./page_token/...`
- [ ] Verify: encrypting same text twice produces different ciphertexts
- [ ] Verify: decrypt(encrypt(text)) == text