### PR TITLE
docs(backend_db): align TTL unit comment with backend_redis (ns → s)

### DIFF
--- a/distributed/backend/backend_db/db.go
+++ b/distributed/backend/backend_db/db.go
@@ -22,7 +22,7 @@ type BackendSQLDB struct {
 	// resultExpire 数据过期时间
 	// -1 代表永不过期
 	// 0 会设置默认过期时间
-	// 单位为ns
+	// 单位为s
 	resultExpire int64
 }
 

--- a/distributed/backend/backend_mongodb/mongo.go
+++ b/distributed/backend/backend_mongodb/mongo.go
@@ -20,7 +20,7 @@ type BackendMongoDB struct {
 	// resultExpire 数据过期时间
 	// -1 代表永不过期
 	// 0 会设置默认过期时间
-	// 单位为ns
+	// 单位为s
 	resultExpire int64
 	// taskTable taskTable
 	taskTable *mongo.Collection


### PR DESCRIPTION
## Summary
Surfaced by retrospective review of PR #29. The `Backend.SetResultExpire(int64)` interface contract was updated to seconds in `backend_redis` (PR #29's fix for the ns→s TTL unit bug), but the parallel `backend_db` implementation kept `// 单位为ns` on the same field.

No functional bug — `backend_db` only persists `resultExpire` into `GroupMeta.TTL` and never passes it to a real TTL operation. But two implementations of the same interface documented different units, which is the kind of drift that bites the next developer.

## Test plan
- [x] Compile-only change to a doc comment; existing tests cover the behavior.