### PR TITLE
fix(cache): close eviction and buffer races

### DIFF
--- a/cache/buffer/iobuffer.go
+++ b/cache/buffer/iobuffer.go
@@ -103,7 +103,8 @@ func (p *pipe) Write(buffer []byte) (int, error) {
 	return len(buffer), p.IoBuffer.Append(buffer)
 }
 
-// CloseWithError 使下一次读取(如果需要,唤醒当前阻止的读取)在所有数据都已经完成后返回提供错误
+// CloseWithError closes the pipe and wakes all blocked readers. After buffered
+// data is consumed, reads return err; a nil err is converted to io.EOF.
 func (p *pipe) CloseWithError(err error) {
 	if err == nil {
 		err = io.EOF
@@ -112,7 +113,7 @@ func (p *pipe) CloseWithError(err error) {
 	defer p.mu.Unlock()
 	p.checkCond()
 	p.err = err
-	defer p.c.Signal()
+	defer p.c.Broadcast()
 }
 
 // checkCond 检查 Cond 是否初始化, 否则赋值锁
@@ -122,7 +123,9 @@ func (p *pipe) checkCond() {
 	}
 }
 
-// NewPipe 初始化 pipe IoBuffer
+// NewPipe initializes a buffered pipe. Read, Write, CloseWithError, and Len
+// may be called concurrently. Callers must provide their own synchronization
+// before mixing any other IoBuffer method with concurrent pipe operations.
 func NewPipe(cap int) IoBuffer {
 	return &pipe{
 		IoBuffer: newIoBuffer(cap),
@@ -146,9 +149,11 @@ type ioBuffer struct {
 
 // Read 从缓冲区读取拷贝到 p
 func (i *ioBuffer) Read(p []byte) (n int, err error) {
-	if i.off > 0 && i.off >= len(i.buffer) {
+	if i.off >= len(i.buffer) {
 		// off已经漂移到buffer末尾或越界
-		i.Reset()
+		if i.off > 0 {
+			i.Reset()
+		}
 		if len(p) == 0 {
 			return
 		}
@@ -233,8 +238,14 @@ func (i *ioBuffer) ReadFrom(r io.Reader) (n int64, err error) {
 
 // Grow 扩张
 func (i *ioBuffer) Grow(n int) error {
-	if _, ok := i.tryGrowByRelies(n); !ok {
-		i.grow(n)
+	start, ok := i.tryGrowByRelies(n)
+	if !ok {
+		start = i.grow(n)
+	}
+	if n > 0 {
+		for j := start; j < len(i.buffer); j++ {
+			i.buffer[j] = 0
+		}
 	}
 	return nil
 }

--- a/cache/buffer/issue78_test.go
+++ b/cache/buffer/issue78_test.go
@@ -1,0 +1,129 @@
+package buffer
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestIoBufferReadEmptyReturnsEOF(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(IoBuffer)
+	}{
+		{name: "new"},
+		{
+			name: "reset",
+			setup: func(buf IoBuffer) {
+				_, _ = buf.Write([]byte{1})
+				buf.Reset()
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := NewIoBuffer(16)
+			defer PutIoPool(buf)
+			if tt.setup != nil {
+				tt.setup(buf)
+			}
+
+			n, err := buf.Read(make([]byte, 1))
+			if n != 0 || !errors.Is(err, io.EOF) {
+				t.Fatalf("Read(empty) = (%d, %v), want (0, io.EOF)", n, err)
+			}
+		})
+	}
+}
+
+func TestIoBufferZeroLengthReadReturnsNil(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{name: "empty"},
+		{name: "non-empty", data: []byte{1}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := NewIoBuffer(16)
+			defer PutIoPool(buf)
+			_, _ = buf.Write(tt.data)
+
+			n, err := buf.Read(nil)
+			if n != 0 || err != nil {
+				t.Fatalf("Read(zero-length) = (%d, %v), want (0, nil)", n, err)
+			}
+			if got := buf.Bytes(); !bytes.Equal(got, tt.data) {
+				t.Fatalf("Read(zero-length) consumed data: got %v, want %v", got, tt.data)
+			}
+		})
+	}
+}
+
+func blockedPipeReaders() int {
+	stack := make([]byte, 1<<20)
+	n := runtime.Stack(stack, true)
+	return bytes.Count(stack[:n], []byte("cache/buffer.(*pipe).Read"))
+}
+
+func waitForBlockedPipeReaders(t *testing.T, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if blockedPipeReaders() >= want {
+			return
+		}
+		runtime.Gosched()
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("blocked pipe readers = %d, want at least %d", blockedPipeReaders(), want)
+}
+
+func TestPipeCloseWakesAllBlockedReaders(t *testing.T) {
+	pipe := NewPipe(16)
+	started := make(chan struct{}, 2)
+	done := make(chan error, 2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			started <- struct{}{}
+			_, err := pipe.Read(make([]byte, 1))
+			done <- err
+		}()
+	}
+	<-started
+	<-started
+	waitForBlockedPipeReaders(t, 2)
+
+	pipe.CloseWithError(nil)
+	timer := time.NewTimer(300 * time.Millisecond)
+	defer timer.Stop()
+	for returned := 0; returned < 2; returned++ {
+		select {
+		case err := <-done:
+			if !errors.Is(err, io.EOF) {
+				t.Fatalf("Read after CloseWithError(nil) returned %v, want io.EOF", err)
+			}
+		case <-timer.C:
+			t.Fatalf("CloseWithError woke %d/2 blocked readers", returned)
+		}
+	}
+}
+
+func TestIoBufferGrowZeroInitializesNewRegion(t *testing.T) {
+	backing := bytes.Repeat([]byte{0xa5}, 16)
+	buf := NewIoBufferBytes(backing[:4])
+
+	if err := buf.Grow(4); err != nil {
+		t.Fatal(err)
+	}
+	want := []byte{0xa5, 0xa5, 0xa5, 0xa5, 0, 0, 0, 0}
+	if got := buf.Bytes(); !bytes.Equal(got, want) {
+		t.Fatalf("Bytes() after Grow = %x, want %x", got, want)
+	}
+}

--- a/cache/local_cache/cache.go
+++ b/cache/local_cache/cache.go
@@ -21,6 +21,8 @@ type Cache struct {
 	*cache
 }
 
+// NewCache creates a cache. If a positive janitor interval is configured with
+// SetInternal, the caller must call Shutdown when the cache is no longer used.
 func NewCache(options ...options.Option) Cache {
 	ctx, cancel := context.WithCancel(context.Background())
 	c := &Config{
@@ -1026,17 +1028,11 @@ func (c *cache) DecrementFloat64(k string, n float64) (float64, error) {
 // Delete 删除k的cache 如果 capture != nil 会调用 capture 函数 将 kv传入
 func (c *cache) Delete(k string) {
 	c.Lock()
+	capture := c.capture
 	v, ok := c.delete(k)
 	c.Unlock()
-	if ok {
-		c.capture(k, v)
-	}
-}
-
-func (c *cache) _delete(k string) {
-	v, ok := c.delete(k)
-	if ok {
-		c.capture(k, v)
+	if ok && capture != nil {
+		capture(k, v)
 	}
 }
 
@@ -1046,43 +1042,60 @@ func (c *cache) _delete(k string) {
 // it under the lock would deadlock. Mirrors the public Delete's ordering. The
 // caller must hold c's write lock and must not touch c after calling this.
 func (c *cache) expireEvictUnlock(k string) {
+	capture := c.capture
 	v, ok := c.delete(k)
 	c.Unlock()
-	if ok {
-		c.capture(k, v)
+	if ok && capture != nil {
+		capture(k, v)
 	}
 }
 
-// delete 删除k的cache 如果具有 capture != nil 则会携带v返回
+// delete removes k and returns its value. The caller must hold c's write lock.
 func (c *cache) delete(k string) (interface{}, bool) {
-	if c.capture != nil {
-		if v, ok := c.member[k]; ok {
-			delete(c.member, k)
-			return v.Val, true
-		}
+	if v, ok := c.member[k]; ok {
+		delete(c.member, k)
+		return v.Val, true
 	}
-	delete(c.member, k)
 	return nil, false
+}
+
+// deleteExpired removes k only when the value observed under the write lock is
+// still expired. The capture handler is snapshotted under the same lock and is
+// invoked after unlocking so it may safely re-enter the cache.
+func (c *cache) deleteExpired(k string) {
+	c.Lock()
+	v, ok := c.member[k]
+	if !ok || !v.Expired() {
+		c.Unlock()
+		return
+	}
+	capture := c.capture
+	delete(c.member, k)
+	c.Unlock()
+	if capture != nil {
+		capture(k, v.Val)
+	}
 }
 
 // DeleteExpire 删除已经过期的kv
 func (c *cache) DeleteExpire() {
+	c.Lock()
+	capture := c.capture
 	var kvList []kv
-	if c.capture != nil {
+	if capture != nil {
 		kvList = make([]kv, 0, len(c.member)/4)
 	}
-	c.Lock()
 	t := time.Now().UnixNano()
 	for k, v := range c.member {
 		if v.Expired(t) {
-			if vv, ok := c.delete(k); ok && c.capture != nil {
+			if vv, ok := c.delete(k); ok && capture != nil {
 				kvList = append(kvList, kv{k, vv})
 			}
 		}
 	}
 	c.Unlock()
 	for _, v := range kvList {
-		c.capture(v.key, v.value)
+		capture(v.key, v.value)
 	}
 }
 
@@ -1172,7 +1185,7 @@ func (c *cache) Iterator() map[string]Iterator {
 	c.RUnlock()
 	// 清除过期key
 	for _, key := range keys {
-		c.Delete(key)
+		c.deleteExpired(key)
 	}
 	return ret
 }
@@ -1191,6 +1204,7 @@ func (c *cache) Flush() {
 	c.member = make(map[string]Iterator)
 }
 
+// Shutdown stops the janitor and releases the cache's members.
 func (c *cache) Shutdown() error {
 	c.Flush()
 	c.cancel()

--- a/cache/local_cache/issue78_test.go
+++ b/cache/local_cache/issue78_test.go
@@ -78,6 +78,10 @@ func TestCaptureConcurrentChangeAndDelete(t *testing.T) {
 			c.DeleteExpire()
 			c.Set("deleted", i, NoExpire)
 			c.Delete("deleted")
+			c.Set("expired-get", i, time.Nanosecond)
+			_, _ = c.Get("expired-get")
+			c.Set("expired-iterator", i, time.Nanosecond)
+			_ = c.Iterator()
 		}
 	}()
 

--- a/cache/local_cache/issue78_test.go
+++ b/cache/local_cache/issue78_test.go
@@ -1,0 +1,86 @@
+package local_cache
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestIteratorDoesNotDeleteFreshReplacement(t *testing.T) {
+	const keyCount = 32
+	expired := make(map[string]Iterator, keyCount)
+	for i := 0; i < keyCount; i++ {
+		expired[fmt.Sprintf("k-%02d", i)] = Iterator{
+			Val:    "expired",
+			Expire: time.Now().Add(-time.Second).UnixNano(),
+		}
+	}
+	firstDelete := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	c := NewCache(SetMember(expired), SetCapture(func(string, interface{}) {
+		once.Do(func() {
+			close(firstDelete)
+			<-release
+		})
+	}))
+	defer c.Shutdown()
+
+	done := make(chan struct{})
+	go func() {
+		_ = c.Iterator()
+		close(done)
+	}()
+	select {
+	case <-firstDelete:
+	case <-time.After(time.Second):
+		t.Fatal("Iterator did not begin expired-entry deletion")
+	}
+
+	for i := 0; i < keyCount; i++ {
+		c.Set(fmt.Sprintf("k-%02d", i), "fresh", NoExpire)
+	}
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Iterator did not finish")
+	}
+
+	for i := 0; i < keyCount; i++ {
+		key := fmt.Sprintf("k-%02d", i)
+		if got, ok := c.Get(key); !ok || got != "fresh" {
+			t.Fatalf("fresh replacement %q was deleted: got (%v, %v)", key, got, ok)
+		}
+	}
+}
+
+func TestCaptureConcurrentChangeAndDelete(t *testing.T) {
+	c := NewCache(SetCapture(func(string, interface{}) {}))
+	defer c.Shutdown()
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < 100_000; i++ {
+			c.ChangeCapture(func(string, interface{}) {})
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < 100_000; i++ {
+			c.Set("expired", i, time.Nanosecond)
+			c.DeleteExpire()
+			c.Set("deleted", i, NoExpire)
+			c.Delete("deleted")
+		}
+	}()
+
+	close(start)
+	wg.Wait()
+}

--- a/cache/local_cache/option.go
+++ b/cache/local_cache/option.go
@@ -21,7 +21,8 @@ type Config struct {
 	member map[string]Iterator
 }
 
-// SetInternal 设置间隔时间
+// SetInternal sets the janitor interval. If interval is positive, the caller
+// must call Cache.Shutdown when the cache is no longer used.
 func SetInternal(interval time.Duration) options.Option {
 	return func(c interface{}) {
 		c.(*Config).interval = interval

--- a/cache/mbuffer/mcache.go
+++ b/cache/mbuffer/mcache.go
@@ -47,6 +47,7 @@ func calcIndex(size int) int {
 // Malloc supports one or two integer argument.
 // The size specifies the length of the returned slice, which means len(ret) == size.
 // A second integer argument may be provided to specify the minimum capacity, which means cap(ret) >= cap.
+// The returned contents are unspecified and are not guaranteed to be zeroed.
 func Malloc(size int, capacity ...int) []byte {
 	if len(capacity) > 1 {
 		panic("too many arguments to Malloc")

--- a/specs/78/PRODUCT.md
+++ b/specs/78/PRODUCT.md
@@ -1,0 +1,18 @@
+# Cache correctness and contracts
+
+## Summary
+
+Cache buffers and local caches remain live and deterministic at empty, close, reuse, and concurrent-update boundaries. Public documentation states the concurrency, shutdown, and memory-initialization responsibilities that callers must follow.
+
+## Behavior
+
+1. Reading an empty I/O buffer into a non-empty destination returns zero bytes and `io.EOF`, including immediately after construction or reset.
+2. Reading with a zero-length destination returns zero bytes and no error, whether the I/O buffer is empty or contains data, and does not consume data.
+3. Closing a pipe wakes every read that is already blocked waiting for data; after buffered data is exhausted, each read returns the terminal error, with a nil close error represented as `io.EOF`.
+4. If an iterator observes an expired cache entry and a concurrent caller replaces that key with an unexpired value before eviction, the replacement remains present.
+5. Deletion, expiration cleanup, and capture-handler replacement can run concurrently without a data race.
+6. A capture handler runs after the cache lock is released and may safely call back into the same cache.
+7. Growing an I/O buffer preserves all existing readable bytes and initializes only the newly readable region to zero.
+8. A pipe supports concurrent calls to `Read`, `Write`, `CloseWithError`, and `Len`; callers must provide their own synchronization before mixing any other I/O-buffer method with concurrent pipe operations.
+9. A cache configured with a positive janitor interval requires its caller to invoke `Shutdown` when the cache is no longer needed.
+10. Memory returned by `Malloc` has the requested length and capacity but its byte contents are unspecified and are not guaranteed to be zeroed.

--- a/specs/78/TECH.md
+++ b/specs/78/TECH.md
@@ -1,0 +1,59 @@
+# Cache correctness and contracts: technical plan
+
+## Context
+
+GitHub issue #78 covers five implementation defects and three public-contract ambiguities in the cache packages.
+
+- `cache/buffer/iobuffer.go:74-132` implements the synchronized pipe surface and its terminal broadcast.
+- `cache/buffer/iobuffer.go:150-165` implements the empty and zero-length read contract.
+- `cache/buffer/iobuffer.go:239-249` and `487-522` extend readable buffer length and identify the newly added range.
+- `cache/local_cache/cache.go:1029-1106` owns deletion, capture snapshots, and off-lock callback invocation.
+- `cache/local_cache/cache.go:1173-1190` collects expired keys and routes cleanup through a write-locked expiry recheck.
+- `cache/local_cache/cache.go:24-52`, `cache/local_cache/option.go:24-30`, and `cache/local_cache/cache.go:1207-1211` define janitor startup and shutdown ownership.
+- `cache/mbuffer/mcache.go:47-90` returns and recycles pooled byte slices without clearing them.
+
+`specs/78/PRODUCT.md` is the source of truth for caller-observable behavior.
+
+## Proposed changes
+
+### Buffer behavior
+
+- Update empty reads to check the actual exhausted state while preserving the zero-length-read exception.
+- Broadcast a terminal pipe close to every condition waiter; keep ordinary writes as single-reader signals.
+- After `Grow` extends readable length, zero exactly the appended range with a Go 1.20-compatible loop. Preserve the existing prefix and do not zero on `Write` or other paths that immediately overwrite the extension.
+
+### Local-cache concurrency
+
+- Add an expiration-specific deletion path that acquires the write lock, re-reads the current entry, and deletes only when that current entry is still expired.
+- Snapshot the active capture handler while holding the cache write lock, release the lock, and invoke only that snapshot afterward.
+- Make the internal map deletion primitive independent of whether a capture handler is installed, so deletion and callback ownership remain separate.
+- Preserve off-lock capture invocation so reentrant handlers cannot deadlock.
+
+### Contract documentation
+
+- Document the four pipe methods that may be used concurrently and require caller synchronization for the rest.
+- Document `Shutdown` ownership wherever a positive janitor interval is configured.
+- Document that `Malloc` returns pooled bytes with unspecified contents.
+
+No new exported type, feature flag, configuration option, finalizer, or synchronization abstraction is introduced.
+
+## Testing and validation
+
+1. Behavior §1 → `cache/buffer/issue78_test.go:TestIoBufferReadEmptyReturnsEOF`, covering construction and reset. Mutation: restore the old positive-offset guard; the new-buffer case must fail.
+2. Behavior §2 → `cache/buffer/issue78_test.go:TestIoBufferZeroLengthReadReturnsNil`, covering empty and non-empty buffers plus non-consumption. Mutation: return EOF before the zero-length exception; the empty case must fail.
+3. Behavior §3 → `cache/buffer/issue78_test.go:TestPipeCloseWakesAllBlockedReaders`, which waits until two readers are parked before closing. Mutation: replace broadcast with a single signal; one reader must remain blocked and the test must fail.
+4. Behavior §4 → `cache/local_cache/issue78_test.go:TestIteratorDoesNotDeleteFreshReplacement`, which blocks the first eviction callback, installs fresh values for every observed expired key, then releases iteration. Mutation: delete without the write-locked expiry recheck; fresh replacements must disappear and the test must fail.
+5. Behavior §5 → `cache/local_cache/issue78_test.go:TestCaptureConcurrentChangeAndDelete`, run with `-race`. Mutation: read the handler after unlocking; the race detector must report the read/write conflict.
+6. Behavior §6 → existing `cache/local_cache/capture_test.go:TestCapture_ReentrantNoDeadlock`. Mutation: invoke capture while holding the write lock; the reentrant callback must time out.
+7. Behavior §7 → `cache/buffer/issue78_test.go:TestIoBufferGrowZeroInitializesNewRegion`, using a fixed non-zero backing pattern to prove prefix preservation and zero initialization. Mutation: remove the zeroing loop; the test must observe the fixed pattern and fail.
+8. Behavior §8 → `go doc ./cache/buffer NewPipe | rg -q 'Read, Write, CloseWithError, and Len'` and `go doc ./cache/buffer NewPipe | rg -q 'own synchronization'` verify the concurrent-safe subset and caller responsibility. Mutation: remove either contract sentence; its command must fail.
+9. Behavior §9 → `go doc ./cache/local_cache NewCache | rg -q 'must call Shutdown'` and `go doc ./cache/local_cache SetInternal | rg -q 'must call Cache.Shutdown'` verify lifecycle ownership. Mutation: remove either requirement; its command must fail.
+10. Behavior §10 → `go doc ./cache/mbuffer Malloc | tr '\n' ' ' | rg -q 'not *guaranteed to be zeroed'` verifies the pooled-memory contract despite `go doc` line wrapping. Mutation: remove the sentence; the command must fail.
+
+Final verification:
+
+```sh
+gofmt -w cache/buffer/iobuffer.go cache/buffer/issue78_test.go cache/local_cache/cache.go cache/local_cache/issue78_test.go cache/local_cache/option.go cache/mbuffer/mcache.go
+go test -race ./cache/buffer ./cache/local_cache ./cache/mbuffer
+go vet ./cache/...
+```


### PR DESCRIPTION
## What

- return `io.EOF` for empty non-zero reads, broadcast terminal pipe close, and zero only bytes exposed by `Grow`
- recheck expiration under the local-cache write lock and snapshot capture callbacks before unlocking
- document the supported pipe concurrency subset, janitor shutdown ownership, and pooled `Malloc` contents
- add issue-scoped PRODUCT/TECH specs and deterministic regression tests

## Why

Issue #78 identified real hangs, lost updates, data races, and uninitialized readable bytes. Three additional findings are contract boundaries rather than implementation bugs and are clarified in documentation.

## How

Expiration cleanup now performs delete-if-still-expired under the write lock. Callback identity is captured under the same lock but invoked afterward, preserving reentrancy. Buffer fixes stay on the existing APIs and use a Go 1.20-compatible zeroing loop.

## Test plan

- `GOTOOLCHAIN=go1.20.14 go test -race -count=1 ./cache/buffer ./cache/local_cache ./cache/mbuffer`
- `GOTOOLCHAIN=go1.20.14 go vet ./cache/...`
- independent review: 0 critical, 0 important
- mutations killed: empty-read guard, Iterator unconditional delete, capture read after unlock

## Compatibility

No exported signature changes. Explicit `Grow` now initializes its newly readable range, and the documented concurrency/lifecycle boundaries match the implementation.

Fixes #78
