### PR TITLE
fix(watching): permuted default thresholds, broken CAS, log races

### DIFF
--- a/gctuner/tuner.go
+++ b/gctuner/tuner.go
@@ -3,15 +3,17 @@ package gctuner
 
 import (
 	"fmt"
-	"github.com/docker/go-units"
-	mem_util "github.com/shirou/gopsutil/mem"
 	"io/ioutil"
 	"math"
 	"os"
 	"runtime/debug"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
+
+	"github.com/docker/go-units"
+	mem_util "github.com/shirou/gopsutil/mem"
 )
 
 var (
@@ -30,10 +32,19 @@ func init() {
 	defaultGCPercent = uint32(gogc)
 }
 
+// tuningMu serialises Tuning's globalTuner installs and teardowns.
+// Previously Tuning read and wrote globalTuner without synchronisation,
+// racing with GetGCPercent and with concurrent Tuning calls — the race
+// detector flagged it under any test that exercised more than one
+// goroutine.
+var tuningMu sync.Mutex
+
 // Tuning sets the threshold of heap which will be respect by gc tuner.
 // When Tuning, the env GOGC will not be take effect.
 // threshold: disable tuning if threshold == 0
 func Tuning(threshold uint64) {
+	tuningMu.Lock()
+	defer tuningMu.Unlock()
 	// disable gc tuner if percent is zero
 	if threshold <= 0 && globalTuner != nil {
 		globalTuner.stop()
@@ -50,10 +61,13 @@ func Tuning(threshold uint64) {
 
 // GetGCPercent returns the current GCPercent.
 func GetGCPercent() uint32 {
-	if globalTuner == nil {
+	tuningMu.Lock()
+	t := globalTuner
+	tuningMu.Unlock()
+	if t == nil {
 		return defaultGCPercent
 	}
-	return globalTuner.getGCPercent()
+	return t.getGCPercent()
 }
 
 // GetMaxGCPercent returns the max gc percent value.

--- a/watching/config.go
+++ b/watching/config.go
@@ -150,13 +150,18 @@ func defaultLogConfigs() *logConfigs {
 	}
 }
 
+// Each default constructor below previously permuted the three trigger
+// fields — `TriggerMin = defaultXxxTriggerAbs`,
+// `TriggerAbs = defaultXxxTriggerDiff`, `TriggerDiff = defaultXxxTriggerMin`
+// — so every default-config user observed wildly wrong dump thresholds.
+
 func defaultGroupConfigs() *groupConfigs {
 	return &groupConfigs{
 		typeConfig: &typeConfig{
 			Enable:      false,
-			TriggerMin:  defaultGoroutineTriggerAbs,
-			TriggerAbs:  defaultGoroutineTriggerDiff,
-			TriggerDiff: defaultGoroutineTriggerMin,
+			TriggerMin:  defaultGoroutineTriggerMin,
+			TriggerAbs:  defaultGoroutineTriggerAbs,
+			TriggerDiff: defaultGoroutineTriggerDiff,
 		},
 		GoroutineTriggerNumMax: 0,
 	}
@@ -165,36 +170,36 @@ func defaultGroupConfigs() *groupConfigs {
 func defaultGCHeapOptions() *typeConfig {
 	return &typeConfig{
 		Enable:      false,
-		TriggerMin:  defaultGCHeapTriggerAbs,
-		TriggerAbs:  defaultGCHeapTriggerDiff,
-		TriggerDiff: defaultGCHeapTriggerMin,
+		TriggerMin:  defaultGCHeapTriggerMin,
+		TriggerAbs:  defaultGCHeapTriggerAbs,
+		TriggerDiff: defaultGCHeapTriggerDiff,
 	}
 }
 
 func defaultMemConfigs() *typeConfig {
 	return &typeConfig{
 		Enable:      false,
-		TriggerMin:  defaultMemTriggerAbs,
-		TriggerAbs:  defaultMemTriggerDiff,
-		TriggerDiff: defaultMemTriggerMin,
+		TriggerMin:  defaultMemTriggerMin,
+		TriggerAbs:  defaultMemTriggerAbs,
+		TriggerDiff: defaultMemTriggerDiff,
 	}
 }
 
 func defaultCPUConfigs() *typeConfig {
 	return &typeConfig{
 		Enable:      false,
-		TriggerMin:  defaultCPUTriggerAbs,
-		TriggerAbs:  defaultCPUTriggerDiff,
-		TriggerDiff: defaultCPUTriggerMin,
+		TriggerMin:  defaultCPUTriggerMin,
+		TriggerAbs:  defaultCPUTriggerAbs,
+		TriggerDiff: defaultCPUTriggerDiff,
 	}
 }
 
 func defaultThreadConfig() *typeConfig {
 	return &typeConfig{
 		Enable:      false,
-		TriggerMin:  defaultThreadTriggerAbs,
-		TriggerAbs:  defaultThreadTriggerDiff,
-		TriggerDiff: defaultThreadTriggerMin,
+		TriggerMin:  defaultThreadTriggerMin,
+		TriggerAbs:  defaultThreadTriggerAbs,
+		TriggerDiff: defaultThreadTriggerDiff,
 	}
 }
 

--- a/watching/config.go
+++ b/watching/config.go
@@ -20,6 +20,12 @@ type configs struct {
 
 	LogLevel int
 	Logger   *os.File
+	// activeLog is the reference-counted handle backing Logger. writeString
+	// acquires a reference for the duration of each write; setLogger retires
+	// the old handle on rotation, and the file is closed only once the last
+	// in-flight writer releases it. Logger is kept as a plain mirror for the
+	// few direct readers.
+	activeLog *loggerRef
 
 	// interval for dump loop, default 5s
 	CollectInterval   time.Duration
@@ -213,6 +219,7 @@ func defaultConfig() *configs {
 		ThreadConfigs:     defaultThreadConfig(),
 		LogLevel:          LogLevelDebug,
 		Logger:            os.Stdout,
+		activeLog:         newLoggerRef(os.Stdout),
 		CollectInterval:   defaultInterval,
 		intervalResetting: make(chan struct{}, 1),
 		CoolDown:          defaultCooldown,

--- a/watching/config_defaults_test.go
+++ b/watching/config_defaults_test.go
@@ -1,0 +1,36 @@
+package watching
+
+import "testing"
+
+// TestDefaultConfigs_FieldsAreNotPermuted covers C-defaults: each of the
+// five default config constructors previously assigned trigger Min/Abs/Diff
+// from the WRONG `default*` constants — Min ← *Abs, Abs ← *Diff,
+// Diff ← *Min — so any default-config user observed garbage thresholds.
+func TestDefaultConfigs_FieldsAreNotPermuted(t *testing.T) {
+	cases := []struct {
+		name string
+		got  *typeConfig
+		min  int
+		abs  int
+		diff int
+	}{
+		{"goroutine", defaultGroupConfigs().typeConfig, defaultGoroutineTriggerMin, defaultGoroutineTriggerAbs, defaultGoroutineTriggerDiff},
+		{"mem", defaultMemConfigs(), defaultMemTriggerMin, defaultMemTriggerAbs, defaultMemTriggerDiff},
+		{"cpu", defaultCPUConfigs(), defaultCPUTriggerMin, defaultCPUTriggerAbs, defaultCPUTriggerDiff},
+		{"thread", defaultThreadConfig(), defaultThreadTriggerMin, defaultThreadTriggerAbs, defaultThreadTriggerDiff},
+		{"gcheap", defaultGCHeapOptions(), defaultGCHeapTriggerMin, defaultGCHeapTriggerAbs, defaultGCHeapTriggerDiff},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if c.got.TriggerMin != c.min {
+				t.Errorf("%s TriggerMin = %d, want %d", c.name, c.got.TriggerMin, c.min)
+			}
+			if c.got.TriggerAbs != c.abs {
+				t.Errorf("%s TriggerAbs = %d, want %d", c.name, c.got.TriggerAbs, c.abs)
+			}
+			if c.got.TriggerDiff != c.diff {
+				t.Errorf("%s TriggerDiff = %d, want %d", c.name, c.got.TriggerDiff, c.diff)
+			}
+		})
+	}
+}

--- a/watching/log.go
+++ b/watching/log.go
@@ -23,26 +23,61 @@ func (w *Watching) debugf(pattern string, args ...interface{}) {
 	}
 }
 
-// currentLogger returns the active logger under the config RWMutex. The
-// previous code read `w.config.Logger` non-atomically while another
-// goroutine performed an `atomic.CompareAndSwapPointer` on the same field
-// whose expected-old-value was ALSO read non-atomically — the CAS was
-// theatre, the read was a data race.
-func (w *Watching) currentLogger() *os.File {
-	w.config.L.RLock()
-	defer w.config.L.RUnlock()
-	return w.config.Logger
+// loggerRef is a reference-counted handle to the active log file. The
+// "current" slot owns one reference; each in-flight writeString that
+// snapshots the handle owns one more. The underlying file is closed only
+// when the last reference is dropped, so a rotation that retires the handle
+// can never close a file out from under a concurrent writer (os.Stdout is
+// never closed). This replaces the previous broken
+// atomic.CompareAndSwapPointer swap, which raced on the pointer read and
+// could close a file mid-write.
+type loggerRef struct {
+	file *os.File
+	refs int32 // atomic; starts at 1 for the current-slot reference
 }
 
-// setLogger swaps the active logger under the config write lock, closing
-// the previous one if it differs and isn't Stdout.
+func newLoggerRef(f *os.File) *loggerRef {
+	return &loggerRef{file: f, refs: 1}
+}
+
+func (r *loggerRef) acquire() { atomic.AddInt32(&r.refs, 1) }
+
+func (r *loggerRef) release() {
+	if atomic.AddInt32(&r.refs, -1) == 0 && r.file != nil && r.file != os.Stdout {
+		_ = r.file.Close()
+	}
+}
+
+// acquireLogger returns the active logger handle with its reference count
+// bumped; the caller MUST call release() on it when done. Reading the
+// current handle and incrementing its count happen under the same lock
+// setLogger uses to swap it, so a writer can never acquire a handle that
+// setLogger has already retired.
+func (w *Watching) acquireLogger() *loggerRef {
+	w.config.L.RLock()
+	ref := w.config.activeLog
+	ref.acquire()
+	w.config.L.RUnlock()
+	return ref
+}
+
+// setLogger installs newLogger as the active log file and retires the
+// previous handle. The retired file is NOT closed here; release() closes it
+// once the last in-flight writer is done — never while the config lock is
+// held and never under blocking file I/O.
 func (w *Watching) setLogger(newLogger *os.File) {
+	newRef := newLoggerRef(newLogger)
 	w.config.L.Lock()
-	old := w.config.Logger
-	w.config.Logger = newLogger
+	old := w.config.activeLog
+	if old != nil && old.file == newLogger {
+		w.config.L.Unlock()
+		return
+	}
+	w.config.activeLog = newRef
+	w.config.Logger = newLogger // keep the mirror in sync for direct readers
 	w.config.L.Unlock()
-	if old != nil && old != newLogger && old != os.Stdout {
-		_ = old.Close()
+	if old != nil {
+		old.release() // drop the current-slot reference
 	}
 }
 
@@ -59,7 +94,9 @@ func (w *Watching) disableRotate() {
 }
 
 func (w *Watching) writeString(content string) {
-	logger := w.currentLogger()
+	ref := w.acquireLogger()
+	defer ref.release()
+	logger := ref.file
 	if _, err := logger.WriteString(content); err != nil {
 		fmt.Println(err) // where to write this log?
 	}
@@ -79,36 +116,44 @@ func (w *Watching) writeString(content string) {
 
 	if state.Size() > w.config.logConfigs.SplitLoggerSize && atomic.CompareAndSwapInt32(&w.changeLog, 0, 1) {
 		defer atomic.StoreInt32(&w.changeLog, 0)
-
-		var (
-			newLogger *os.File
-			err       error
-			dumpPath  = w.config.DumpPath
-			suffix    = time.Now().Format("20060102150405")
-			srcPath   = filepath.Clean(filepath.Join(dumpPath, defaultLoggerName))
-			dstPath   = srcPath + "_" + suffix + ".back"
-		)
-
-		err = os.Rename(srcPath, dstPath)
-
-		if err != nil {
-			w.disableRotate()
-			//nolint
-			fmt.Println("rename err:", err, "from now on, it will be disabled split log")
-
-			return
-		}
-
-		newLogger, err = os.OpenFile(filepath.Clean(srcPath), defaultLoggerFlags, defaultLoggerPerm)
-
-		if err != nil {
-			w.disableRotate()
-			//nolint
-			fmt.Println("open new file err:", err, "from now on, it will be disabled split log")
-
-			return
-		}
-
-		w.setLogger(newLogger)
+		w.rotate(ref)
 	}
+}
+
+// rotate renames the active log file aside and installs a fresh one. The
+// caller must hold the changeLog gate. It first re-validates that ref is
+// still the active handle: another writer may have rotated since ref was
+// acquired, in which case that rotation already replaced the file. Rotating
+// again off a retired handle's size would rotate the new (possibly nearly
+// empty) active file and, with the second-granularity suffix, collide with a
+// same-second backup. Only the holder of the still-current handle rotates.
+func (w *Watching) rotate(ref *loggerRef) {
+	w.config.L.RLock()
+	stale := w.config.activeLog != ref
+	w.config.L.RUnlock()
+	if stale {
+		return
+	}
+
+	dumpPath := w.config.DumpPath
+	suffix := time.Now().Format("20060102150405")
+	srcPath := filepath.Clean(filepath.Join(dumpPath, defaultLoggerName))
+	dstPath := srcPath + "_" + suffix + ".back"
+
+	if err := os.Rename(srcPath, dstPath); err != nil {
+		w.disableRotate()
+		//nolint
+		fmt.Println("rename err:", err, "from now on, it will be disabled split log")
+		return
+	}
+
+	newLogger, err := os.OpenFile(filepath.Clean(srcPath), defaultLoggerFlags, defaultLoggerPerm)
+	if err != nil {
+		w.disableRotate()
+		//nolint
+		fmt.Println("open new file err:", err, "from now on, it will be disabled split log")
+		return
+	}
+
+	w.setLogger(newLogger)
 }

--- a/watching/log.go
+++ b/watching/log.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"sync/atomic"
 	"time"
-	"unsafe"
 )
 
 // log write content to log file.
@@ -24,18 +23,54 @@ func (w *Watching) debugf(pattern string, args ...interface{}) {
 	}
 }
 
+// currentLogger returns the active logger under the config RWMutex. The
+// previous code read `w.config.Logger` non-atomically while another
+// goroutine performed an `atomic.CompareAndSwapPointer` on the same field
+// whose expected-old-value was ALSO read non-atomically — the CAS was
+// theatre, the read was a data race.
+func (w *Watching) currentLogger() *os.File {
+	w.config.L.RLock()
+	defer w.config.L.RUnlock()
+	return w.config.Logger
+}
+
+// setLogger swaps the active logger under the config write lock, closing
+// the previous one if it differs and isn't Stdout.
+func (w *Watching) setLogger(newLogger *os.File) {
+	w.config.L.Lock()
+	old := w.config.Logger
+	w.config.Logger = newLogger
+	w.config.L.Unlock()
+	if old != nil && old != newLogger && old != os.Stdout {
+		_ = old.Close()
+	}
+}
+
+func (w *Watching) rotateEnabled() bool {
+	w.config.L.RLock()
+	defer w.config.L.RUnlock()
+	return w.config.logConfigs.RotateEnable
+}
+
+func (w *Watching) disableRotate() {
+	w.config.L.Lock()
+	w.config.logConfigs.RotateEnable = false
+	w.config.L.Unlock()
+}
+
 func (w *Watching) writeString(content string) {
-	if _, err := w.config.Logger.WriteString(content); err != nil {
+	logger := w.currentLogger()
+	if _, err := logger.WriteString(content); err != nil {
 		fmt.Println(err) // where to write this log?
 	}
 
-	if !w.config.logConfigs.RotateEnable {
+	if !w.rotateEnabled() {
 		return
 	}
 
-	state, err := w.config.Logger.Stat()
+	state, err := logger.Stat()
 	if err != nil {
-		w.config.logConfigs.RotateEnable = false
+		w.disableRotate()
 		//nolint
 		fmt.Println("get logger stat:", err, "from now on, it will be disabled split log")
 
@@ -57,7 +92,7 @@ func (w *Watching) writeString(content string) {
 		err = os.Rename(srcPath, dstPath)
 
 		if err != nil {
-			w.config.logConfigs.RotateEnable = false
+			w.disableRotate()
 			//nolint
 			fmt.Println("rename err:", err, "from now on, it will be disabled split log")
 
@@ -67,16 +102,13 @@ func (w *Watching) writeString(content string) {
 		newLogger, err = os.OpenFile(filepath.Clean(srcPath), defaultLoggerFlags, defaultLoggerPerm)
 
 		if err != nil {
-			w.config.logConfigs.RotateEnable = false
+			w.disableRotate()
 			//nolint
 			fmt.Println("open new file err:", err, "from now on, it will be disabled split log")
 
 			return
 		}
 
-		old := w.config.Logger
-		if atomic.CompareAndSwapPointer((*unsafe.Pointer)(unsafe.Pointer(&w.config.Logger)), unsafe.Pointer(w.config.Logger), unsafe.Pointer(newLogger)) {
-			_ = old.Close()
-		}
+		w.setLogger(newLogger)
 	}
 }

--- a/watching/log_rotation_test.go
+++ b/watching/log_rotation_test.go
@@ -1,0 +1,160 @@
+package watching
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func countBackups(t *testing.T, dir string) int {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	n := 0
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".back") {
+			n++
+		}
+	}
+	return n
+}
+
+func newRotatingWatching(t *testing.T, dir string, splitSize int64) (*Watching, *os.File) {
+	t.Helper()
+	f, err := os.OpenFile(filepath.Join(dir, defaultLoggerName), defaultLoggerFlags, defaultLoggerPerm)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	w := &Watching{config: defaultConfig()}
+	w.config.DumpPath = dir
+	w.config.logConfigs.RotateEnable = true
+	w.config.logConfigs.SplitLoggerSize = splitSize
+	w.setLogger(f) // retire the os.Stdout default, install the temp file
+	return w, f
+}
+
+// TestLoggerRef_DeferredCloseUntilLastRelease pins the lifetime contract of
+// the rotation fix: retiring the current-slot reference (what setLogger does
+// on rotation) must NOT close the file while an in-flight writer still holds
+// a reference. The file is closed only when the final reference is released.
+// Reverting release() to close eagerly on retire makes the mid-write
+// assertion below fail.
+func TestLoggerRef_DeferredCloseUntilLastRelease(t *testing.T) {
+	dir := t.TempDir()
+	f, err := os.OpenFile(filepath.Join(dir, "ref.log"), defaultLoggerFlags, defaultLoggerPerm)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	ref := newLoggerRef(f) // refs=1: the current slot
+	ref.acquire()          // refs=2: an in-flight writer snapshots it
+
+	ref.release() // refs=1: rotation retires the current slot — must NOT close
+	if _, err := f.WriteString("still-open\n"); err != nil {
+		t.Fatalf("file was closed while a writer still held a reference: %v", err)
+	}
+
+	ref.release() // refs=0: the writer finishes — now it closes
+	if _, err := f.WriteString("after-close\n"); err == nil {
+		t.Fatal("file should be closed after the last reference is released")
+	}
+}
+
+// TestLoggerRef_StdoutNeverClosed guards that os.Stdout is never closed even
+// when its reference count reaches zero (the default logger, before a
+// WithDumpPath swap retires it).
+func TestLoggerRef_StdoutNeverClosed(t *testing.T) {
+	ref := newLoggerRef(os.Stdout) // refs=1
+	ref.release()                  // refs=0 — must be a no-op for os.Stdout
+	if _, err := os.Stdout.Stat(); err != nil {
+		t.Fatalf("os.Stdout was closed by release(): %v", err)
+	}
+}
+
+// TestRotate_CurrentRefRotates is the positive control: rotate() on the
+// still-current handle performs exactly one rotation (one .back file).
+func TestRotate_CurrentRefRotates(t *testing.T) {
+	dir := t.TempDir()
+	w, _ := newRotatingWatching(t, dir, defaultShardLoggerSize)
+
+	ref := w.acquireLogger() // current handle
+	defer ref.release()
+
+	if got := countBackups(t, dir); got != 0 {
+		t.Fatalf("precondition: %d backups, want 0", got)
+	}
+	w.rotate(ref)
+	if got := countBackups(t, dir); got != 1 {
+		t.Fatalf("current ref did not rotate: %d backups, want 1", got)
+	}
+}
+
+// TestRotate_StaleRefSkips guards the stale-rotation fix: a writer whose
+// acquired handle was already retired by a concurrent rotation must NOT
+// rotate again — otherwise it rotates the new active file off the retired
+// handle's size. Removing the staleness re-check in rotate() makes this fail
+// (the stale ref produces an extra .back file).
+func TestRotate_StaleRefSkips(t *testing.T) {
+	dir := t.TempDir()
+	w, _ := newRotatingWatching(t, dir, defaultShardLoggerSize)
+
+	staleRef := w.acquireLogger() // points at the current handle
+	defer staleRef.release()
+
+	// Simulate another writer rotating the active handle out from under us.
+	f2, err := os.OpenFile(filepath.Join(dir, "rotated.tmp"), defaultLoggerFlags, defaultLoggerPerm)
+	if err != nil {
+		t.Fatalf("open f2: %v", err)
+	}
+	w.setLogger(f2) // activeLog is now f2; staleRef is retired-but-open
+
+	before := countBackups(t, dir)
+	w.rotate(staleRef) // stale ref must skip
+	if got := countBackups(t, dir); got != before {
+		t.Fatalf("stale ref triggered a rotation: backups %d -> %d", before, got)
+	}
+}
+
+// TestWriteString_ConcurrentRotationNoUseAfterClose drives many concurrent
+// writers against a tiny split size so rotation fires repeatedly while other
+// goroutines are mid-write. With the refcount handle, no writer ever touches
+// a closed file and the swap introduces no data race. Run under -race; it
+// must complete without panic, keep rotation enabled (an eager close would
+// make a stale writer hit a closed file in Stat and disable rotation), and
+// leave the active logger usable.
+func TestWriteString_ConcurrentRotationNoUseAfterClose(t *testing.T) {
+	dir := t.TempDir()
+	w, _ := newRotatingWatching(t, dir, 1) // 1-byte split forces a rotation attempt on nearly every write
+
+	const writers, perWriter = 8, 64
+	var wg sync.WaitGroup
+	wg.Add(writers)
+	for i := 0; i < writers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perWriter; j++ {
+				w.writeString("concurrent-rotation-line\n")
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Rotation must not have been disabled by a closed/stale-file Stat error.
+	w.config.L.RLock()
+	stillEnabled := w.config.logConfigs.RotateEnable
+	w.config.L.RUnlock()
+	if !stillEnabled {
+		t.Fatal("rotation was disabled during the storm — a writer hit a closed/stale file")
+	}
+
+	// The active logger must still be usable after the storm.
+	ref := w.acquireLogger()
+	defer ref.release()
+	if _, err := ref.file.WriteString("final\n"); err != nil {
+		t.Fatalf("active logger unusable after concurrent rotation: %v", err)
+	}
+}

--- a/watching/option.go
+++ b/watching/option.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"sync/atomic"
 	"time"
-	"unsafe"
 
 	"github.com/docker/go-units"
 	"github.com/songzhibin97/gkit/options"
@@ -25,7 +24,16 @@ func WithCollectInterval(interval string) options.Option {
 			return
 		}
 		opts.config.CollectInterval = newInterval
-		opts.config.intervalResetting <- struct{}{}
+		// Non-blocking send: the channel has cap=1 and only one reader
+		// (startDumpLoop, which runs after Start()). A second
+		// WithCollectInterval invocation before Start() — or two rapid
+		// calls between ticks — would otherwise wedge here forever.
+		// Coalescing repeated reset signals into the buffered slot is
+		// correct since the reader only needs to know "interval changed".
+		select {
+		case opts.config.intervalResetting <- struct{}{}:
+		default:
+		}
 		return
 	}
 }
@@ -73,12 +81,11 @@ func WithDumpPath(dumpPath string, loginfo ...string) options.Option {
 				return
 			}
 		}
-		old := opts.config.Logger
-		if atomic.CompareAndSwapPointer((*unsafe.Pointer)(unsafe.Pointer(&opts.config.Logger)), unsafe.Pointer(opts.config.Logger), unsafe.Pointer(logger)) {
-			if old != os.Stdout {
-				_ = old.Close()
-			}
-		}
+		// Swap under the config RWMutex. The previous broken pattern
+		// (unsafe CompareAndSwapPointer with an unprotected read of
+		// `opts.config.Logger` as the expected-old-value) gave no atomicity
+		// guarantee and tripped the race detector.
+		opts.setLogger(logger)
 		return
 	}
 }

--- a/watching/reporter.go
+++ b/watching/reporter.go
@@ -7,7 +7,14 @@ import (
 	"io/ioutil"
 	"mime/multipart"
 	"net/http"
+	"time"
 )
+
+// defaultReporterTimeout bounds outbound profile uploads. Without it,
+// a slow or hung backend stalls the reporter goroutine for the lifetime
+// of its connect+read, which serialises behind it and blocks every
+// subsequent dump.
+const defaultReporterTimeout = 30 * time.Second
 
 type ProfileReporter interface {
 	Report(pType string, buf []byte, reason string, eventID string) error
@@ -51,7 +58,7 @@ func (r *HttpReporter) Report(ptype string, buf []byte, reason string, eventID s
 	}
 
 	request.Header.Add("Content-Type", writer.FormDataContentType())
-	client := &http.Client{}
+	client := &http.Client{Timeout: defaultReporterTimeout}
 	response, err := client.Do(request)
 	if err != nil {
 		return fmt.Errorf("do Request err: %v", err)

--- a/watching/watching.go
+++ b/watching/watching.go
@@ -718,7 +718,10 @@ func (w *Watching) initEnvironment() {
 
 func (w *Watching) EnableDump(curCPU int) (err error) {
 	if w.config.CPUMaxPercent != 0 && curCPU >= w.config.CPUMaxPercent {
-		return fmt.Errorf("current cpu percent [%v] is greater than the CPUMaxPercent [%v]", cpu, w.config.CPUMaxPercent)
+		// Bug fix C29: the previous format passed the package constant
+		// `cpu` (configureType iota = 1) instead of the parameter, so the
+		// error message always reported "current cpu percent [1]".
+		return fmt.Errorf("current cpu percent [%v] is greater than the CPUMaxPercent [%v]", curCPU, w.config.CPUMaxPercent)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

PR 8 of 10 from the second-pass audit. Eight watching/gctuner defects.

| ID | Defect | Fix |
|---|---|---|
| **C-defaults** | All 5 default config constructors swapped Min/Abs/Diff: `Min ← *Abs`, `Abs ← *Diff`, `Diff ← *Min`. Every default user got garbage thresholds. | Restore correct field assignments. |
| **C8** | `atomic.CompareAndSwapPointer` with `unsafe.Pointer` cast — expected-old read non-atomically from `w.config.Logger`; hot-path reads also non-atomic. CAS was theatre. | `setLogger`/`currentLogger` helpers backed by `config.L` RWMutex. |
| **C29** | `EnableDump` formatted package constant `cpu` (iota=1) instead of parameter `curCPU`. Error always said `[1]`. | Use `curCPU`. |
| **I-bb** | `http.Client{}` with no Timeout — slow backend stalled reporter. | `Timeout: 30s` default via named const. |
| **I-dd** | `WithCollectInterval` did a blocking send on a cap=1 chan at option time → second invocation deadlocked. | Non-blocking `select` + `default`. |
| **I-ee** | `RotateEnable` r/w from rotation failure branches without sync. | `rotateEnabled()`/`disableRotate()` helpers under `config.L`. |
| **I-ii** | `gctuner.globalTuner` unprotected package var. | `tuningMu` serialises install/teardown + GetGCPercent snapshot. |

## Compatibility

All fixes are internal. No exported signature changes. Behaviour fixes:
- Default thresholds now match the documented `default*Trigger{Min,Abs,Diff}` constants.
- `WithCollectInterval` becomes safe to call repeatedly.
- `EnableDump` reports correct CPU%.

## Test plan
- [x] `watching/config_defaults_test.go::TestDefaultConfigs_FieldsAreNotPermuted` — the broken pre-fix permutation would have failed every case
- [x] `go test -race ./watching/ ./gctuner/` — passes
- [x] `go build ./...` — passes