### PR TITLE
test(parser): use relative path to demo.api instead of hardcoded absolute

### DIFF
--- a/parser/parse_go/model_test.go
+++ b/parser/parse_go/model_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestGoParsePB_GeneratePB(t *testing.T) {
 	rr, err := ParseGo(
-		"/Users/songzhibin/go/src/Songzhibin/gkit/parse/demo/demo.api", AddParseFunc(parseDoc), AddParseStruct(parseTag))
+		"../demo/demo.api", AddParseFunc(parseDoc), AddParseStruct(parseTag))
 	if err != nil {
 		panic(err)
 	}
@@ -18,7 +18,7 @@ func TestGoParsePB_GeneratePB(t *testing.T) {
 }
 
 func TestGoParsePB_PileDriving(t *testing.T) {
-	rr, err := ParseGo("/Users/songzhibin/go/src/Songzhibin/gkit/parse/demo/demo.api")
+	rr, err := ParseGo("../demo/demo.api")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## Summary
The test used a hardcoded absolute path `/Users/songzhibin/go/src/Songzhibin/gkit/parse/demo/demo.api` that (a) only worked on the author's machine and (b) had a typo — `parse` instead of `parser`. The fixture actually lives at `parser/demo/demo.api`.

## Fix
Switch to relative `../demo/demo.api` which resolves from `parser/parse_go/` for any checkout location.

## Background
Direct-pushed earlier as bce6a33; reverted and re-opened as a PR per repo policy.

## Test plan
- [x] `go test ./parser/parse_go/...` passes