### PR TITLE
fix(tools/codec): cycle-safe deepcopy, bind nil-panic, parser corruption, aes oracle

### DIFF
--- a/encrypt/aes/aes.go
+++ b/encrypt/aes/aes.go
@@ -5,10 +5,19 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
+	"crypto/subtle"
 	"encoding/base64"
 	"errors"
 	"io"
 )
+
+// ErrDecryptionFailed is returned by Decrypt for any decryption failure
+// (bad base64, wrong key size, bad block alignment, padding mismatch).
+// Collapsing all failure modes into a single opaque error is the standard
+// defence against CBC padding oracles — the previous implementation
+// returned distinct error strings for each cause, letting a network
+// attacker probe ciphertext byte-by-byte.
+var ErrDecryptionFailed = errors.New("aes: decryption failed")
 
 const defaultKey = "gkit"
 
@@ -79,24 +88,24 @@ func Encrypt(orig string, key string) (string, error) {
 func Decrypt(cryted string, key string) (string, error) {
 	crytedByte, err := base64.StdEncoding.DecodeString(cryted)
 	if err != nil {
-		return "", err
+		return "", ErrDecryptionFailed
 	}
 	k := []byte(key)
 
 	block, err := aes.NewCipher(k)
 	if err != nil {
-		return "", err
+		return "", ErrDecryptionFailed
 	}
 	blockSize := block.BlockSize()
 
 	if len(crytedByte) < blockSize {
-		return "", errors.New("ciphertext too short")
+		return "", ErrDecryptionFailed
 	}
 	iv := crytedByte[:blockSize]
 	crytedByte = crytedByte[blockSize:]
 
-	if len(crytedByte)%blockSize != 0 {
-		return "", errors.New("ciphertext is not a multiple of the block size")
+	if len(crytedByte) == 0 || len(crytedByte)%blockSize != 0 {
+		return "", ErrDecryptionFailed
 	}
 
 	blockMode := cipher.NewCBCDecrypter(block, iv)
@@ -105,7 +114,7 @@ func Decrypt(cryted string, key string) (string, error) {
 
 	orig, err = PKCS7UnPadding(orig)
 	if err != nil {
-		return "", err
+		return "", ErrDecryptionFailed
 	}
 	return string(orig), nil
 }
@@ -117,7 +126,11 @@ func PKCS7Padding(ciphertext []byte, blocksize int) []byte {
 	return append(ciphertext, padText...)
 }
 
-// PKCS7UnPadding 去码
+// PKCS7UnPadding 去码. Compares the padding bytes in constant time to
+// avoid leaking the failing byte position via timing — the previous
+// implementation short-circuited on the first mismatch, which combined
+// with distinguishable error strings in Decrypt formed a textbook CBC
+// padding oracle.
 func PKCS7UnPadding(origData []byte) ([]byte, error) {
 	length := len(origData)
 	if length == 0 {
@@ -127,10 +140,12 @@ func PKCS7UnPadding(origData []byte) ([]byte, error) {
 	if unPadding == 0 || unPadding > length {
 		return nil, errors.New("invalid padding")
 	}
-	for i := length - unPadding; i < length; i++ {
-		if int(origData[i]) != unPadding {
-			return nil, errors.New("invalid padding")
-		}
+	// Build a reference slice of `unPadding` repeated bytes and compare in
+	// constant time. subtle.ConstantTimeCompare returns 1 iff both slices
+	// are equal and same length; 0 otherwise.
+	want := bytes.Repeat([]byte{byte(unPadding)}, unPadding)
+	if subtle.ConstantTimeCompare(origData[length-unPadding:], want) != 1 {
+		return nil, errors.New("invalid padding")
 	}
 	return origData[:(length - unPadding)], nil
 }

--- a/parser/demo/demo.api
+++ b/parser/demo/demo.api
@@ -47,7 +47,6 @@ func Register(req Request)(Response){
 
 
             // start
-            var _ = 1
             // end
 
 }

--- a/parser/parse_go/model.go
+++ b/parser/parse_go/model.go
@@ -377,6 +377,13 @@ func (g *GoParsePB) PileDriving(functionName string, startNotes, endNotes string
 		return err
 	}
 	startNotesPos, endNotesPos, err := g.pileFind(srcData, functionName, startNotes, endNotes)
+	if err != nil {
+		// Previously this error was silently overwritten by the next
+		// `srcData, err = g.pileDriving(...)` line, letting pileDriving
+		// run with bogus positions and the resulting corrupted bytes get
+		// written back to the user's source file via ioutil.WriteFile.
+		return err
+	}
 	srcData, err = g.pileDriving(srcData, startNotesPos, endNotesPos, insertCode)
 	if err != nil {
 		return err

--- a/parser/parse_go/parse_go.go
+++ b/parser/parse_go/parse_go.go
@@ -1,7 +1,6 @@
 package parse_go
 
 import (
-	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -68,22 +67,35 @@ func parseTag(file *File) {
 	}
 }
 
+// docTagValue returns the part after the first colon, or "" if the doc
+// line doesn't actually contain a colon. The previous implementation did
+// `strings.Split(doc, ":")[1]` which panicked on a malformed line; the
+// panic was then swallowed by a recover that printed to stdout, so the
+// affected field was silently left at its zero value and the generated
+// code went out the door with empty Method / ServerName / Router.
+func docTagValue(doc string) (string, bool) {
+	parts := strings.SplitN(doc, ":", 2)
+	if len(parts) != 2 {
+		return "", false
+	}
+	return parts[1], true
+}
+
 func parseDoc(server *Server) {
-	defer func() {
-		if err := recover(); err != nil {
-			fmt.Println("panic:", err)
-			return
-		}
-	}()
 	for _, doc := range server.Doc {
-		if strings.Contains(doc, "@method") {
-			server.Method = strings.Split(doc, ":")[1]
-		}
-		if strings.Contains(doc, "@service") {
-			server.ServerName = strings.Split(doc, ":")[1]
-		}
-		if strings.Contains(doc, "@router") {
-			server.Router = strings.Split(doc, ":")[1]
+		switch {
+		case strings.Contains(doc, "@method"):
+			if v, ok := docTagValue(doc); ok {
+				server.Method = v
+			}
+		case strings.Contains(doc, "@service"):
+			if v, ok := docTagValue(doc); ok {
+				server.ServerName = v
+			}
+		case strings.Contains(doc, "@router"):
+			if v, ok := docTagValue(doc); ok {
+				server.Router = v
+			}
 		}
 	}
 }

--- a/tools/bind/default_validator.go
+++ b/tools/bind/default_validator.go
@@ -38,6 +38,15 @@ func (v *defaultValidator) ValidateStruct(obj interface{}) error {
 	value := reflect.ValueOf(obj)
 	switch value.Kind() {
 	case reflect.Ptr:
+		if value.IsNil() {
+			// Typed nil pointers reach this branch through the top-level
+			// `obj == nil` check (which only catches untyped nil). The
+			// previous code unconditionally dereferenced with .Elem() and
+			// then .Interface(), panicking with "reflect: call of
+			// reflect.Value.Interface on zero Value" — a direct violation
+			// of the bind contract ("should never panic").
+			return nil
+		}
 		return v.ValidateStruct(value.Elem().Interface())
 	case reflect.Struct:
 		return v.validateStruct(obj)

--- a/tools/bind/default_validator_test.go
+++ b/tools/bind/default_validator_test.go
@@ -1,0 +1,24 @@
+package bind
+
+import "testing"
+
+type validatorTarget struct {
+	Name string `binding:"required"`
+}
+
+// TestValidateStruct_TypedNilPointer covers I-ll: previously
+// ValidateStruct on a typed nil pointer panicked deep in
+// reflect.Value.Interface, violating the documented "should never panic"
+// contract.
+func TestValidateStruct_TypedNilPointer(t *testing.T) {
+	v := &defaultValidator{}
+	var p *validatorTarget // typed nil
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("ValidateStruct panicked on typed nil pointer: %v", r)
+		}
+	}()
+	if err := v.ValidateStruct(p); err != nil {
+		t.Fatalf("ValidateStruct on typed nil pointer err = %v, want nil", err)
+	}
+}

--- a/tools/deepcopy/cycle_test.go
+++ b/tools/deepcopy/cycle_test.go
@@ -1,6 +1,7 @@
 package deepcopy
 
 import (
+	"reflect"
 	"testing"
 	"time"
 )
@@ -37,5 +38,86 @@ func TestClone_SelfReferentialDoesNotStackOverflow(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("Clone of self-referential struct hung (regression to stack overflow)")
+	}
+}
+
+// TestClone_SelfReferentialSliceDoesNotStackOverflow covers the slice cycle the
+// original fix missed: only Ptr/Map were registered in visited, so a slice that
+// contains itself recursed forever and stack-overflowed.
+func TestClone_SelfReferentialSliceDoesNotStackOverflow(t *testing.T) {
+	s := make([]interface{}, 1)
+	s[0] = s // self-reference
+
+	done := make(chan interface{}, 1)
+	go func() {
+		done <- Clone(s)
+	}()
+	select {
+	case got := <-done:
+		cp, ok := got.([]interface{})
+		if !ok {
+			t.Fatalf("Clone returned %T, want []interface{}", got)
+		}
+		if len(cp) != 1 {
+			t.Fatalf("len = %d, want 1", len(cp))
+		}
+		inner, ok := cp[0].([]interface{})
+		if !ok {
+			t.Fatalf("cp[0] = %T, want []interface{}", cp[0])
+		}
+		// The cycle must point back to the copy, not the original or a fresh slice.
+		if reflect.ValueOf(inner).Pointer() != reflect.ValueOf(cp).Pointer() {
+			t.Fatal("slice cycle not preserved: cp[0] is not cp")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Clone of self-referential slice hung (regression to stack overflow)")
+	}
+}
+
+// TestDeepCopy_AliasedSubSliceKeepsLength guards against keying slice cycles by
+// backing-array address alone: a slice and a sub-slice that share a backing
+// array (full and full[:3]) start at the same address but have different
+// lengths, so they must be copied independently — not conflated into one copy
+// of the wrong length.
+func TestDeepCopy_AliasedSubSliceKeepsLength(t *testing.T) {
+	type holder struct {
+		Full []int
+		Half []int
+	}
+	full := []int{0, 1, 2, 3, 4, 5}
+	src := &holder{Full: full, Half: full[:3]}
+
+	var dst holder
+	if err := DeepCopy(&dst, src); err != nil {
+		t.Fatalf("DeepCopy: %v", err)
+	}
+	if len(dst.Full) != 6 {
+		t.Fatalf("Full len = %d, want 6", len(dst.Full))
+	}
+	if len(dst.Half) != 3 {
+		t.Fatalf("Half len = %d, want 3 (sub-slice length must not be conflated with Full)", len(dst.Half))
+	}
+}
+
+// TestDeepCopy_EmptySlicesDifferentTypesNoCollision guards the element type in
+// the visit key: distinct zero-size allocations (make([]int,0), make([]string,0))
+// can share a backing address, so keying without the type conflates them and
+// dst.Set the wrong element type — a panic. Both must copy cleanly.
+func TestDeepCopy_EmptySlicesDifferentTypesNoCollision(t *testing.T) {
+	type holder struct {
+		A []int
+		B []string
+	}
+	src := &holder{A: make([]int, 0), B: make([]string, 0)}
+
+	var dst holder
+	if err := DeepCopy(&dst, src); err != nil {
+		t.Fatalf("DeepCopy: %v", err)
+	}
+	if dst.A == nil || dst.B == nil {
+		t.Fatalf("empty slices became nil: A=%v B=%v", dst.A, dst.B)
+	}
+	if len(dst.A) != 0 || len(dst.B) != 0 {
+		t.Fatalf("lengths: A=%d B=%d, want 0,0", len(dst.A), len(dst.B))
 	}
 }

--- a/tools/deepcopy/cycle_test.go
+++ b/tools/deepcopy/cycle_test.go
@@ -1,0 +1,41 @@
+package deepcopy
+
+import (
+	"testing"
+	"time"
+)
+
+type cyclicNode struct {
+	Name string
+	Next *cyclicNode
+}
+
+// TestClone_SelfReferentialDoesNotStackOverflow covers C25: previously a
+// self-referencing pointer (`n.Next = n`) recursed forever in deepCopy
+// and crashed with stack overflow.
+func TestClone_SelfReferentialDoesNotStackOverflow(t *testing.T) {
+	n := &cyclicNode{Name: "root"}
+	n.Next = n
+
+	done := make(chan interface{}, 1)
+	go func() {
+		done <- Clone(n)
+	}()
+	select {
+	case got := <-done:
+		c, ok := got.(*cyclicNode)
+		if !ok {
+			t.Fatalf("Clone returned %T, want *cyclicNode", got)
+		}
+		if c.Name != "root" {
+			t.Fatalf("Name = %q", c.Name)
+		}
+		// The cycle must be preserved: c.Next should refer back to c (the
+		// copy), not the original.
+		if c.Next != c {
+			t.Fatalf("cycle not preserved: c.Next != c")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Clone of self-referential struct hung (regression to stack overflow)")
+	}
+}

--- a/tools/deepcopy/deepcopy.go
+++ b/tools/deepcopy/deepcopy.go
@@ -1,11 +1,16 @@
 package deepcopy
 
 import (
-	"github.com/songzhibin97/gkit/tools"
 	"reflect"
+
+	"github.com/songzhibin97/gkit/tools"
 )
 
-func deepCopy(dst, src reflect.Value) {
+// deepCopy recursively copies src into dst. The visited map tracks
+// already-copied pointers so self-referential structures
+// (`type N struct{ Next *N }; n := &N{}; n.Next = n`) do not recurse
+// forever and stack-overflow the process.
+func deepCopy(dst, src reflect.Value, visited map[uintptr]reflect.Value) {
 	switch src.Kind() {
 	case reflect.Interface:
 		value := src.Elem()
@@ -13,28 +18,51 @@ func deepCopy(dst, src reflect.Value) {
 			return
 		}
 		newValue := reflect.New(value.Type()).Elem()
-		deepCopy(newValue, value)
+		deepCopy(newValue, value, visited)
 		dst.Set(newValue)
 	case reflect.Ptr:
+		if src.IsNil() {
+			return
+		}
+		ptr := src.Pointer()
+		if v, ok := visited[ptr]; ok {
+			dst.Set(v)
+			return
+		}
 		value := src.Elem()
 		if !value.IsValid() {
 			return
 		}
-		dst.Set(reflect.New(value.Type()))
-		deepCopy(dst.Elem(), value)
+		newPtr := reflect.New(value.Type())
+		visited[ptr] = newPtr
+		dst.Set(newPtr)
+		deepCopy(dst.Elem(), value, visited)
 	case reflect.Map:
-		dst.Set(reflect.MakeMap(src.Type()))
-		keys := src.MapKeys()
-		for _, key := range keys {
+		if src.IsNil() {
+			return
+		}
+		ptr := src.Pointer()
+		if v, ok := visited[ptr]; ok {
+			dst.Set(v)
+			return
+		}
+		newMap := reflect.MakeMap(src.Type())
+		visited[ptr] = newMap
+		dst.Set(newMap)
+		for _, key := range src.MapKeys() {
 			value := src.MapIndex(key)
 			newValue := reflect.New(value.Type()).Elem()
-			deepCopy(newValue, value)
+			deepCopy(newValue, value, visited)
 			dst.SetMapIndex(key, newValue)
 		}
 	case reflect.Slice:
-		dst.Set(reflect.MakeSlice(src.Type(), src.Len(), src.Cap()))
+		if src.IsNil() {
+			return
+		}
+		newSlice := reflect.MakeSlice(src.Type(), src.Len(), src.Cap())
+		dst.Set(newSlice)
 		for i := 0; i < src.Len(); i++ {
-			deepCopy(dst.Index(i), src.Index(i))
+			deepCopy(dst.Index(i), src.Index(i), visited)
 		}
 	case reflect.Struct:
 		typeSrc := src.Type()
@@ -42,7 +70,7 @@ func deepCopy(dst, src reflect.Value) {
 			value := src.Field(i)
 			tag := typeSrc.Field(i).Tag
 			if value.CanSet() && tag.Get("gkit") != "-" {
-				deepCopy(dst.Field(i), value)
+				deepCopy(dst.Field(i), value, visited)
 			}
 		}
 	default:
@@ -62,12 +90,25 @@ func DeepCopy(dst, src interface{}) error {
 	if !dstV.IsValid() || !srcV.IsValid() {
 		return tools.ErrorInvalidValue
 	}
-	deepCopy(dstV, srcV)
+	deepCopy(dstV, srcV, map[uintptr]reflect.Value{})
 	return nil
 }
 
 func Clone(v interface{}) interface{} {
-	dst := reflect.New(reflect.TypeOf(v).Elem())
-	deepCopy(dst, reflect.ValueOf(v))
-	return dst.Interface()
+	rv := reflect.ValueOf(v)
+	visited := map[uintptr]reflect.Value{}
+	if rv.Kind() == reflect.Ptr && !rv.IsNil() {
+		// Allocate a new *T, register it in the visited map BEFORE
+		// recursing so a self-referential field whose pointer equals the
+		// caller's input resolves back to this newly-allocated pointer.
+		// Without the pre-registration, deepCopy would allocate a fresh
+		// inner pointer and the topological self-loop would be lost.
+		dst := reflect.New(rv.Type().Elem())
+		visited[rv.Pointer()] = dst
+		deepCopy(dst.Elem(), rv.Elem(), visited)
+		return dst.Interface()
+	}
+	dst := reflect.New(rv.Type())
+	deepCopy(dst.Elem(), rv, visited)
+	return dst.Elem().Interface()
 }

--- a/tools/deepcopy/deepcopy.go
+++ b/tools/deepcopy/deepcopy.go
@@ -6,11 +6,25 @@ import (
 	"github.com/songzhibin97/gkit/tools"
 )
 
+// visitKey identifies an already-copied source so cycles resolve to the
+// in-progress copy. The element type is part of the key because distinct
+// zero-size allocations (e.g. []int{} and []string{}) can share a backing
+// address; without the type they would collide and dst.Set the wrong type.
+// Slices additionally key on len/cap so a slice and a sub-slice sharing a
+// backing array (e.g. a and a[:n]) are NOT conflated into one copy of the
+// wrong length.
+type visitKey struct {
+	typ reflect.Type
+	ptr uintptr
+	len int
+	cap int
+}
+
 // deepCopy recursively copies src into dst. The visited map tracks
-// already-copied pointers so self-referential structures
-// (`type N struct{ Next *N }; n := &N{}; n.Next = n`) do not recurse
-// forever and stack-overflow the process.
-func deepCopy(dst, src reflect.Value, visited map[uintptr]reflect.Value) {
+// already-copied pointers/maps/slices so self-referential structures
+// (`type N struct{ Next *N }; n := &N{}; n.Next = n`, or `s := make([]any,1);
+// s[0] = s`) do not recurse forever and stack-overflow the process.
+func deepCopy(dst, src reflect.Value, visited map[visitKey]reflect.Value) {
 	switch src.Kind() {
 	case reflect.Interface:
 		value := src.Elem()
@@ -24,8 +38,8 @@ func deepCopy(dst, src reflect.Value, visited map[uintptr]reflect.Value) {
 		if src.IsNil() {
 			return
 		}
-		ptr := src.Pointer()
-		if v, ok := visited[ptr]; ok {
+		key := visitKey{typ: src.Type(), ptr: src.Pointer()}
+		if v, ok := visited[key]; ok {
 			dst.Set(v)
 			return
 		}
@@ -34,32 +48,38 @@ func deepCopy(dst, src reflect.Value, visited map[uintptr]reflect.Value) {
 			return
 		}
 		newPtr := reflect.New(value.Type())
-		visited[ptr] = newPtr
+		visited[key] = newPtr
 		dst.Set(newPtr)
 		deepCopy(dst.Elem(), value, visited)
 	case reflect.Map:
 		if src.IsNil() {
 			return
 		}
-		ptr := src.Pointer()
-		if v, ok := visited[ptr]; ok {
+		key := visitKey{typ: src.Type(), ptr: src.Pointer()}
+		if v, ok := visited[key]; ok {
 			dst.Set(v)
 			return
 		}
 		newMap := reflect.MakeMap(src.Type())
-		visited[ptr] = newMap
+		visited[key] = newMap
 		dst.Set(newMap)
-		for _, key := range src.MapKeys() {
-			value := src.MapIndex(key)
+		for _, k := range src.MapKeys() {
+			value := src.MapIndex(k)
 			newValue := reflect.New(value.Type()).Elem()
 			deepCopy(newValue, value, visited)
-			dst.SetMapIndex(key, newValue)
+			dst.SetMapIndex(k, newValue)
 		}
 	case reflect.Slice:
 		if src.IsNil() {
 			return
 		}
+		key := visitKey{typ: src.Type(), ptr: src.Pointer(), len: src.Len(), cap: src.Cap()}
+		if v, ok := visited[key]; ok {
+			dst.Set(v)
+			return
+		}
 		newSlice := reflect.MakeSlice(src.Type(), src.Len(), src.Cap())
+		visited[key] = newSlice
 		dst.Set(newSlice)
 		for i := 0; i < src.Len(); i++ {
 			deepCopy(dst.Index(i), src.Index(i), visited)
@@ -90,13 +110,13 @@ func DeepCopy(dst, src interface{}) error {
 	if !dstV.IsValid() || !srcV.IsValid() {
 		return tools.ErrorInvalidValue
 	}
-	deepCopy(dstV, srcV, map[uintptr]reflect.Value{})
+	deepCopy(dstV, srcV, map[visitKey]reflect.Value{})
 	return nil
 }
 
 func Clone(v interface{}) interface{} {
 	rv := reflect.ValueOf(v)
-	visited := map[uintptr]reflect.Value{}
+	visited := map[visitKey]reflect.Value{}
 	if rv.Kind() == reflect.Ptr && !rv.IsNil() {
 		// Allocate a new *T, register it in the visited map BEFORE
 		// recursing so a self-referential field whose pointer equals the
@@ -104,7 +124,7 @@ func Clone(v interface{}) interface{} {
 		// Without the pre-registration, deepCopy would allocate a fresh
 		// inner pointer and the topological self-loop would be lost.
 		dst := reflect.New(rv.Type().Elem())
-		visited[rv.Pointer()] = dst
+		visited[visitKey{typ: rv.Type(), ptr: rv.Pointer()}] = dst
 		deepCopy(dst.Elem(), rv.Elem(), visited)
 		return dst.Interface()
 	}

--- a/tools/reflect2value/err.go
+++ b/tools/reflect2value/err.go
@@ -1,5 +1,7 @@
 package reflect2value
 
+import "fmt"
+
 type errNonsupportType struct {
 	valueType string
 }
@@ -10,4 +12,29 @@ func NewErrNonsupportType(valueType string) error {
 
 func (e *errNonsupportType) Error() string {
 	return e.valueType + ":不是支持类型"
+}
+
+// ErrOverflow is returned when a numeric value cannot fit into the target
+// type without truncation. Previously SetInt/SetUint/SetFloat silently
+// stored a truncated value (e.g. 200 into int8 → -56).
+type ErrOverflow struct {
+	TargetType string
+	Value      int64
+	Float      float64
+	IsFloat    bool
+}
+
+func NewErrOverflow(targetType string, value int64) error {
+	return &ErrOverflow{TargetType: targetType, Value: value}
+}
+
+func NewErrOverflowFloat(targetType string, value float64) error {
+	return &ErrOverflow{TargetType: targetType, Float: value, IsFloat: true}
+}
+
+func (e *ErrOverflow) Error() string {
+	if e.IsFloat {
+		return fmt.Sprintf("reflect2value: value %g overflows %s", e.Float, e.TargetType)
+	}
+	return fmt.Sprintf("reflect2value: value %d overflows %s", e.Value, e.TargetType)
 }

--- a/tools/reflect2value/reflect.go
+++ b/tools/reflect2value/reflect.go
@@ -200,7 +200,9 @@ func reflectValues(valueType string, value interface{}) (reflect.Value, error) {
 			if err != nil {
 				return reflect.Value{}, err
 			}
-
+			if theValue.Index(i).OverflowInt(intValue) {
+				return reflect.Value{}, NewErrOverflow(theValue.Index(i).Type().String(), intValue)
+			}
 			theValue.Index(i).SetInt(intValue)
 		}
 
@@ -229,7 +231,9 @@ func reflectValues(valueType string, value interface{}) (reflect.Value, error) {
 			if err != nil {
 				return reflect.Value{}, err
 			}
-
+			if theValue.Index(i).OverflowUint(uintValue) {
+				return reflect.Value{}, NewErrOverflow(theValue.Index(i).Type().String(), int64(uintValue))
+			}
 			theValue.Index(i).SetUint(uintValue)
 		}
 
@@ -246,7 +250,9 @@ func reflectValues(valueType string, value interface{}) (reflect.Value, error) {
 			if err != nil {
 				return reflect.Value{}, err
 			}
-
+			if theValue.Index(i).OverflowFloat(floatValue) {
+				return reflect.Value{}, NewErrOverflowFloat(theValue.Index(i).Type().String(), floatValue)
+			}
 			theValue.Index(i).SetFloat(floatValue)
 		}
 

--- a/tools/reflect2value/reflect.go
+++ b/tools/reflect2value/reflect.go
@@ -108,7 +108,12 @@ func reflectValue(valueType string, value interface{}) (reflect.Value, error) {
 		if err != nil {
 			return reflect.Value{}, err
 		}
-
+		// Guard against silent truncation: SetInt(int64) into a narrower
+		// target (int8/int16/int32) previously stored e.g. 200 → -56
+		// with no signal to the caller.
+		if theValue.Elem().OverflowInt(intValue) {
+			return reflect.Value{}, NewErrOverflow(theType.String(), intValue)
+		}
 		theValue.Elem().SetInt(intValue)
 		return theValue.Elem(), err
 	}
@@ -119,7 +124,9 @@ func reflectValue(valueType string, value interface{}) (reflect.Value, error) {
 		if err != nil {
 			return reflect.Value{}, err
 		}
-
+		if theValue.Elem().OverflowUint(uintValue) {
+			return reflect.Value{}, NewErrOverflow(theType.String(), int64(uintValue))
+		}
 		theValue.Elem().SetUint(uintValue)
 		return theValue.Elem(), err
 	}
@@ -130,7 +137,9 @@ func reflectValue(valueType string, value interface{}) (reflect.Value, error) {
 		if err != nil {
 			return reflect.Value{}, err
 		}
-
+		if theValue.Elem().OverflowFloat(floatValue) {
+			return reflect.Value{}, NewErrOverflowFloat(theType.String(), floatValue)
+		}
 		theValue.Elem().SetFloat(floatValue)
 		return theValue.Elem(), err
 	}

--- a/tools/reflect2value/reflect_test.go
+++ b/tools/reflect2value/reflect_test.go
@@ -1,0 +1,86 @@
+package reflect2value
+
+import (
+	"errors"
+	"math"
+	"testing"
+)
+
+// TestReflectValue_IntOverflow guards the new narrowing-overflow check: setting
+// an int64 into a narrower target (int8/16/32) previously truncated silently
+// (e.g. 200 -> -56). It must now return *ErrOverflow instead.
+func TestReflectValue_IntOverflow(t *testing.T) {
+	v, err := ReflectValue("int8", int64(200))
+	if err == nil {
+		t.Fatalf("int8=200: want overflow error, got %v", v.Interface())
+	}
+	var oe *ErrOverflow
+	if !errors.As(err, &oe) {
+		t.Fatalf("int8=200: want *ErrOverflow, got %T: %v", err, err)
+	}
+
+	v, err = ReflectValue("int8", int64(100))
+	if err != nil {
+		t.Fatalf("int8=100: unexpected error: %v", err)
+	}
+	if got := v.Int(); got != 100 {
+		t.Fatalf("int8=100: got %d, want 100", got)
+	}
+
+	// Full-width int64 must not falsely overflow.
+	if _, err := ReflectValue("int64", int64(math.MaxInt64)); err != nil {
+		t.Fatalf("int64=MaxInt64: unexpected overflow: %v", err)
+	}
+}
+
+// TestReflectValue_UintOverflow guards the unsigned narrowing check.
+func TestReflectValue_UintOverflow(t *testing.T) {
+	if _, err := ReflectValue("uint8", uint64(300)); err == nil {
+		t.Fatal("uint8=300: want overflow error")
+	}
+	v, err := ReflectValue("uint8", uint64(200))
+	if err != nil {
+		t.Fatalf("uint8=200: unexpected error: %v", err)
+	}
+	if got := v.Uint(); got != 200 {
+		t.Fatalf("uint8=200: got %d, want 200", got)
+	}
+}
+
+// TestReflectValue_FloatOverflow guards the float narrowing check.
+func TestReflectValue_FloatOverflow(t *testing.T) {
+	if _, err := ReflectValue("float32", float64(1e40)); err == nil {
+		t.Fatal("float32=1e40: want overflow error")
+	}
+	v, err := ReflectValue("float32", float64(1.5))
+	if err != nil {
+		t.Fatalf("float32=1.5: unexpected error: %v", err)
+	}
+	if got := v.Float(); got != 1.5 {
+		t.Fatalf("float32=1.5: got %v, want 1.5", got)
+	}
+}
+
+// TestReflectValue_SliceOverflow guards the slice conversion paths, which set
+// elements with SetInt/SetUint/SetFloat and previously skipped the overflow
+// checks the scalar paths have — so []int8{200} truncated to -56 silently.
+func TestReflectValue_SliceOverflow(t *testing.T) {
+	if _, err := ReflectValue("[]int8", []int64{200}); err == nil {
+		t.Fatal("[]int8 with 200: want overflow error")
+	}
+	if _, err := ReflectValue("[]uint8", []uint64{300}); err == nil {
+		t.Fatal("[]uint8 with 300: want overflow error")
+	}
+	if _, err := ReflectValue("[]float32", []float64{1e40}); err == nil {
+		t.Fatal("[]float32 with 1e40: want overflow error")
+	}
+
+	// In-range slices still convert.
+	v, err := ReflectValue("[]int8", []int64{100, 127})
+	if err != nil {
+		t.Fatalf("[]int8 in-range: unexpected error: %v", err)
+	}
+	if v.Len() != 2 || v.Index(0).Int() != 100 || v.Index(1).Int() != 127 {
+		t.Fatalf("[]int8 in-range: got %v", v.Interface())
+	}
+}


### PR DESCRIPTION
## Summary

PR 9 of 10 from the second-pass audit. Six correctness/security defects in tools, parser, encrypt.

| ID | Defect | Fix |
|---|---|---|
| **C25** | `deepcopy` had no visited-pointer set → self-referential structs stack-overflowed. | Thread `map[uintptr]reflect.Value` through; pre-register top-level pointer in `Clone` to preserve self-loop topology. |
| **I-ll** | `bind.ValidateStruct` on a typed nil pointer panicked in `value.Elem().Interface()`. | Guard with `value.IsNil()` before recursing. |
| **I-nn** | `reflect2value` called `SetInt`/`SetUint`/`SetFloat` without `OverflowInt`/`Uint`/`Float` guards → silent truncation into narrower targets. | Add overflow checks + new `ErrOverflow` error. |
| **I-mm** | `parser.parseDoc` did `strings.Split(":")[1]` inside `recover` + `fmt.Println`; malformed input silently produced empty fields in generated code. | `SplitN`+length-check; dropped the recover. |
| **C26** | `PileDriving` overwrote `pileFind`'s `err`, then wrote corrupted bytes back to the user's source file. | Add the missing early return. |
| **I-kk** | `Decrypt` returned distinguishable error strings + `PKCS7UnPadding` short-circuited byte compare → textbook CBC padding oracle. | Collapse Decrypt errors into single `ErrDecryptionFailed`; use `subtle.ConstantTimeCompare` in unpad. |

## Compatibility

- `Clone` and `DeepCopy` API unchanged; `Clone` is now correct for self-referential structs (previously broken).
- `ValidateStruct` keeps signature; typed-nil now returns nil instead of panicking.
- `reflect2value` may now error where it previously silently truncated — strictly more correct.
- `parseDoc` keeps signature; malformed lines now leave fields zero-valued (same as before) but without the recover spam.
- `aes.Decrypt` returns `ErrDecryptionFailed` for all failure modes — callers that checked `err != nil` are unaffected; callers that pattern-matched the old error strings (none in this repo) should switch to `errors.Is(err, ErrDecryptionFailed)`.

## Test plan
- [x] `tools/deepcopy/cycle_test.go::TestClone_SelfReferentialDoesNotStackOverflow` — proves cycle handling
- [x] `tools/bind/default_validator_test.go::TestValidateStruct_TypedNilPointer` — proves typed-nil safety
- [x] `go test -race ./tools/deepcopy/ ./tools/bind/ ./encrypt/aes/ ./parser/parse_go/` — all green
- [x] `go build ./...` — passes