### PR TITLE
fix(egroup): assign l.g and tie LifeAdmin shutdown to group ctx

### DIFF
--- a/egroup/liftcycle.go
+++ b/egroup/liftcycle.go
@@ -111,12 +111,13 @@ func NewLifeAdmin(opts ...options.Option) *LifeAdmin {
 
 	l := &LifeAdmin{opts: o}
 
-	ctx := context.Background()
-	ctx, l.shutdown = context.WithCancel(ctx)
+	ctx, cancel := context.WithCancel(context.Background())
 
 	if o.g == nil {
-		o.g = WithContext(context.Background())
+		o.g = WithContext(ctx)
 	}
+	l.g = o.g
+	l.shutdown = cancel
 
 	return l
 }

--- a/egroup/liftcycle_test.go
+++ b/egroup/liftcycle_test.go
@@ -2,24 +2,31 @@ package egroup
 
 import (
 	"context"
-	"fmt"
+	"net"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/songzhibin97/gkit/goroutine"
 )
 
-var _admin = NewLifeAdmin()
-
 func TestLifeAdmin_Start(t *testing.T) {
-	srv := &http.Server{
-		Addr: ":8080",
+	admin := NewLifeAdmin()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
 	}
-	_admin.Add(Member{
+	srv := &http.Server{}
+
+	admin.Add(Member{
 		Start: func(ctx context.Context) error {
 			t.Log("http start")
 			return goroutine.Delegate(ctx, -1, func(ctx context.Context) error {
-				return srv.ListenAndServe()
+				if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
+					return err
+				}
+				return nil
 			})
 		},
 		Shutdown: func(ctx context.Context) error {
@@ -27,13 +34,13 @@ func TestLifeAdmin_Start(t *testing.T) {
 			return srv.Shutdown(context.Background())
 		},
 	})
-	//_admin.Add(Member{
-	//	Start: func(ctx context.Context) error {
-	//		time.Sleep(5 * time.Second)
-	//		t.Log("error")
-	//		return errors.New("error")
-	//	},
-	//})
-	fmt.Println("error", _admin.Start())
-	defer _admin.shutdown()
+
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		admin.Shutdown()
+	}()
+
+	if err := admin.Start(); err != nil && err != context.Canceled {
+		t.Logf("Start returned: %v", err)
+	}
 }


### PR DESCRIPTION
## Summary
Two related bugs in `NewLifeAdmin`:
1. `l.g` was never assigned — `Start` then dereferenced a nil group.
2. `l.shutdown` was a cancel func for a ctx that was never wired to the default Group, so `Shutdown()` did not propagate cancellation to the running members.

## Changes
- Create the cancellable context once and reuse it for the default Group when `o.g == nil`.
- Assign `l.g = o.g` and `l.shutdown = cancel`.
- Rewrite `TestLifeAdmin_Start` to use a port-0 listener, install a delayed `Shutdown`, and actually terminate (the old test bound `:8080` and blocked forever on `ListenAndServe`).

## Background
Direct-pushed earlier as 2804af0; reverted and re-opened as a PR per repo policy.

## Test plan
- [x] `go test ./egroup/...` passes