### PR TITLE
fix(goroutine): eliminate data race on Delegate ctx variable

### DIFF
--- a/goroutine/goroutine.go
+++ b/goroutine/goroutine.go
@@ -166,6 +166,7 @@ func (g *Goroutine) Trick() string {
 // Delegate 委托执行 一般用于回收函数超时控制
 func Delegate(c context.Context, t time.Duration, f func(ctx context.Context) error) error {
 	ch := make(chan error, 1)
+	fctx := c
 	go func() {
 		defer func() {
 			if err := recover(); err != nil {
@@ -181,7 +182,7 @@ func Delegate(c context.Context, t time.Duration, f func(ctx context.Context) er
 				return
 			}
 		}()
-		ch <- f(c)
+		ch <- f(fctx)
 	}()
 	// 增加优雅退出超时控制
 	var (


### PR DESCRIPTION
## Background
Surfaced by a retrospective `pr-review` of merged PR #48. The reviewer ran `go test -race ./goroutine/` and got a reliable race report on `TestNewGoroutine` that traced back to `Delegate`, not to the recover/AddTask fix #48 was actually about.

## The race
\`\`\`
WARNING: DATA RACE
Read at 0x... by goroutine N:
  goroutine.Delegate.func1() goroutine/goroutine.go:184 +0x74

Previous write at 0x... by goroutine M:
  goroutine.Delegate() goroutine/goroutine.go:191 +0x190
\`\`\`
- Line 184 (inside worker goroutine): `ch <- f(c)` — reads `c`.
- Line 191 (parent): `_, c, cancel = timeout.Shrink(c, t)` — reassigns `c`.

The goroutine was launched on line 169, before the parent reassigned `c`. Even though the goroutine usually wins the scheduling race in practice, Go's memory model has no happens-before relation between the two, so `-race` reliably flags it.

## The fix
Capture the original `c` into a local (`fctx`) **before** launching the worker, and pass that to `f`. No behavior change — `f` continues to receive the unmodified parent ctx; the timeout still only affects the select escape on lines 196-201.

## Test plan
- [x] `go test -race -timeout 60s ./goroutine/` was failing before the fix, now passes.
- [x] No other tests touched.

## Out of scope (deliberate)
- `f` not receiving the timeout-shrunken context is a separate behavioral question — `Delegate` returns on timeout but lets `f` keep running with the original ctx. That's existing behavior and worth its own discussion; this PR only fixes the memory-model race.