### PR TITLE
fix(egroup): release wg counter when AddTask refuses the task — Wait deadlock

### DIFF
--- a/egroup/errgroup.go
+++ b/egroup/errgroup.go
@@ -69,7 +69,7 @@ func (g *Group) Go(f func() error) {
 		return
 	}
 	g.wg.Add(1)
-	g.goroutine.AddTask(func() {
+	ok := g.goroutine.AddTask(func() {
 		defer g.wg.Done()
 		if err := f(); err != nil {
 			g.Do(func() {
@@ -81,4 +81,7 @@ func (g *Group) Go(f func() error) {
 			})
 		}
 	})
+	if !ok {
+		g.wg.Done()
+	}
 }

--- a/egroup/errgroup_test.go
+++ b/egroup/errgroup_test.go
@@ -1,0 +1,58 @@
+package egroup
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/songzhibin97/gkit/goroutine"
+)
+
+// TestGroupGoAfterShutdownDoesNotDeadlock verifies that when the
+// underlying goroutine pool refuses a task (e.g. because Shutdown ran),
+// Group.Go releases the wg counter it pre-incremented so that subsequent
+// Wait calls don't block forever.
+func TestGroupGoAfterShutdownDoesNotDeadlock(t *testing.T) {
+	pool := goroutine.NewGoroutine(context.Background())
+	g := WithContextGroup(context.Background(), pool)
+
+	if err := pool.Shutdown(); err != nil {
+		t.Fatalf("pool shutdown: %v", err)
+	}
+
+	// AddTask now returns false; Go must compensate the wg.Add(1).
+	g.Go(func() error { return nil })
+	g.Go(func() error { return nil })
+
+	done := make(chan struct{})
+	go func() {
+		g.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Wait blocked after AddTask refused — wg counter leaked")
+	}
+}
+
+func TestGroupGoNormalRunPropagatesError(t *testing.T) {
+	g := WithContext(context.Background())
+	defer func() { _ = g.Shutdown() }()
+
+	want := errors.New("boom")
+	var ran sync.WaitGroup
+	ran.Add(1)
+	g.Go(func() error {
+		defer ran.Done()
+		return want
+	})
+	ran.Wait()
+	// Give the Once + cancel time to settle.
+	time.Sleep(50 * time.Millisecond)
+	if err := g.Wait(); !errors.Is(err, want) {
+		t.Fatalf("Wait err = %v, want %v", err, want)
+	}
+}


### PR DESCRIPTION
## Background
Surfaced by a retrospective `pr-review` of merged PR #48. That PR made `goroutine.Goroutine.AddTask` correctly return `false` (instead of panicking) when the pool is closed. The interaction with `egroup.Group.Go` then exposed a latent leak.

## The bug
`Group.Go` pre-increments `wg` before calling `AddTask`, relying on the deferred `wg.Done` inside the task body:
```go
g.wg.Add(1)
g.goroutine.AddTask(func() {
    defer g.wg.Done()
    ...
})
```
When `AddTask` returns `false`, the wrapped function is never enqueued. The `defer wg.Done` never runs. Any subsequent `g.Wait()` blocks **forever**.

This is reachable in practice whenever a `Group` outlives the pool it was constructed with — e.g. a service-wide pool that gets `Shutdown()`'d during graceful termination while a request handler still holds a `Group`.

## The fix
Check `AddTask`'s `ok` return; compensate `wg.Done()` on the false path.

## Test plan
- [x] New `TestGroupGoAfterShutdownDoesNotDeadlock` enqueues into a pre-shut-down pool and asserts `Wait()` returns within 2s.
- [x] Verified test fails on master with `Wait blocked after AddTask refused — wg counter leaked`, passes with the fix.
- [x] Existing `TestGroupGoNormalRunPropagatesError` (also added) covers the success path.