### PR TITLE
test: rename example functions to satisfy Go example naming rules

### DIFF
--- a/cache/local_cache/example_test.go
+++ b/cache/local_cache/example_test.go
@@ -36,7 +36,7 @@ func ExampleNewCache() {
 		}))
 }
 
-func ExampleCacheStorage() {
+func Example_storage() {
 	// Set 添加cache 无论是否存在都会覆盖
 	ch.Set("k1", "v1", DefaultExpire)
 
@@ -57,7 +57,7 @@ func ExampleCacheStorage() {
 	CacheErrNoExist(err) // true
 }
 
-func ExampleGet() {
+func Example_get() {
 	// Get 根据key获取 cache 保证有效期内的kv被取出
 	v, ok := ch.Get("k1")
 	if !ok {
@@ -85,7 +85,7 @@ func ExampleGet() {
 	log.Println(ch.Count())
 }
 
-func ExampleIncrement() {
+func Example_increment() {
 	ch.Set("k3", 1, DefaultExpire)
 	ch.Set("k4", 1.1, DefaultExpire)
 	// Increment 为k对应的value增加n n必须为数字类型
@@ -104,7 +104,7 @@ func ExampleIncrement() {
 	// Decrement 同理
 }
 
-func ExampleDelete() {
+func Example_delete() {
 	// Delete 如果设置了 capture 会触发不或函数
 	ch.Delete("k1")
 
@@ -112,7 +112,7 @@ func ExampleDelete() {
 	ch.DeleteExpire()
 }
 
-func ExampleChangeCapture() {
+func Example_changeCapture() {
 	// 提供了在运行中改变捕获函数的方法
 	// ChangeCapture
 	ch.ChangeCapture(func(k string, v interface{}) {
@@ -120,7 +120,7 @@ func ExampleChangeCapture() {
 	})
 }
 
-func ExampleSaveLoad() {
+func Example_saveLoad() {
 	// 写入文件采用go独有的gob协议
 
 	io := buffer.NewIoBuffer(1000)
@@ -138,12 +138,12 @@ func ExampleSaveLoad() {
 	_ = ch.LoadFile("path")
 }
 
-func ExampleFlush() {
+func Example_flush() {
 	// Flush 释放member成员
 	ch.Flush()
 }
 
-func ExampleShutdown() {
+func Example_shutdown() {
 	// Shutdown 释放对象
 	_ = ch.Shutdown()
 }

--- a/container/queue/codel/example_test.go
+++ b/container/queue/codel/example_test.go
@@ -8,7 +8,7 @@ import (
 
 var queue *Queue
 
-func ExampleNew() {
+func ExampleNewQueue() {
 	// 默认配置
 	// queue = NewQueue()
 

--- a/window/example_test.go
+++ b/window/example_test.go
@@ -1,6 +1,6 @@
 package window
 
-func ExampleInitWindow() {
+func ExampleNewWindow() {
 	// 初始化窗口
 	w := NewWindow()
 


### PR DESCRIPTION
## Summary
Example function names must reference an existing package identifier (`ExampleF`, `ExampleT`, `ExampleT_M`) or use the lowercase-suffix form (`Example_xxx`). The old names referred to identifiers that don't exist, which made the test binaries fail to build for these packages and broke `go test ./...`.

## Affected packages
- `window`: `ExampleInitWindow` → `ExampleNewWindow`
- `container/queue/codel`: `ExampleNew` → `ExampleNewQueue`
- `cache/local_cache`: 8 examples renamed to `Example_storage`, `Example_get`, `Example_increment`, `Example_delete`, `Example_changeCapture`, `Example_saveLoad`, `Example_flush`, `Example_shutdown`

## Background
Direct-pushed earlier as d77b027; reverted and re-opened as a PR per repo policy.

## Test plan
- [x] `go test ./window/ ./container/queue/codel/ ./cache/local_cache/` builds and runs