### PR TITLE
fix(controller_redis): RPush taskBody instead of handler interface

### DIFF
--- a/distributed/controller/controller_redis/redis.go
+++ b/distributed/controller/controller_redis/redis.go
@@ -248,7 +248,7 @@ func (c *ControllerRedis) consumeOne(taskBody []byte, queue string, handler task
 		if t.IgnoreNotRegisteredTask {
 			return nil
 		}
-		c.client.RPush(c.GetStopCtx(), queue, handler)
+		c.client.RPush(c.GetStopCtx(), queue, taskBody)
 		return nil
 	}
 	return handler.Process(&t)


### PR DESCRIPTION
## Summary
- `consumeOne` was pushing the `task.Processor` interface back into Redis when a task was not registered
- An interface value cannot be serialized by Redis, producing garbage data that breaks subsequent consumption
- Changed to push the original `taskBody` bytes

## Test plan
- [ ] `go test ./distributed/controller/controller_redis/...`