### PR TITLE
fix(bbr): return minRT=1 when no samples instead of MaxInt64

### DIFF
--- a/overload/bbr/bbr.go
+++ b/overload/bbr/bbr.go
@@ -132,7 +132,7 @@ func (l *BBR) minRT() int64 {
 	if rawMinRT > 0 && l.rtStat.Timespan() < 1 {
 		return rawMinRT
 	}
-	rawMinRT = int64(math.Ceil(l.rtStat.Reduce(func(iterator stat.Iterator) float64 {
+	reduced := l.rtStat.Reduce(func(iterator stat.Iterator) float64 {
 		result := math.MaxFloat64
 		for i := 1; iterator.Next() && i < l.conf.winBucket; i++ {
 			bucket := iterator.Bucket()
@@ -147,9 +147,14 @@ func (l *BBR) minRT() int64 {
 			result = math.Min(result, avg)
 		}
 		return result
-	})))
-	if rawMinRT <= 0 {
+	})
+	if reduced >= math.MaxFloat64 {
 		rawMinRT = 1
+	} else {
+		rawMinRT = int64(math.Ceil(reduced))
+		if rawMinRT <= 0 {
+			rawMinRT = 1
+		}
 	}
 	atomic.StoreInt64(&l.rawMinRt, rawMinRT)
 	return rawMinRT


### PR DESCRIPTION
## Summary
When all buckets in the rolling counter are empty, `Reduce`'s callback returns its `math.MaxFloat64` seed unchanged. Casting that to `int64` saturates to `math.MaxInt64`, which passes the existing `<= 0` fallback and is stored as `rawMinRt`. Downstream `maxFlight = maxPass * minRT * winBucketPerSec / 1000` then overflows wildly.

## Fix
Detect the sentinel (`reduced >= math.MaxFloat64`) before the int conversion and substitute `1`, preserving the existing `<= 0` fallback for the normal path.

## Background
Direct-pushed earlier as e6ac508; reverted and re-opened as a PR per repo policy.

## Test plan
- [x] `go test ./overload/bbr/...` passes (TestBBRMinRt now green)