### PR TITLE
fix(concurrency): make lifecycle transitions race-safe

### DIFF
--- a/concurrent/or_done.go
+++ b/concurrent/or_done.go
@@ -2,28 +2,30 @@ package concurrent
 
 import "reflect"
 
-// OrDone 任意channel完成后返回
+// OrDone returns a signal channel that closes when any non-nil input first
+// becomes readable or closes. It never forwards an input value.
 func OrDone(channels ...<-chan interface{}) <-chan interface{} {
-	switch len(channels) {
-	case 0:
-		// 返回已经关闭的channel 通知各个接受者关闭
-		c := make(chan interface{})
-		close(c)
-		return c
-	case 1:
-		return channels[0]
+	orDone := make(chan interface{})
+	if len(channels) == 0 {
+		close(orDone)
+		return orDone
 	}
-	orDone := make(chan interface{}, 1)
+	cases := make([]reflect.SelectCase, 0, len(channels))
+	for _, channel := range channels {
+		if channel == nil {
+			continue
+		}
+		cases = append(cases, reflect.SelectCase{
+			Dir:  reflect.SelectRecv,
+			Chan: reflect.ValueOf(channel),
+		})
+	}
+	if len(cases) == 0 {
+		return orDone
+	}
+
 	go func() {
 		defer close(orDone)
-		var cases []reflect.SelectCase
-		for _, channel := range channels {
-			cases = append(cases, reflect.SelectCase{
-				Dir:  reflect.SelectRecv,
-				Chan: reflect.ValueOf(channel),
-			})
-		}
-		// 选择一个可用的
 		reflect.Select(cases)
 	}()
 	return orDone

--- a/concurrent/or_done_issue80_test.go
+++ b/concurrent/or_done_issue80_test.go
@@ -1,0 +1,72 @@
+package concurrent
+
+import (
+	"testing"
+	"time"
+)
+
+func requireClosedSignal(t *testing.T, signal <-chan interface{}) {
+	t.Helper()
+	select {
+	case value, ok := <-signal:
+		if ok {
+			t.Fatalf("completion signal forwarded payload %v", value)
+		}
+		if value != nil {
+			t.Fatalf("closed completion signal value = %v, want nil", value)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("completion signal did not close")
+	}
+}
+
+func requireOpenSignal(t *testing.T, signal <-chan interface{}) {
+	t.Helper()
+	select {
+	case value, ok := <-signal:
+		t.Fatalf("completion signal fired unexpectedly: value=%v ok=%v", value, ok)
+	case <-time.After(20 * time.Millisecond):
+	}
+}
+
+func TestOrDoneNoInputsIsClosedSignal(t *testing.T) {
+	requireClosedSignal(t, OrDone())
+}
+
+func TestOrDoneSingleInputIsSignalOnly(t *testing.T) {
+	t.Run("payload", func(t *testing.T) {
+		source := make(chan interface{}, 1)
+		source <- "payload"
+		requireClosedSignal(t, OrDone(source))
+	})
+
+	t.Run("closed", func(t *testing.T) {
+		source := make(chan interface{})
+		close(source)
+		requireClosedSignal(t, OrDone(source))
+	})
+
+	t.Run("nil", func(t *testing.T) {
+		requireOpenSignal(t, OrDone(nil))
+	})
+}
+
+func TestOrDoneMultipleInputsAndNilSemantics(t *testing.T) {
+	t.Run("first payload closes signal", func(t *testing.T) {
+		ready := make(chan interface{}, 1)
+		ready <- "payload"
+		other := make(chan interface{})
+		requireClosedSignal(t, OrDone(nil, other, ready))
+	})
+
+	t.Run("first close closes signal", func(t *testing.T) {
+		closed := make(chan interface{})
+		close(closed)
+		other := make(chan interface{})
+		requireClosedSignal(t, OrDone(other, nil, closed))
+	})
+
+	t.Run("all nil remains open", func(t *testing.T) {
+		requireOpenSignal(t, OrDone(nil, nil))
+	})
+}

--- a/container/group/group.go
+++ b/container/group/group.go
@@ -38,9 +38,9 @@ func (g *Group) ReSet(nf func() interface{}) {
 		panic("container.group: 不能为新函数分配nil")
 	}
 	g.Lock()
+	defer g.Unlock()
 	g.f = nf
-	g.Unlock()
-	g.Clear()
+	g.objs = make(map[string]interface{})
 }
 
 func (g *Group) Clear() {

--- a/container/group/reset_atomic_issue80_test.go
+++ b/container/group/reset_atomic_issue80_test.go
@@ -1,0 +1,82 @@
+package group
+
+import (
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestGroupResetIsAtomicWithConcurrentGet(t *testing.T) {
+	g := NewGroup(func() interface{} { return "old" }).(*Group)
+	if got := g.Get("key"); got != "old" {
+		t.Fatalf("initial Get() = %v, want old", got)
+	}
+
+	// Hold a reader while ReSet queues for the write lock, then queue another
+	// reader behind it. RWMutex releases that reader when ReSet unlocks, so it
+	// observes the exact state published by ReSet's critical section.
+	g.RLock()
+	resetStarted := make(chan struct{})
+	resetDone := make(chan struct{})
+	go func() {
+		close(resetStarted)
+		g.ReSet(func() interface{} { return "new" })
+		close(resetDone)
+	}()
+	<-resetStarted
+
+	deadline := time.Now().Add(time.Second)
+	for g.TryRLock() {
+		g.RUnlock()
+		if time.Now().After(deadline) {
+			g.RUnlock()
+			t.Fatal("ReSet did not queue for the group lock")
+		}
+		runtime.Gosched()
+	}
+
+	type observedState struct {
+		factoryValue interface{}
+		cachedValue  interface{}
+		cached       bool
+	}
+	observed := make(chan observedState, 1)
+	observerStarted := make(chan struct{})
+	go func() {
+		close(observerStarted)
+		g.RLock()
+		cachedValue, cached := g.objs["key"]
+		observed <- observedState{
+			factoryValue: g.f(),
+			cachedValue:  cachedValue,
+			cached:       cached,
+		}
+		g.RUnlock()
+	}()
+	<-observerStarted
+	// Give the observer an opportunity to block behind the queued writer before
+	// releasing this reader. Without that ordering it would only observe the
+	// post-ReSet state and would not exercise the publication boundary.
+	for i := 0; i < 100; i++ {
+		runtime.Gosched()
+	}
+
+	g.RUnlock()
+
+	state := <-observed
+	if state.factoryValue != "new" {
+		t.Fatalf("published factory returned %v, want new", state.factoryValue)
+	}
+	if state.cached {
+		t.Fatalf("new factory was visible with stale cache value %v", state.cachedValue)
+	}
+	select {
+	case <-resetDone:
+	case <-time.After(time.Second):
+		t.Fatal("ReSet did not return")
+	}
+
+	if got := g.Get("key"); got != "new" {
+		t.Fatalf("Get() after ReSet = %v, want new", got)
+	}
+}

--- a/container/pool/active_race_test.go
+++ b/container/pool/active_race_test.go
@@ -1,0 +1,152 @@
+package pool
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+var errActiveRaceFactory = errors.New("controlled factory failure")
+
+type activeRaceResource struct {
+	shutdowns int32
+}
+
+func (r *activeRaceResource) Shutdown() error {
+	atomic.AddInt32(&r.shutdowns, 1)
+	return nil
+}
+
+func waitForAtomicAtLeast(t *testing.T, value *int64, want int64) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if atomic.LoadInt64(value) >= want {
+			return
+		}
+		runtime.Gosched()
+	}
+	t.Fatalf("counter = %d, want at least %d", atomic.LoadInt64(value), want)
+}
+
+func updateAtomicMax(value *int64, candidate int64) {
+	for {
+		current := atomic.LoadInt64(value)
+		if candidate <= current || atomic.CompareAndSwapInt64(value, current, candidate) {
+			return
+		}
+	}
+}
+
+func TestListActiveCountConcurrentRelease(t *testing.T) {
+	const workers = 8
+
+	list := NewList(SetActive(1), SetIdle(0), SetWait(false, 0)).(*List)
+	defer func() { _ = list.Shutdown() }()
+
+	held := &activeRaceResource{}
+	failureEntered := make(chan struct{})
+	failureRelease := make(chan struct{})
+	var factoryCalls int64
+	var inFactory int64
+	var maxInFactory int64
+	list.New(func(context.Context) (IShutdown, error) {
+		call := atomic.AddInt64(&factoryCalls, 1)
+		inFlight := atomic.AddInt64(&inFactory, 1)
+		updateAtomicMax(&maxInFactory, inFlight)
+		defer atomic.AddInt64(&inFactory, -1)
+
+		if call == 1 {
+			return held, nil
+		}
+		if call == 2 {
+			close(failureEntered)
+			<-failureRelease
+		}
+		runtime.Gosched()
+		return nil, errActiveRaceFactory
+	})
+
+	resource, err := list.Get(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resource != held {
+		t.Fatalf("first resource = %p, want held resource %p", resource, held)
+	}
+
+	start := make(chan struct{})
+	ready := make(chan struct{}, workers)
+	unexpected := make(chan error, workers)
+	var attempts int64
+	var stop int32
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			ready <- struct{}{}
+			<-start
+			for atomic.LoadInt32(&stop) == 0 {
+				atomic.AddInt64(&attempts, 1)
+				got, getErr := list.Get(context.Background())
+				if got != nil {
+					unexpected <- errors.New("failing factory returned a resource")
+					return
+				}
+				if getErr != ErrPoolExhausted && !errors.Is(getErr, errActiveRaceFactory) {
+					unexpected <- getErr
+					return
+				}
+			}
+		}()
+	}
+	for i := 0; i < workers; i++ {
+		<-ready
+	}
+	close(start)
+
+	// Keep active at the configured limit while every worker repeatedly executes
+	// the capacity check, then force-close the held resource to start the
+	// controlled factory-failure/release cycle.
+	waitForAtomicAtLeast(t, &attempts, 1_000)
+	putDone := make(chan error, 1)
+	go func() {
+		putDone <- list.Put(context.Background(), held, true)
+	}()
+
+	select {
+	case <-failureEntered:
+	case <-time.After(3 * time.Second):
+		t.Fatal("factory failure did not enter")
+	}
+	beforeRelease := atomic.LoadInt64(&attempts)
+	waitForAtomicAtLeast(t, &attempts, beforeRelease+1_000)
+	close(failureRelease)
+	waitForAtomicAtLeast(t, &factoryCalls, 200)
+
+	atomic.StoreInt32(&stop, 1)
+	wg.Wait()
+	if err := <-putDone; err != nil {
+		t.Fatalf("force-close Put: %v", err)
+	}
+	select {
+	case err := <-unexpected:
+		t.Fatal(err)
+	default:
+	}
+
+	if got := atomic.LoadInt64(&maxInFactory); got > 1 {
+		t.Fatalf("concurrent factory calls = %d, active limit = 1", got)
+	}
+	if got := atomic.LoadUint64(&list.active); got != 0 {
+		t.Fatalf("active after all controlled factory failures = %d, want 0", got)
+	}
+	if got := atomic.LoadInt32(&held.shutdowns); got != 1 {
+		t.Fatalf("force-closed resource Shutdown count = %d, want 1", got)
+	}
+}

--- a/container/pool/cleaner_lifecycle_test.go
+++ b/container/pool/cleaner_lifecycle_test.go
@@ -1,0 +1,269 @@
+package pool
+
+import (
+	"context"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type cleanerLifecycleResource struct {
+	id        int64
+	started   chan struct{}
+	unblock   <-chan struct{}
+	once      sync.Once
+	shutdowns int32
+}
+
+func newCleanerLifecycleResource(id int64, unblock <-chan struct{}) *cleanerLifecycleResource {
+	return &cleanerLifecycleResource{
+		id:      id,
+		started: make(chan struct{}),
+		unblock: unblock,
+	}
+}
+
+func (r *cleanerLifecycleResource) Shutdown() error {
+	atomic.AddInt32(&r.shutdowns, 1)
+	r.once.Do(func() { close(r.started) })
+	if r.unblock != nil {
+		<-r.unblock
+	}
+	return nil
+}
+
+func cleanupCleanerLifecycleList(t *testing.T, list *List) {
+	t.Helper()
+	t.Cleanup(func() {
+		if err := list.Shutdown(); err != nil && err != ErrPoolClosed {
+			t.Errorf("cleanup Shutdown: %v", err)
+		}
+	})
+}
+
+func ageCleanerLifecycleIdle(t *testing.T, list *List, age time.Duration) {
+	t.Helper()
+	list.mu.Lock()
+	entry := list.idles.Back()
+	if entry == nil {
+		list.mu.Unlock()
+		t.Fatal("pool has no idle resource to age")
+	}
+	idle := entry.Value.(item)
+	idle.createdAt = nowFunc().Add(-age)
+	entry.Value = idle
+	list.mu.Unlock()
+}
+
+func mustGetCleanerLifecycleResource(t *testing.T, list *List) *cleanerLifecycleResource {
+	t.Helper()
+	resource, err := list.Get(context.Background())
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	return resource.(*cleanerLifecycleResource)
+}
+
+func waitForCleanerLifecycleShutdown(t *testing.T, resource *cleanerLifecycleResource) {
+	t.Helper()
+	select {
+	case <-resource.started:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("resource %d was not cleaned", resource.id)
+	}
+	if got := atomic.LoadInt32(&resource.shutdowns); got != 1 {
+		t.Fatalf("resource %d Shutdown count = %d, want 1", resource.id, got)
+	}
+}
+
+func waitForCleanerLifecycleClosed(t *testing.T, list *List) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if atomic.LoadUint32(&list.closed) == 1 {
+			return
+		}
+		runtime.Gosched()
+	}
+	t.Fatal("pool did not enter the closed state")
+}
+
+func TestListCleanerFollowsReloadedIdleTimeout(t *testing.T) {
+	list := NewList(
+		SetActive(1),
+		SetIdle(1),
+		SetIdleTimeout(0),
+		SetWait(false, 0),
+	).(*List)
+	cleanupCleanerLifecycleList(t, list)
+
+	var nextID int64
+	list.New(func(context.Context) (IShutdown, error) {
+		return newCleanerLifecycleResource(atomic.AddInt64(&nextID, 1), nil), nil
+	})
+
+	// A cleaner must remain reloadable even when it was disabled at construction.
+	first := mustGetCleanerLifecycleResource(t, list)
+	if err := list.Put(context.Background(), first, false); err != nil {
+		t.Fatal(err)
+	}
+	ageCleanerLifecycleIdle(t, list, 2*time.Hour)
+	list.Reload(SetIdleTimeout(time.Hour))
+	waitForCleanerLifecycleShutdown(t, first)
+
+	// Disabling cleanup must use the latest configuration. The watchdog only
+	// guards against an erroneous close; expiry itself is controlled by the idle
+	// timestamp, and Get proves that the same resource remains available.
+	second := mustGetCleanerLifecycleResource(t, list)
+	if err := list.Put(context.Background(), second, false); err != nil {
+		t.Fatal(err)
+	}
+	list.Reload(SetIdleTimeout(0))
+	ageCleanerLifecycleIdle(t, list, 2*time.Hour)
+	select {
+	case <-second.started:
+		t.Fatal("resource was cleaned while idle cleanup was disabled")
+	case <-time.After(2 * minDuration):
+	}
+	got := mustGetCleanerLifecycleResource(t, list)
+	if got != second {
+		t.Fatalf("Get while cleanup disabled returned resource %d, want %d", got.id, second.id)
+	}
+	if err := list.Put(context.Background(), got, false); err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-enabling cleanup must immediately apply to resources that became stale
+	// while disabled.
+	ageCleanerLifecycleIdle(t, list, 2*time.Hour)
+	list.Reload(SetIdleTimeout(time.Hour))
+	waitForCleanerLifecycleShutdown(t, second)
+
+	// A positive period change also uses the newest value: a long timeout keeps
+	// the resource, then shortening it cleans the now-expired resource.
+	third := mustGetCleanerLifecycleResource(t, list)
+	if err := list.Put(context.Background(), third, false); err != nil {
+		t.Fatal(err)
+	}
+	list.Reload(SetIdleTimeout(10 * time.Hour))
+	ageCleanerLifecycleIdle(t, list, 2*time.Hour)
+	got = mustGetCleanerLifecycleResource(t, list)
+	if got != third {
+		t.Fatalf("Get under longer timeout returned resource %d, want %d", got.id, third.id)
+	}
+	if err := list.Put(context.Background(), got, false); err != nil {
+		t.Fatal(err)
+	}
+	ageCleanerLifecycleIdle(t, list, 2*time.Hour)
+	list.Reload(SetIdleTimeout(time.Hour))
+	waitForCleanerLifecycleShutdown(t, third)
+}
+
+func TestListShutdownStopsCleanerAndWakesWaiters(t *testing.T) {
+	t.Run("waits for cleaner completion", func(t *testing.T) {
+		release := make(chan struct{})
+		var releaseOnce sync.Once
+		unblock := func() { releaseOnce.Do(func() { close(release) }) }
+
+		list := NewList(
+			SetActive(1),
+			SetIdle(1),
+			SetIdleTimeout(time.Hour),
+			SetWait(true, 0),
+		).(*List)
+		cleanupCleanerLifecycleList(t, list)
+		t.Cleanup(unblock)
+
+		resource := newCleanerLifecycleResource(1, release)
+		list.New(func(context.Context) (IShutdown, error) { return resource, nil })
+		if got := mustGetCleanerLifecycleResource(t, list); got != resource {
+			t.Fatalf("Get returned %p, want %p", got, resource)
+		}
+		if err := list.Put(context.Background(), resource, false); err != nil {
+			t.Fatal(err)
+		}
+
+		// Make the idle entry expired without waiting for wall-clock time. Init's
+		// wake then deterministically drives the cleaner into resource Shutdown.
+		ageCleanerLifecycleIdle(t, list, 2*time.Hour)
+		list.Init(time.Nanosecond)
+
+		select {
+		case <-resource.started:
+		case <-time.After(2 * time.Second):
+			t.Fatal("cleaner did not begin resource Shutdown")
+		}
+
+		shutdownResult := make(chan error, 1)
+		go func() { shutdownResult <- list.Shutdown() }()
+		waitForCleanerLifecycleClosed(t, list)
+		select {
+		case err := <-shutdownResult:
+			t.Fatalf("Shutdown returned before cleaner completed: %v", err)
+		case <-time.After(minDuration):
+		}
+
+		unblock()
+		select {
+		case err := <-shutdownResult:
+			if err != nil {
+				t.Fatalf("Shutdown: %v", err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("Shutdown did not return after cleaner completed")
+		}
+		if got := atomic.LoadInt32(&resource.shutdowns); got != 1 {
+			t.Fatalf("cleaned resource Shutdown count = %d, want 1", got)
+		}
+		if err := list.Shutdown(); err != ErrPoolClosed {
+			t.Fatalf("second Shutdown err = %v, want ErrPoolClosed", err)
+		}
+	})
+
+	t.Run("stops disabled cleaner and broadcasts close", func(t *testing.T) {
+		list := newWaitTestList(t, 1, true, 0)
+		cleanupCleanerLifecycleList(t, list)
+		held := mustGetWaitResource(t, list)
+
+		releaseSelect := make(chan struct{})
+		ctx := newWaitGateContext(context.Background(), releaseSelect)
+		result := make(chan waitGetResult, 1)
+		go func() {
+			resource, err := list.Get(ctx)
+			result <- waitGetResult{resource: resource, err: err}
+		}()
+		select {
+		case <-ctx.entered:
+		case <-time.After(time.Second):
+			t.Fatal("waiter did not reach the pre-select gate")
+		}
+
+		shutdownResult := make(chan error, 1)
+		go func() { shutdownResult <- list.Shutdown() }()
+		select {
+		case err := <-shutdownResult:
+			if err != nil {
+				t.Fatalf("Shutdown: %v", err)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("Shutdown did not stop the disabled cleaner")
+		}
+		close(releaseSelect)
+		got := awaitWaitGet(t, result)
+		if got.resource != nil || got.err != ErrPoolClosed {
+			t.Fatalf("waiting Get after Shutdown = (%v, %v), want (nil, ErrPoolClosed)", got.resource, got.err)
+		}
+
+		// Reload after shutdown must not send to a lifecycle channel that was
+		// closed as part of stopping the cleaner.
+		list.Reload(SetIdleTimeout(time.Second))
+		if err := list.Shutdown(); err != ErrPoolClosed {
+			t.Fatalf("second Shutdown err = %v, want ErrPoolClosed", err)
+		}
+		if err := list.Put(context.Background(), held, true); err != nil {
+			t.Fatal(err)
+		}
+	})
+}

--- a/container/pool/list.go
+++ b/container/pool/list.go
@@ -21,11 +21,23 @@ type List struct {
 	// mu: 互斥锁, 保护以下字段
 	mu sync.Mutex
 
-	// cond: 发送信号,通知有回收动作,在等待的可以再次尝试获取资源
-	cond chan struct{}
+	// generation is closed and replaced under mu whenever pool state changes
+	// may allow a waiter to make progress.
+	generation chan struct{}
 
-	// cleanerCh: 清空 ch
-	cleanerCh chan struct{}
+	// cleanerWake resets the cleaner after an idle timeout reload. It remains
+	// open for the lifetime of List so Reload cannot send to a closed channel.
+	cleanerWake chan struct{}
+
+	// cleanerStop is closed exactly once by the first successful Shutdown.
+	cleanerStop chan struct{}
+
+	// cleanerDone is closed after the single cleaner goroutine has stopped.
+	cleanerDone chan struct{}
+
+	// cleanerOnce prevents duplicate cleaner goroutines if Timer is called by
+	// code outside NewList.
+	cleanerOnce sync.Once
 
 	// active: 最大连接数
 	active uint64
@@ -44,93 +56,138 @@ type List struct {
 func (l *List) Reload(options ...options.Option) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
+	previousIdleTimeout := l.conf.idleTimeout
 	for _, option := range options {
 		option(l.conf)
+	}
+	l.notifyLocked()
+	if l.conf.idleTimeout != previousIdleTimeout {
+		l.wakeCleaner()
 	}
 }
 
 // Init 初始化
 func (l *List) Init(d time.Duration) {
-	// 如果 <= 0 放弃设置
 	if d <= 0 {
 		return
 	}
-	// 如果时间间隔d小于等待超时,并且 cleanerCh 不为nil 监听信号
-	if d < l.conf.idleTimeout && l.cleanerCh != nil {
-		select {
-		// 发送立即清除旧配置的信号,如果阻塞说明在时间周期内进行清洁,跳过
-		case l.cleanerCh <- struct{}{}:
-		default:
-		}
-	}
-	// 懒加载
-	if l.cleanerCh == nil {
-		l.cleanerCh = make(chan struct{}, 1)
-		// 开启定时任务
-		go l.Timer(l.conf.idleTimeout)
+	l.wakeCleaner()
+}
+
+// wakeCleaner requests an immediate cleaner pass and timer reset. The channel
+// is buffered so Reload never waits for the cleaner, and it is intentionally
+// never closed so calls racing with or following Shutdown remain safe.
+func (l *List) wakeCleaner() {
+	select {
+	case l.cleanerWake <- struct{}{}:
+	default:
 	}
 }
 
 // Timer 定时任务
-func (l *List) Timer(d time.Duration) {
-	if d < minDuration {
-		d = minDuration
-	}
-	// ticker: 定时任务
-	ticker := time.NewTicker(d)
+func (l *List) Timer(_ time.Duration) {
+	l.cleanerOnce.Do(l.runCleaner)
+}
+
+func (l *List) runCleaner() {
+	defer close(l.cleanerDone)
+
+	timer := time.NewTimer(time.Hour)
+	stopAndDrainTimer(timer)
+	defer stopAndDrainTimer(timer)
+
 	for {
-		select {
-		// 触发条件:
-		// 1. 定时周期
-		// 2. l.cleanerCh 接收到信号
-		case <-ticker.C:
-		case <-l.cleanerCh:
-		}
 		l.mu.Lock()
-		// 是否关闭 或者 没有设置超时时间
-		if atomic.LoadUint32(&l.closed) == 1 || l.conf.idleTimeout <= 0 {
-			l.mu.Unlock()
+		idleTimeout := l.conf.idleTimeout
+		l.mu.Unlock()
+
+		var timerC <-chan time.Time
+		if idleTimeout > 0 {
+			if idleTimeout < minDuration {
+				idleTimeout = minDuration
+			}
+			stopAndDrainTimer(timer)
+			timer.Reset(idleTimeout)
+			timerC = timer.C
+		} else {
+			stopAndDrainTimer(timer)
+		}
+
+		select {
+		case <-timerC:
+		case <-l.cleanerWake:
+		case <-l.cleanerStop:
 			return
 		}
-		// 循环链表
-		for i, n := 0, l.idles.Len(); i < n; i++ {
-			// idles.Back() 返回链表中最后一个元素, 如果当前链表已经是空了 则返回nil
-			e := l.idles.Back()
-			if e == nil {
-				break
-			}
-			// 断言为 item
-			ic := e.Value.(item)
-			// 判断时间是否超时
-			if !ic.expire(l.conf.idleTimeout) {
-				break
-			}
-			// 如果已经超时,则删除此元素
-			l.idles.Remove(e)
-			// release 计数
-			l.release()
-			l.mu.Unlock()
-			_ = ic.s.Shutdown()
-			l.mu.Lock()
-		}
-		l.mu.Unlock()
+
+		l.cleanExpired()
 	}
 }
 
-// release 当前活跃线程数-1 并发送信号通知
-// hold p.mu during the call.
-func (l *List) release() {
+func stopAndDrainTimer(timer *time.Timer) {
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+}
+
+// cleanExpired removes every expired idle from the live list while holding mu,
+// then shuts the detached resources down off-lock. Shutdown can therefore
+// snapshot only the remaining idles and each resource is closed exactly once.
+func (l *List) cleanExpired() {
+	l.mu.Lock()
+	if atomic.LoadUint32(&l.closed) == 1 || l.conf.idleTimeout <= 0 {
+		l.mu.Unlock()
+		return
+	}
+
+	idleTimeout := l.conf.idleTimeout
+	shutdowns := make([]IShutdown, 0)
+	for {
+		e := l.idles.Back()
+		if e == nil {
+			break
+		}
+		idle := e.Value.(item)
+		if !idle.expire(idleTimeout) {
+			break
+		}
+		l.idles.Remove(e)
+		shutdowns = append(shutdowns, idle.s)
+	}
+	if len(shutdowns) > 0 {
+		atomic.AddUint64(&l.active, ^uint64(len(shutdowns)-1))
+		l.notifyLocked()
+	}
+	l.mu.Unlock()
+
+	for _, shutdown := range shutdowns {
+		_ = shutdown.Shutdown()
+	}
+}
+
+// releaseLocked atomically decrements the active count and broadcasts a state
+// change. The caller must hold l.mu.
+func (l *List) releaseLocked() {
 	// l.active -= 1
 	atomic.AddUint64(&l.active, ^uint64(0))
-	l.signal()
+	l.notifyLocked()
 }
 
-// signal 发送信号通知
-func (l *List) signal() {
-	select {
-	case l.cond <- struct{}{}:
-	default:
-	}
+// releaseUnlocked is the release path for callers that do not hold l.mu.
+func (l *List) releaseUnlocked() {
+	l.mu.Lock()
+	l.releaseLocked()
+	l.mu.Unlock()
+}
+
+// notifyLocked broadcasts a state change without losing notifications that
+// happen before a waiter starts selecting. The caller must hold l.mu.
+func (l *List) notifyLocked() {
+	close(l.generation)
+	l.generation = make(chan struct{})
 }
 
 // Get 获取
@@ -149,15 +206,16 @@ func (l *List) Get(ctx context.Context) (IShutdown, error) {
 			}
 			ic := e.Value.(item)
 			l.idles.Remove(e)
+			idleTimeout := l.conf.idleTimeout
 			l.mu.Unlock()
 			// 没有过期的可以直接返回了
-			if !ic.expire(l.conf.idleTimeout) {
+			if !ic.expire(idleTimeout) {
 				return ic.s, nil
 			}
 			// 清理 重新获取锁
 			_ = ic.s.Shutdown()
 			l.mu.Lock()
-			l.release()
+			l.releaseLocked()
 		}
 
 		// 检查是否关闭
@@ -166,7 +224,7 @@ func (l *List) Get(ctx context.Context) (IShutdown, error) {
 			return nil, ErrPoolClosed
 		}
 		// 判断是否需要新增
-		if l.conf.active == 0 || l.active < l.conf.active {
+		if l.conf.active == 0 || atomic.LoadUint64(&l.active) < l.conf.active {
 			if l.f == nil {
 				l.mu.Unlock()
 				return nil, ErrPoolNewFuncIsNull
@@ -181,7 +239,7 @@ func (l *List) Get(ctx context.Context) (IShutdown, error) {
 			l.mu.Unlock()
 			c, err := newItem(ctx)
 			if err != nil {
-				l.release()
+				l.releaseUnlocked()
 				c = nil
 			}
 			return c, err
@@ -191,22 +249,32 @@ func (l *List) Get(ctx context.Context) (IShutdown, error) {
 			l.mu.Unlock()
 			return nil, ErrPoolExhausted
 		}
-		// 获取超时时间,解锁进入等待状态
+		// Capture the current generation while holding mu. A state change that
+		// happens after unlock closes this channel, even if select has not begun.
+		generation := l.generation
+		wait := l.conf.wait
 		wt := l.conf.waitTimeout
 		l.mu.Unlock()
 
-		// 控制链路超时时间
-		_, nCtx, cancel := timeout.Shrink(ctx, wt)
-
-		// 超时/收到了某应用回收的信号
-		select {
-		case <-nCtx.Done():
-			cancel()
-			return nil, nCtx.Err()
-		case <-l.cond:
+		if wait && wt == 0 {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-generation:
+			}
+		} else {
+			// 控制链路超时时间
+			_, nCtx, cancel := timeout.Shrink(ctx, wt)
+			select {
+			case <-nCtx.Done():
+				err := nCtx.Err()
+				cancel()
+				return nil, err
+			case <-generation:
+				cancel()
+			}
 		}
 		// 自旋,再次尝试获得句柄
-		cancel()
 		l.mu.Lock()
 	}
 }
@@ -227,12 +295,12 @@ func (l *List) Put(ctx context.Context, s IShutdown, forceClose bool) error {
 	}
 	// 如果 s == nil 进入回收
 	if s == nil {
-		l.signal()
+		l.notifyLocked()
 		l.mu.Unlock()
 		return nil
 	}
+	l.releaseLocked()
 	l.mu.Unlock()
-	l.release()
 	return s.Shutdown()
 }
 
@@ -243,6 +311,7 @@ func (l *List) Shutdown() error {
 		l.mu.Unlock()
 		return ErrPoolClosed
 	}
+	close(l.cleanerStop)
 	// container/list.List does not support copy-by-value: a copy of the
 	// sentinel root carries pointers back to elements whose `list` field
 	// still references the original. Snapshot the IShutdowns into a slice
@@ -256,10 +325,12 @@ func (l *List) Shutdown() error {
 		atomic.AddUint64(&l.active, ^uint64(len(shutdowns)-1))
 	}
 	l.idles.Init()
+	l.notifyLocked()
 	l.mu.Unlock()
 	for _, s := range shutdowns {
 		_ = s.Shutdown()
 	}
+	<-l.cleanerDone
 	return nil
 }
 
@@ -272,11 +343,18 @@ func (l *List) New(f func(ctx context.Context) (IShutdown, error)) {
 
 // NewList 实例化
 func NewList(options ...options.Option) Pool {
-	l := &List{conf: defaultConfig()}
-	l.cond = make(chan struct{})
+	l := &List{
+		conf:        defaultConfig(),
+		generation:  make(chan struct{}),
+		cleanerWake: make(chan struct{}, 1),
+		cleanerStop: make(chan struct{}),
+		cleanerDone: make(chan struct{}),
+	}
 	for _, option := range options {
 		option(l.conf)
 	}
-	l.Init(l.conf.idleTimeout)
+	// The cleaner exists even when cleanup starts disabled so a later Reload can
+	// enable it without spawning a second goroutine.
+	go l.Timer(l.conf.idleTimeout)
 	return l
 }

--- a/container/pool/wait_generation_test.go
+++ b/container/pool/wait_generation_test.go
@@ -1,0 +1,267 @@
+package pool
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type waitGateContext struct {
+	context.Context
+	entered chan struct{}
+	release <-chan struct{}
+	once    sync.Once
+}
+
+func newWaitGateContext(parent context.Context, release <-chan struct{}) *waitGateContext {
+	return &waitGateContext{
+		Context: parent,
+		entered: make(chan struct{}),
+		release: release,
+	}
+}
+
+func (c *waitGateContext) enter() {
+	c.once.Do(func() { close(c.entered) })
+	<-c.release
+}
+
+func (c *waitGateContext) Deadline() (time.Time, bool) {
+	c.enter()
+	return c.Context.Deadline()
+}
+
+func (c *waitGateContext) Done() <-chan struct{} {
+	c.enter()
+	return c.Context.Done()
+}
+
+type waitTestResource struct {
+	id        int64
+	shutdowns int32
+}
+
+func (r *waitTestResource) Shutdown() error {
+	atomic.AddInt32(&r.shutdowns, 1)
+	return nil
+}
+
+type waitGetResult struct {
+	resource IShutdown
+	err      error
+}
+
+func newWaitTestList(t *testing.T, active uint64, wait bool, waitTimeout time.Duration) *List {
+	t.Helper()
+	list := NewList(
+		SetActive(active),
+		SetIdle(active),
+		SetIdleTimeout(0),
+		SetWait(wait, waitTimeout),
+	).(*List)
+	var id int64
+	list.New(func(context.Context) (IShutdown, error) {
+		return &waitTestResource{id: atomic.AddInt64(&id, 1)}, nil
+	})
+	return list
+}
+
+func mustGetWaitResource(t *testing.T, list *List) IShutdown {
+	t.Helper()
+	resource, err := list.Get(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resource
+}
+
+func awaitWaitGet(t *testing.T, result <-chan waitGetResult) waitGetResult {
+	t.Helper()
+	select {
+	case got := <-result:
+		return got
+	case <-time.After(2 * time.Second):
+		t.Fatal("Get did not return")
+		return waitGetResult{}
+	}
+}
+
+func TestListWaitBroadcastCannotBeLost(t *testing.T) {
+	t.Run("resources returned before select", func(t *testing.T) {
+		list := newWaitTestList(t, 2, true, 500*time.Millisecond)
+		defer func() { _ = list.Shutdown() }()
+		held := []IShutdown{mustGetWaitResource(t, list), mustGetWaitResource(t, list)}
+
+		releaseSelect := make(chan struct{})
+		contexts := []*waitGateContext{
+			newWaitGateContext(context.Background(), releaseSelect),
+			newWaitGateContext(context.Background(), releaseSelect),
+		}
+		results := make(chan waitGetResult, len(contexts))
+		for _, ctx := range contexts {
+			go func(ctx context.Context) {
+				resource, err := list.Get(ctx)
+				results <- waitGetResult{resource: resource, err: err}
+			}(ctx)
+		}
+		for _, ctx := range contexts {
+			select {
+			case <-ctx.entered:
+			case <-time.After(time.Second):
+				t.Fatal("waiter did not reach the pre-select gate")
+			}
+		}
+
+		// Both waiters have passed the locked state check and are stopped before
+		// select. Returning both resources now proves that a prior notification is
+		// retained and broadcast rather than coalesced or dropped.
+		for _, resource := range held {
+			if err := list.Put(context.Background(), resource, false); err != nil {
+				t.Fatal(err)
+			}
+		}
+		close(releaseSelect)
+
+		seen := make(map[IShutdown]bool, len(held))
+		for range contexts {
+			got := awaitWaitGet(t, results)
+			if got.err != nil {
+				t.Fatalf("waiting Get: %v", got.err)
+			}
+			seen[got.resource] = true
+			if err := list.Put(context.Background(), got.resource, true); err != nil {
+				t.Fatal(err)
+			}
+		}
+		for _, resource := range held {
+			if !seen[resource] {
+				t.Fatalf("returned resource %p was not received by a waiter", resource)
+			}
+		}
+	})
+
+	t.Run("shutdown broadcast", func(t *testing.T) {
+		list := newWaitTestList(t, 1, true, 500*time.Millisecond)
+		held := mustGetWaitResource(t, list)
+		releaseSelect := make(chan struct{})
+		ctx := newWaitGateContext(context.Background(), releaseSelect)
+		result := make(chan waitGetResult, 1)
+		go func() {
+			resource, err := list.Get(ctx)
+			result <- waitGetResult{resource: resource, err: err}
+		}()
+		select {
+		case <-ctx.entered:
+		case <-time.After(time.Second):
+			t.Fatal("waiter did not reach the pre-select gate")
+		}
+
+		if err := list.Shutdown(); err != nil {
+			t.Fatal(err)
+		}
+		close(releaseSelect)
+		got := awaitWaitGet(t, result)
+		if got.resource != nil || got.err != ErrPoolClosed {
+			t.Fatalf("Get after Shutdown = (%v, %v), want (nil, ErrPoolClosed)", got.resource, got.err)
+		}
+		if err := list.Put(context.Background(), held, true); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestListWaitWithoutPoolTimeoutUsesCallerContext(t *testing.T) {
+	t.Run("resource return", func(t *testing.T) {
+		list := newWaitTestList(t, 1, true, 0)
+		defer func() { _ = list.Shutdown() }()
+		held := mustGetWaitResource(t, list)
+		releaseSelect := make(chan struct{})
+		ctx := newWaitGateContext(context.Background(), releaseSelect)
+		result := make(chan waitGetResult, 1)
+		go func() {
+			resource, err := list.Get(ctx)
+			result <- waitGetResult{resource: resource, err: err}
+		}()
+		select {
+		case <-ctx.entered:
+		case <-time.After(time.Second):
+			t.Fatal("waiter did not reach the pre-select gate")
+		}
+
+		if err := list.Put(context.Background(), held, false); err != nil {
+			t.Fatal(err)
+		}
+		close(releaseSelect)
+		got := awaitWaitGet(t, result)
+		if got.err != nil || got.resource != held {
+			t.Fatalf("Get after Put = (%v, %v), want held resource", got.resource, got.err)
+		}
+		if err := list.Put(context.Background(), got.resource, true); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("caller cancellation", func(t *testing.T) {
+		list := newWaitTestList(t, 1, true, 0)
+		defer func() { _ = list.Shutdown() }()
+		held := mustGetWaitResource(t, list)
+		base, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		releaseSelect := make(chan struct{})
+		ctx := newWaitGateContext(base, releaseSelect)
+		result := make(chan waitGetResult, 1)
+		go func() {
+			resource, err := list.Get(ctx)
+			result <- waitGetResult{resource: resource, err: err}
+		}()
+		select {
+		case <-ctx.entered:
+		case <-time.After(time.Second):
+			t.Fatal("waiter did not reach the pre-select gate")
+		}
+		close(releaseSelect)
+
+		select {
+		case got := <-result:
+			t.Fatalf("Get returned before caller cancellation: (%v, %v)", got.resource, got.err)
+		case <-time.After(50 * time.Millisecond):
+		}
+		cancel()
+		got := awaitWaitGet(t, result)
+		if got.resource != nil || !errors.Is(got.err, context.Canceled) {
+			t.Fatalf("Get after caller cancel = (%v, %v), want (nil, context.Canceled)", got.resource, got.err)
+		}
+		if err := list.Put(context.Background(), held, true); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("wait false zero remains exhausted", func(t *testing.T) {
+		list := newWaitTestList(t, 1, false, 0)
+		defer func() { _ = list.Shutdown() }()
+		held := mustGetWaitResource(t, list)
+		resource, err := list.Get(context.Background())
+		if resource != nil || err != ErrPoolExhausted {
+			t.Fatalf("Get exhausted = (%v, %v), want (nil, ErrPoolExhausted)", resource, err)
+		}
+		if err := list.Put(context.Background(), held, true); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("positive timeout remains bounded", func(t *testing.T) {
+		list := newWaitTestList(t, 1, false, 30*time.Millisecond)
+		defer func() { _ = list.Shutdown() }()
+		held := mustGetWaitResource(t, list)
+		resource, err := list.Get(context.Background())
+		if resource != nil || !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("Get after positive pool timeout = (%v, %v), want deadline exceeded", resource, err)
+		}
+		if err := list.Put(context.Background(), held, true); err != nil {
+			t.Fatal(err)
+		}
+	})
+}

--- a/container/queue/codel/decision_issue80_test.go
+++ b/container/queue/codel/decision_issue80_test.go
@@ -1,0 +1,148 @@
+package codel
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+type pushGateContext struct {
+	entered chan struct{}
+	release chan struct{}
+	done    chan struct{}
+	once    sync.Once
+}
+
+func newPushGateContext() *pushGateContext {
+	return &pushGateContext{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+		done:    make(chan struct{}),
+	}
+}
+
+func (*pushGateContext) Deadline() (time.Time, bool) { return time.Time{}, false }
+
+func (c *pushGateContext) Done() <-chan struct{} {
+	c.once.Do(func() { close(c.entered) })
+	<-c.release
+	return c.done
+}
+
+func (c *pushGateContext) Err() error {
+	select {
+	case <-c.done:
+		return context.Canceled
+	default:
+		return nil
+	}
+}
+
+func (*pushGateContext) Value(interface{}) interface{} { return nil }
+
+func TestQueueDecisionBufferedBeforePushWaits(t *testing.T) {
+	q := NewQueue(SetTarget(1<<60), SetInternal(1<<60))
+	ctx := newPushGateContext()
+	result := make(chan error, 1)
+	go func() { result <- q.Push(ctx) }()
+
+	select {
+	case <-ctx.entered:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("Push did not enqueue and reach the pre-select gate")
+	}
+
+	popWithWatchdog(t, q)
+	close(ctx.release)
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("Push returned %v, want the buffered allow decision", err)
+		}
+	case <-time.After(250 * time.Millisecond):
+		close(ctx.done)
+		<-result
+		t.Fatal("Pop lost its decision before Push began receiving")
+	}
+}
+
+func TestQueueCanceledPushDoesNotBlockOrCrossWire(t *testing.T) {
+	previousProcs := runtime.GOMAXPROCS(1)
+	defer runtime.GOMAXPROCS(previousProcs)
+
+	q := NewQueue(SetTarget(1<<60), SetInternal(1<<60))
+	firstCtx, cancelFirst := context.WithCancel(context.Background())
+	firstResult := make(chan error, 1)
+	go func() { firstResult <- q.Push(firstCtx) }()
+	firstPacket := takePacket(t, q)
+	q.packets <- firstPacket
+	cancelFirst()
+	if err := awaitPushResult(t, firstResult); !errors.Is(err, context.Canceled) {
+		t.Fatalf("first Push error = %v, want context.Canceled", err)
+	}
+
+	// The first Push is gone before Pop decides. Its one-shot buffered channel
+	// must absorb the decision without blocking and must never be reused.
+	popWithWatchdog(t, q)
+
+	secondCtx, cancelSecond := context.WithCancel(context.Background())
+	defer cancelSecond()
+	secondResult := make(chan error, 1)
+	go func() { secondResult <- q.Push(secondCtx) }()
+	secondPacket := takePacket(t, q)
+	if secondPacket.ch == firstPacket.ch || cap(secondPacket.ch) != 1 {
+		cancelSecond()
+		_ = awaitPushResult(t, secondResult)
+		t.Fatalf(
+			"second Push decision channel = %p (cap=%d), first = %p; want independent buffered channels",
+			secondPacket.ch,
+			cap(secondPacket.ch),
+			firstPacket.ch,
+		)
+	}
+
+	q.packets <- secondPacket
+	popWithWatchdog(t, q)
+	if err := awaitPushResult(t, secondResult); err != nil {
+		t.Fatalf("second Push received another request's decision: %v", err)
+	}
+}
+
+func takePacket(t *testing.T, q *Queue) packet {
+	t.Helper()
+	select {
+	case p := <-q.packets:
+		return p
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("Push did not enqueue a packet")
+		return packet{}
+	}
+}
+
+func popWithWatchdog(t *testing.T, q *Queue) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		q.Pop()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("Pop blocked while handing off a decision")
+	}
+}
+
+func awaitPushResult(t *testing.T, result <-chan error) error {
+	t.Helper()
+	select {
+	case err := <-result:
+		return err
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("Push did not return")
+		return nil
+	}
+}

--- a/container/queue/codel/queue.go
+++ b/container/queue/codel/queue.go
@@ -42,7 +42,6 @@ type Queue struct {
 	// dropping: 是否处于降级状态
 	dropping bool
 
-	pool    sync.Pool
 	packets chan packet
 
 	mux      sync.RWMutex
@@ -78,15 +77,14 @@ func (q *Queue) Stat() Stat {
 // 如果返回错误为nil，则在完成请求处理后，调用方必须调用q.Done()
 func (q *Queue) Push(ctx context.Context) (err error) {
 	r := packet{
-		ch: q.pool.Get().(chan bool),
+		ch: make(chan bool, 1),
 		ts: time.Now().UnixNano() / int64(time.Millisecond),
 	}
 	select {
 	case q.packets <- r:
 	default:
-		// 如果缓冲区阻塞,直接将 err 赋值,并且将资源放回pool中
+		// 如果缓冲区阻塞,直接将 err 赋值
 		err = bbr.LimitExceed
-		q.pool.Put(r.ch)
 	}
 	// 判断是否发送到缓冲区
 	if err == nil {
@@ -96,7 +94,6 @@ func (q *Queue) Push(ctx context.Context) (err error) {
 			if drop {
 				err = bbr.LimitExceed
 			}
-			q.pool.Put(r.ch)
 		case <-ctx.Done():
 			err = ctx.Err()
 		}
@@ -110,13 +107,9 @@ func (q *Queue) Pop() {
 		select {
 		case p := <-q.packets:
 			drop := q.judge(p)
-			select {
-			case p.ch <- drop:
-				if !drop {
-					return
-				}
-			default:
-				q.pool.Put(p.ch)
+			p.ch <- drop
+			if !drop {
+				return
 			}
 		default:
 			return
@@ -212,9 +205,6 @@ func NewQueue(options ...options.Option) *Queue {
 	}
 	for _, option := range options {
 		option(q.conf)
-	}
-	q.pool.New = func() interface{} {
-		return make(chan bool)
 	}
 	return q
 }

--- a/egroup/errgroup.go
+++ b/egroup/errgroup.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"sync"
-	"sync/atomic"
 
 	"github.com/songzhibin97/gkit/options"
 
@@ -12,13 +11,14 @@ import (
 )
 
 type Group struct {
-	ctx    context.Context
-	cancel func()
-	wg     sync.WaitGroup
+	ctx     context.Context
+	cancel  func()
+	wg      sync.WaitGroup
+	stateMu sync.Mutex
+	closed  bool
 	sync.Once
 	goroutine goroutine.GGroup
 	err       error
-	close     int32
 }
 
 func WithContextGroup(ctx context.Context, group goroutine.GGroup) *Group {
@@ -41,7 +41,10 @@ var ErrGroupClosed = errors.New("group has closed")
 
 // Wait 等待
 func (g *Group) Wait() error {
-	if atomic.LoadInt32(&g.close) != 0 {
+	g.stateMu.Lock()
+	closed := g.closed
+	g.stateMu.Unlock()
+	if closed {
 		return ErrGroupClosed
 	}
 
@@ -53,35 +56,51 @@ func (g *Group) Wait() error {
 }
 
 func (g *Group) Shutdown() error {
-	if !atomic.CompareAndSwapInt32(&g.close, 0, 1) {
+	g.stateMu.Lock()
+	if g.closed {
+		g.stateMu.Unlock()
 		return nil
 	}
-	g.wg.Wait()
+	g.closed = true
 	if g.cancel != nil {
 		g.cancel()
 	}
+	g.stateMu.Unlock()
+
+	g.wg.Wait()
 	return g.goroutine.Shutdown()
 }
 
 // Go 异步调用
 func (g *Group) Go(f func() error) {
-	if atomic.LoadInt32(&g.close) != 0 {
+	g.stateMu.Lock()
+	if g.closed {
+		g.stateMu.Unlock()
 		return
 	}
 	g.wg.Add(1)
-	ok := g.goroutine.AddTask(func() {
+	g.stateMu.Unlock()
+
+	ok := g.goroutine.AddTaskN(g.ctx, func() {
 		defer g.wg.Done()
 		if err := f(); err != nil {
-			g.Do(func() {
-				// 级联取消
-				g.err = err
-				if g.cancel != nil {
-					g.cancel()
-				}
-			})
+			g.recordError(err)
 		}
 	})
 	if !ok {
+		g.recordError(ErrGroupClosed)
 		g.wg.Done()
 	}
+}
+
+func (g *Group) recordError(err error) {
+	if err == nil {
+		return
+	}
+	g.Do(func() {
+		g.err = err
+		if g.cancel != nil {
+			g.cancel()
+		}
+	})
 }

--- a/egroup/lifecycle_issue80_test.go
+++ b/egroup/lifecycle_issue80_test.go
@@ -1,0 +1,485 @@
+package egroup
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type issue80AsyncGroup struct {
+	mu               sync.Mutex
+	closed           bool
+	addCalls         int
+	addAfterShutdown int
+	shutdownCalls    int
+}
+
+func (g *issue80AsyncGroup) ChangeMax(int64) {}
+
+func (g *issue80AsyncGroup) AddTask(f func()) bool {
+	g.mu.Lock()
+	if g.closed {
+		g.addAfterShutdown++
+		g.mu.Unlock()
+		return false
+	}
+	g.addCalls++
+	g.mu.Unlock()
+
+	go f()
+	return true
+}
+
+func (g *issue80AsyncGroup) AddTaskN(ctx context.Context, f func()) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	default:
+		return g.AddTask(f)
+	}
+}
+
+func (g *issue80AsyncGroup) Shutdown() error {
+	g.mu.Lock()
+	g.closed = true
+	g.shutdownCalls++
+	g.mu.Unlock()
+	return nil
+}
+
+func (*issue80AsyncGroup) Trick() string { return "" }
+
+func (g *issue80AsyncGroup) counts() (addCalls, addAfterShutdown, shutdownCalls int) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.addCalls, g.addAfterShutdown, g.shutdownCalls
+}
+
+type issue80RejectGroup struct {
+	addCalls atomic.Int32
+}
+
+func (*issue80RejectGroup) ChangeMax(int64) {}
+
+func (g *issue80RejectGroup) AddTask(func()) bool {
+	g.addCalls.Add(1)
+	return false
+}
+
+func (g *issue80RejectGroup) AddTaskN(context.Context, func()) bool {
+	g.addCalls.Add(1)
+	return false
+}
+
+func (*issue80RejectGroup) Shutdown() error { return nil }
+func (*issue80RejectGroup) Trick() string   { return "" }
+
+type issue80CancelRejectGroup struct {
+	ctx     context.Context
+	started chan struct{}
+	once    sync.Once
+}
+
+func (*issue80CancelRejectGroup) ChangeMax(int64) {}
+
+func (g *issue80CancelRejectGroup) AddTask(func()) bool {
+	g.once.Do(func() { close(g.started) })
+	<-g.ctx.Done()
+	return false
+}
+
+func (g *issue80CancelRejectGroup) AddTaskN(context.Context, func()) bool {
+	return g.AddTask(nil)
+}
+
+func (*issue80CancelRejectGroup) Shutdown() error { return nil }
+func (*issue80CancelRejectGroup) Trick() string   { return "" }
+
+type issue80ContextAwareBlockingGroup struct {
+	started       chan struct{}
+	legacyRelease chan struct{}
+	startOnce     sync.Once
+	releaseOnce   sync.Once
+}
+
+func (*issue80ContextAwareBlockingGroup) ChangeMax(int64) {}
+
+func (g *issue80ContextAwareBlockingGroup) markStarted() {
+	g.startOnce.Do(func() { close(g.started) })
+}
+
+func (g *issue80ContextAwareBlockingGroup) AddTask(func()) bool {
+	g.markStarted()
+	<-g.legacyRelease
+	return false
+}
+
+func (g *issue80ContextAwareBlockingGroup) AddTaskN(ctx context.Context, _ func()) bool {
+	g.markStarted()
+	<-ctx.Done()
+	return false
+}
+
+func (*issue80ContextAwareBlockingGroup) Shutdown() error { return nil }
+func (*issue80ContextAwareBlockingGroup) Trick() string   { return "" }
+
+func (g *issue80ContextAwareBlockingGroup) releaseLegacyAdd() {
+	g.releaseOnce.Do(func() { close(g.legacyRelease) })
+}
+
+func newIssue80LifeAdmin(stop time.Duration) *LifeAdmin {
+	ctx, cancel := context.WithCancel(context.Background())
+	g := WithContextGroup(ctx, &issue80AsyncGroup{})
+	return &LifeAdmin{
+		opts: &config{
+			startTimeout: -1,
+			stopTimeout:  stop,
+		},
+		shutdown: cancel,
+		g:        g,
+	}
+}
+
+type issue80ShutdownObservation struct {
+	err      error
+	deadline time.Time
+	hasLimit bool
+}
+
+func TestLifeAdminShutdownUsesFreshBoundedContext(t *testing.T) {
+	t.Run("waits for callback completion", func(t *testing.T) {
+		const stop = 2 * time.Second
+		admin := newIssue80LifeAdmin(stop)
+
+		startReady := make(chan struct{})
+		startStopped := make(chan struct{})
+		shutdownEntered := make(chan issue80ShutdownObservation, 1)
+		shutdownFinished := make(chan struct{})
+		releaseShutdown := make(chan struct{})
+		var releaseOnce sync.Once
+		release := func() { releaseOnce.Do(func() { close(releaseShutdown) }) }
+		defer release()
+
+		admin.Add(Member{
+			Start: func(ctx context.Context) error {
+				close(startReady)
+				<-ctx.Done()
+				close(startStopped)
+				return nil
+			},
+			Shutdown: func(ctx context.Context) error {
+				deadline, ok := ctx.Deadline()
+				shutdownEntered <- issue80ShutdownObservation{
+					err:      ctx.Err(),
+					deadline: deadline,
+					hasLimit: ok,
+				}
+				<-releaseShutdown
+				close(shutdownFinished)
+				return nil
+			},
+		})
+
+		startDone := make(chan error, 1)
+		go func() { startDone <- admin.Start() }()
+		waitIssue80Signal(t, startReady, "member start")
+
+		admin.Shutdown()
+		observation := waitIssue80Value(t, shutdownEntered, "member shutdown")
+		assertIssue80FreshBoundedContext(t, observation, stop)
+		waitIssue80Signal(t, startStopped, "member start cancellation")
+
+		select {
+		case err := <-startDone:
+			t.Fatalf("Start returned before shutdown callback completed: %v", err)
+		case <-time.After(50 * time.Millisecond):
+		}
+
+		release()
+		select {
+		case err := <-startDone:
+			if err != nil && !errors.Is(err, context.Canceled) {
+				t.Fatalf("Start error = %v, want nil or context cancellation", err)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("Start did not return after shutdown callback completed")
+		}
+		waitIssue80Signal(t, shutdownFinished, "shutdown callback completion")
+	})
+
+	t.Run("waits until stop timeout", func(t *testing.T) {
+		const stop = 120 * time.Millisecond
+		admin := newIssue80LifeAdmin(stop)
+
+		startReady := make(chan struct{})
+		shutdownEntered := make(chan issue80ShutdownObservation, 1)
+		shutdownTimedOut := make(chan struct{})
+		admin.Add(Member{
+			Start: func(ctx context.Context) error {
+				close(startReady)
+				<-ctx.Done()
+				return nil
+			},
+			Shutdown: func(ctx context.Context) error {
+				deadline, ok := ctx.Deadline()
+				shutdownEntered <- issue80ShutdownObservation{
+					err:      ctx.Err(),
+					deadline: deadline,
+					hasLimit: ok,
+				}
+				<-ctx.Done()
+				close(shutdownTimedOut)
+				return ctx.Err()
+			},
+		})
+
+		startDone := make(chan error, 1)
+		go func() { startDone <- admin.Start() }()
+		waitIssue80Signal(t, startReady, "member start")
+
+		startedAt := time.Now()
+		admin.Shutdown()
+		observation := waitIssue80Value(t, shutdownEntered, "member shutdown")
+		assertIssue80FreshBoundedContext(t, observation, stop)
+
+		select {
+		case <-startDone:
+			elapsed := time.Since(startedAt)
+			if elapsed < stop/2 {
+				t.Fatalf("Start returned after %v, before stop timeout %v", elapsed, stop)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("Start did not return after stop timeout")
+		}
+		waitIssue80Signal(t, shutdownTimedOut, "shutdown context timeout")
+	})
+}
+
+func TestGroupShutdownCancelsBeforeWaiting(t *testing.T) {
+	backend := &issue80AsyncGroup{}
+	g := WithContextGroup(context.Background(), backend)
+	taskStarted := make(chan struct{})
+	taskCanceled := make(chan struct{})
+	g.Go(func() error {
+		close(taskStarted)
+		<-g.ctx.Done()
+		close(taskCanceled)
+		return nil
+	})
+	waitIssue80Signal(t, taskStarted, "group task")
+
+	shutdownDone := make(chan error, 1)
+	go func() { shutdownDone <- g.Shutdown() }()
+
+	select {
+	case <-taskCanceled:
+	case <-time.After(500 * time.Millisecond):
+		g.cancel()
+		<-shutdownDone
+		t.Fatal("Shutdown waited for task before canceling group context")
+	}
+
+	select {
+	case err := <-shutdownDone:
+		if err != nil {
+			t.Fatalf("Shutdown error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Shutdown did not return after the canceled task exited")
+	}
+
+	if err := g.Shutdown(); err != nil {
+		t.Fatalf("repeated Shutdown error = %v, want nil", err)
+	}
+}
+
+func TestGroupGoShutdownRegistrationIsSerialized(t *testing.T) {
+	t.Run("shutdown cancels a context-aware blocked registration", func(t *testing.T) {
+		backend := &issue80ContextAwareBlockingGroup{
+			started:       make(chan struct{}),
+			legacyRelease: make(chan struct{}),
+		}
+		defer backend.releaseLegacyAdd()
+		g := WithContextGroup(context.Background(), backend)
+
+		var ran atomic.Bool
+		goDone := make(chan struct{})
+		go func() {
+			g.Go(func() error {
+				ran.Store(true)
+				return nil
+			})
+			close(goDone)
+		}()
+		waitIssue80Signal(t, backend.started, "context-aware task registration")
+
+		shutdownDone := make(chan error, 1)
+		go func() { shutdownDone <- g.Shutdown() }()
+
+		select {
+		case err := <-shutdownDone:
+			if err != nil {
+				t.Fatalf("Shutdown error = %v", err)
+			}
+		case <-time.After(500 * time.Millisecond):
+			// Unblock the legacy AddTask path so a broken implementation does not
+			// leak test goroutines after the assertion.
+			backend.releaseLegacyAdd()
+			<-goDone
+			<-shutdownDone
+			t.Fatal("Shutdown did not cancel a blocked task registration")
+		}
+		waitIssue80Signal(t, goDone, "context-aware Go rejection")
+		if ran.Load() {
+			t.Fatal("task ran after its registration was canceled")
+		}
+	})
+
+	t.Run("registered submission is released by shutdown cancellation", func(t *testing.T) {
+		backend := &issue80CancelRejectGroup{started: make(chan struct{})}
+		g := WithContextGroup(context.Background(), backend)
+		backend.ctx = g.ctx
+
+		var ran atomic.Bool
+		goDone := make(chan struct{})
+		go func() {
+			g.Go(func() error {
+				ran.Store(true)
+				return nil
+			})
+			close(goDone)
+		}()
+		waitIssue80Signal(t, backend.started, "task registration")
+
+		shutdownDone := make(chan error, 1)
+		go func() { shutdownDone <- g.Shutdown() }()
+
+		select {
+		case err := <-shutdownDone:
+			if err != nil {
+				t.Fatalf("Shutdown error = %v", err)
+			}
+		case <-time.After(500 * time.Millisecond):
+			g.cancel()
+			<-shutdownDone
+			t.Fatal("Shutdown did not cancel a concurrently registered submission")
+		}
+		waitIssue80Signal(t, goDone, "Go rejection")
+		if ran.Load() {
+			t.Fatal("task ran after backend rejected the registered submission")
+		}
+	})
+
+	t.Run("stress concurrent registration and shutdown", func(t *testing.T) {
+		const rounds = 500
+		for round := 0; round < rounds; round++ {
+			backend := &issue80AsyncGroup{}
+			g := WithContextGroup(context.Background(), backend)
+			start := make(chan struct{})
+			panicValue := make(chan interface{}, 5)
+			var callers sync.WaitGroup
+			callers.Add(5)
+
+			for i := 0; i < 4; i++ {
+				go func() {
+					defer callers.Done()
+					defer func() {
+						if recovered := recover(); recovered != nil {
+							panicValue <- recovered
+						}
+					}()
+					<-start
+					runtime.Gosched()
+					g.Go(func() error { return nil })
+				}()
+			}
+			go func() {
+				defer callers.Done()
+				defer func() {
+					if recovered := recover(); recovered != nil {
+						panicValue <- recovered
+					}
+				}()
+				<-start
+				_ = g.Shutdown()
+			}()
+
+			close(start)
+			callers.Wait()
+			close(panicValue)
+			for recovered := range panicValue {
+				t.Fatalf("round %d panicked during Go/Shutdown: %v", round, recovered)
+			}
+
+			_, addAfterShutdown, _ := backend.counts()
+			if addAfterShutdown != 0 {
+				t.Fatalf("round %d submitted %d tasks after backend shutdown", round, addAfterShutdown)
+			}
+		}
+	})
+}
+
+func TestGroupRejectedTaskReturnsErrorFromWait(t *testing.T) {
+	backend := &issue80RejectGroup{}
+	g := WithContextGroup(context.Background(), backend)
+	var ran atomic.Bool
+
+	g.Go(func() error {
+		ran.Store(true)
+		return nil
+	})
+
+	if ran.Load() {
+		t.Fatal("task ran even though the backend rejected it")
+	}
+	if err := g.Wait(); !errors.Is(err, ErrGroupClosed) {
+		t.Fatalf("Wait error = %v, want %v", err, ErrGroupClosed)
+	}
+	if got := backend.addCalls.Load(); got != 1 {
+		t.Fatalf("backend AddTask calls = %d, want 1", got)
+	}
+	select {
+	case <-g.ctx.Done():
+	default:
+		t.Fatal("backend rejection did not cancel group context")
+	}
+}
+
+func assertIssue80FreshBoundedContext(t *testing.T, got issue80ShutdownObservation, stop time.Duration) {
+	t.Helper()
+	if got.err != nil {
+		t.Fatalf("shutdown context was already canceled: %v", got.err)
+	}
+	if !got.hasLimit {
+		t.Fatal("shutdown context has no deadline")
+	}
+	remaining := time.Until(got.deadline)
+	if remaining <= 0 || remaining > stop+50*time.Millisecond {
+		t.Fatalf("shutdown context deadline remaining = %v, want (0, %v]", remaining, stop+50*time.Millisecond)
+	}
+}
+
+func waitIssue80Signal(t *testing.T, ch <-chan struct{}, operation string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for %s", operation)
+	}
+}
+
+func waitIssue80Value[T any](t *testing.T, ch <-chan T, operation string) T {
+	t.Helper()
+	select {
+	case value := <-ch:
+		return value
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for %s", operation)
+		var zero T
+		return zero
+	}
+}

--- a/egroup/liftcycle.go
+++ b/egroup/liftcycle.go
@@ -52,7 +52,7 @@ func (l *LifeAdmin) Start() error {
 				l.g.Go(func() error {
 					// 等待异常或信号关闭触发
 					<-l.g.ctx.Done()
-					return goroutine.Delegate(l.g.ctx, l.opts.stopTimeout, m.Shutdown)
+					return goroutine.Delegate(context.Background(), l.opts.stopTimeout, m.Shutdown)
 				})
 			}
 			if m.Start != nil {

--- a/specs/80/PRODUCT.md
+++ b/specs/80/PRODUCT.md
@@ -1,0 +1,31 @@
+# Issue 80：并发与生命周期正确性
+
+## Summary
+
+修复 `concurrent`、`container`、`egroup` 与 `window` 中已确认的并发、等待、关闭和跨架构错误，使调用方在竞争、取消、重载与关闭条件下得到一致且可终止的结果。
+
+## Behavior
+
+1. 连接池在并发创建、创建失败、归还和强制关闭资源时始终遵守配置的活跃资源上限；失败或已关闭的资源不会永久占用容量，也不会导致并发访问崩溃或状态损坏。
+2. 当连接池的资源或容量重新可用时，所有正在等待的调用都会重新检查池状态；通知即使发生在调用开始休眠之前也不会丢失，多个并发等待者不会因通知合并而在已有可用资源时虚假超时。
+3. `SetWait(true, 0)` 表示不设置池内等待超时：`Get` 会等待资源可用或调用方 context 结束，并原样返回调用方 context 的错误。
+4. 连接池的空闲清理配置可在运行时从禁用切换为启用、从启用切换为禁用或更改周期；每次重载后的行为以最新配置为准，禁用期间不清理，重新启用后过期资源会被清理。
+5. 连接池 `Shutdown` 返回前停止内部空闲清理活动并唤醒等待者；等待者观察到池已关闭，空闲资源仍只关闭一次，重复 `Shutdown` 保持既有幂等错误语义。
+6. CoDel 队列接受一个 `Push` 后，只要对应 packet 被 `Pop` 裁决，该 `Push` 就会收到自己的放行或拒绝结果；裁决不会因发送方尚未开始等待而丢失，也不会被其他请求接收。
+7. CoDel `Push` 的 context 先结束时会返回该 context 的错误；稍后到达的裁决不会阻塞 `Pop`，也不会影响或解除后续 `Push`。
+8. `LifeAdmin` 开始关闭成员时，成员收到的是尚未取消且受 `stopTimeout` 限制的 context；`Start` 会等待成员关闭完成或该超时到达，不会在关闭函数仍运行时提前返回。
+9. `egroup.Group.Shutdown` 会先发出取消信号再等待已接收任务退出，因此等待 group context 的任务不会与 `Shutdown` 相互死锁。
+10. `egroup.Group.Go` 与 `Shutdown` 并发时，关闭判定和任务登记具有单一顺序：关闭开始后不再接收新任务，已登记任务全部被计入等待，调用不会触发 WaitGroup 误用或 panic。
+11. 底层 goroutine group 拒绝 `Go` 提交的任务时，任务不会执行，且调用方随后可从 `Wait` 观察到非 nil 错误，而不是得到成功结果。
+12. LeapArray 跨周期重置时一次性发布完整的新 bucket；并发读取者只能看到完整的旧 bucket 或完整的新 bucket，不会看到新起始时间搭配旧值，也不会因调用方的 `BucketBuilder.Reset` 写入而发生并发状态损坏。
+13. AtomicArray 在所有受支持的指针宽度上都按传入索引访问对应 bucket；32 位平台的非零索引不会读取相邻槽位或越界内存。
+14. `Group.ReSet` 对调用方表现为一次原子操作：新 factory 生效时旧缓存已同时失效；同一轮 reset 的新 factory 不会因并发 `Get` 在清空前后为同一 key 创建两次。
+15. `OrDone()` 不传 channel 时立即返回一个已关闭、且不产生 payload 的完成信号 channel。
+16. `OrDone(ch)` 传一个 channel 时，在该 channel 第一次可读或关闭时关闭结果 channel；结果 channel 不转发源 payload，nil 源 channel 会像普通 nil channel 一样永不触发。
+17. `OrDone(channels...)` 传多个 channel 时，在任一非 nil channel 第一次可读或关闭时关闭结果 channel且不转发 payload；nil channel 不会自行触发，全部为 nil 时结果保持未完成。
+
+## Non-goals
+
+- 不为 `FanInRec`、`MergeChannel`、`Pipeline` 或 `FanOut` 新增 context、取消或下游放弃协议。
+- 不改变 `FanOut` async 模式的顺序、并发度或背压契约。
+- 不扩大现有导出 API；本次只修复上述既有 API 的确定性错误。

--- a/specs/80/TECH.md
+++ b/specs/80/TECH.md
@@ -1,0 +1,130 @@
+# Issue 80：技术方案
+
+## Context
+
+行为来源为 [PRODUCT.md](./PRODUCT.md)。当前实现的关键问题分布如下：
+
+- `container/pool/list.go` 混用原子与普通方式访问活跃计数，以无缓冲通知 channel 做非阻塞发送，并让空闲 cleaner 的启动和周期固定在构造时。
+- `container/queue/codel/queue.go` 为每个 packet 从池中取得无缓冲裁决 channel；`Pop` 在发送方尚未等待时会丢弃裁决并提前复用 channel。
+- `egroup/liftcycle.go` 用已经取消的 group context 调成员 `Shutdown`；`egroup/errgroup.go` 在取消前等待，并未串行化关闭判定与 WaitGroup 登记。
+- `window/leap_array.go` 让外部 builder 原地修改已发布 bucket；`window/array.go` 以固定 8 字节计算指针槽位。
+- `container/group/group.go` 将 factory 替换和缓存清空拆成两个临界区。
+- `concurrent/or_done.go` 对单 channel 直接返回源 channel，而多 channel 只产生完成信号。
+
+本 issue 的范围仅为 PRODUCT Behavior §1–§17。`FanInRec`、`MergeChannel`、`Pipeline` 与 `FanOut` 的新取消、顺序和背压设计是 Non-goals，不修改其代码或签名。
+
+## Proposed changes
+
+### A. Pool（Behavior §1–§5）
+
+目标文件：`container/pool/list.go`、`container/pool/pool.go`，回归测试放在 `container/pool/`。
+
+- 活跃计数的所有并发读取统一使用原子 load；容量 check 与 increment 继续在 `mu` 下形成一个决策，释放路径使用与调用点锁状态明确区分的 helper。
+- 用 `mu` 保护的 generation channel 取代非阻塞发送：等待者在持锁时捕获当前 channel，状态变化在持锁时关闭并替换该 channel，等待者醒来后循环重新检查关闭、idle 和容量状态。这样通知发生在解锁后、真正 select 前也不会丢失，并可同时唤醒多个等待者。
+- 保留现有 `SetWait(false, 0)` 立即返回耗尽、正 `waitTimeout` 受该超时限制的行为；仅为 `SetWait(true, 0)` 直接等待 generation channel 或调用方 context，不创建零时长 timeout。
+- cleaner 使用可重设且总会 `Stop` 的 timer，并有独立 wake、stop、done 生命周期。`Reload` 在 idle timeout 的 0↔正数或正数变化时唤醒/启动 cleaner；禁用时停止 timer但保留重载能力。`Shutdown` 发 stop、广播池关闭并等待 cleaner done 后返回。
+- 不改变 `Pool` 接口、资源 factory/Put 签名或重复关闭的现有错误值。
+
+### B. CoDel（Behavior §6–§7）
+
+目标文件：`container/queue/codel/queue.go`，回归测试放在 `container/queue/codel/`。
+
+- 每次 `Push` 分配一个容量为 1 的 one-shot decision channel，并随 packet 传递；移除 decision channel 的 `sync.Pool` 复用。
+- `Pop` 将一次裁决写入该 buffered channel。发送不依赖 `Push` 是否已 park；若 `Push` 已因 context 返回，buffer 仍吸收该裁决并随 packet 生命周期回收，不会阻塞或流入后续请求。
+- 保持队列容量、CoDel 算法、`Push`/`Pop` 导出签名和错误类型不变。
+
+### C. Egroup（Behavior §8–§11）
+
+目标文件：`egroup/liftcycle.go`、`egroup/errgroup.go`，回归测试放在 `egroup/`。
+
+- 成员关闭使用新的 `context.Background()` 作为 `Delegate` 父 context，再由现有 `stopTimeout` 施加 deadline；不复用已取消的 group context。`Delegate` wrapper 仍被 group 任务计数，因此 `Start` 等待关闭完成或超时。
+- `Group` 增加内部状态锁，同一临界区完成“是否已关闭”判断与 `wg.Add(1)`；任务通过底层已有的 `AddTaskN` 与 group context 登记，使关闭 cancel 能解除尚未完成的阻塞登记。`Shutdown` 在同一锁下切换关闭状态并调用 cancel，释放锁后再 `wg.Wait()`，最后关闭底层 goroutine group。
+- `AddTask` 拒绝时平衡 WaitGroup 计数，并通过现有 first-error 路径记录 `ErrGroupClosed` 与触发取消，使 `Wait` 返回可观察错误；不新增导出方法或错误类型。
+- 保持 first-error、重复 `Shutdown` 和关闭后 `Go` 静默不接收的既有外部形态。
+
+### D. Window（Behavior §12–§13）
+
+目标文件：`window/array.go`、`window/bucket.go`、`window/leap_array.go`，回归测试放在 `window/`。
+
+- AtomicArray 不再保存/计算 slice 基址与固定 stride；对规范化后的 index 直接取得 `&data[index]`，在该槽位执行 atomic load/CAS。
+- LeapArray 跨周期时创建未发布 candidate bucket：用 `builder.NewEmptyBucket()` 初始化全新的 Value，在 candidate 上调用外部 `Reset`，完成后以 CAS 原子替换旧指针。candidate 不共享旧 bucket 的 Value 引用，因此即使 builder 原地清理 value，也不会写到读者仍在使用的旧状态。
+- 不复制已使用的 `atomic.Value` 或复用其底层可变对象，不要求第三方 builder 改用原子写，也不改变 `BucketBuilder` 导出接口。
+- 将现有指针大小断言改为基于本机 `unsafe.Sizeof(uintptr(0))`，使同一测试可在 32 位执行。
+
+### E. Group（Behavior §14）
+
+目标文件：`container/group/group.go`，回归测试放在 `container/group/`。
+
+- `ReSet` 在一个写锁临界区内同时替换 factory 和替换缓存 map；保留 nil factory panic、`Clear` 与所有导出签名。
+
+### F. OrDone（Behavior §15–§17）
+
+目标文件：`concurrent/or_done.go`，回归测试放在 `concurrent/`。
+
+- 0 个输入直接返回已关闭 channel。
+- 1 个及以上输入都由统一 waiter 等待第一次 receive-ready 事件，然后只关闭结果 channel，不发送选中的 payload。
+- 保留 reflect select 对 nil channel 的标准语义：nil case 永不就绪；全部 nil 时 waiter 持续等待。
+- 不修改其他 concurrent combinator。
+
+## Testing and validation
+
+### Behavior-to-test mapping
+
+1. Behavior §1 → `TestListActiveCountConcurrentRelease`：并发 factory 失败与容量检查，在 `-race` 下无竞态，成功创建数不超过 active 上限。
+2. Behavior §2 → `TestListWaitBroadcastCannotBeLost`：两个等待者在捕获等待 generation 后、进入 select 前归还两个资源，二者都及时成功而非等到 timeout。
+3. Behavior §3 → `TestListWaitWithoutPoolTimeoutUsesCallerContext`：`SetWait(true, 0)` 不提前返回；归还资源时成功，只有 caller cancel 时返回其 context 错误。
+4. Behavior §4 → `TestListCleanerFollowsReloadedIdleTimeout`：覆盖 0→正数、正数→0、禁用期间不清理及重新启用/缩短周期后清理。
+5. Behavior §5 → `TestListShutdownStopsCleanerAndWakesWaiters`：`Shutdown` 等待 cleaner done、等待者返回 `ErrPoolClosed`，并复用现有 idle exactly-once 测试验证资源计数。
+6. Behavior §6 → `TestQueueDecisionBufferedBeforePushWaits`：从内部 packets 取得已入队 packet，验证 decision channel 为 one-shot buffered，并在接收方可能 park 前写入裁决，原 `Push` 得到该裁决。
+7. Behavior §7 → `TestQueueCanceledPushDoesNotBlockOrCrossWire`：取消第一个 `Push` 后再投递其裁决不会阻塞；第二个 packet 使用独立 channel并只收到自己的裁决。
+8. Behavior §8 → `TestLifeAdminShutdownUsesFreshBoundedContext`：成员断言 context 初始未取消且有 stopTimeout deadline；`Start` 在 callback 完成前不返回，并另测超时边界。
+9. Behavior §9 → `TestGroupShutdownCancelsBeforeWaiting`：任务等待 group cancellation，`Shutdown` 在测试 deadline 内返回；mutation 为恢复 wait-before-cancel 时确定超时。
+10. Behavior §10 → `TestGroupGoShutdownRegistrationIsSerialized`：用可控底层 group 扩大交错，证明 shutdown cancel 能解除阻塞的 context-aware 登记，并重复并发 `Go`/`Shutdown`；在 `-race` 下无 panic/WaitGroup misuse，关闭后无新任务被接收。
+11. Behavior §11 → `TestGroupRejectedTaskReturnsErrorFromWait`：拒绝型底层 group 不执行任务，`Wait` 返回 `ErrGroupClosed`。
+12. Behavior §12 → `TestLeapArrayPublishesResetBucketAtomically`：builder 在 candidate 上分阶段写 Start/Value，同时读旧槽位；发布前只见完整旧值，发布后只见完整新值，`-race` 无报告。
+13. Behavior §13 → `TestAtomicArrayUsesNativePointerStride`：每个 index 返回 `data[index]`；同一测试交叉编译并在 386 emulator/binfmt 可用时执行。
+14. Behavior §14 → `TestGroupResetIsAtomicWithConcurrentGet`：受控并发 reset/get 下，每轮新 factory 对同 key 最多调用一次，且 reset 返回后缓存来自新 factory。
+15. Behavior §15 → `TestOrDoneNoInputsIsClosedSignal`：立即 receive 到 closed 状态且无 payload。
+16. Behavior §16 → `TestOrDoneSingleInputIsSignalOnly`：value/close 都只关闭结果，不转发值；nil 输入在测试观察窗内不触发。
+17. Behavior §17 → `TestOrDoneMultipleInputsAndNilSemantics`：最先 value/close 的非 nil 输入关闭结果、无 payload；nil 不抢占，全部 nil 不触发。
+
+### Red → green commands
+
+每组先只加入对应测试并在原实现上记录失败，再实施该组最小修复并运行同一命令转绿：
+
+```bash
+go test -race -count=1 ./container/pool -run 'TestList(Active|Wait|Cleaner|Shutdown)'
+go test -race -count=1 ./container/queue/codel -run 'TestQueue(Decision|Canceled)'
+go test -race -count=1 ./egroup -run 'Test(LifeAdmin|Group)'
+go test -race -count=1 ./window -run 'Test(LeapArrayPublishes|AtomicArrayUses)'
+go test -race -count=1 ./container/group -run 'TestGroupResetIsAtomic'
+go test -race -count=1 ./concurrent -run 'TestOrDone'
+```
+
+### Mutation / revert checks
+
+- A：把 active load 恢复为普通读，`TestListActiveCountConcurrentRelease` 必须被 `-race` 杀死；把 generation capture 移到解锁后、移除 `wait=true && timeout=0` 分支、忽略 Reload wake 或 Shutdown stop，各自对应 §2–§5 测试必须失败。
+- B：把 decision channel 改回无缓冲或复用同一个 channel，§6/§7 测试必须阻塞、超时或观察到 channel identity/裁决错误。
+- C：把 shutdown parent 改回 group ctx、恢复 wait-before-cancel、移除状态锁或拒绝错误记录，§8–§11 对应测试必须失败；并发登记 mutation 同时跑 `-race`。
+- D：恢复已发布 bucket 原地 Reset 时 §12 的 `-race` 测试必须失败；恢复 8 字节 stride 时 386 的 §13 测试必须返回错误槽位。
+- E：恢复 `ReSet` 两段临界区时 §14 受控交错测试必须观察到同一 factory 重复创建。
+- F：恢复单输入直接返回或向结果发送 selected payload 时 §16/§17 必须失败。
+
+mutation 只在本地临时修改后运行，验证失败即恢复正确实现；不把 mutation 留在 diff 中。
+
+### Final verification
+
+```bash
+git diff --name-only -- '*.go' | xargs gofmt -w
+go test -race -count=1 ./concurrent ./container/group ./container/pool ./container/queue/codel ./egroup ./window
+go vet ./concurrent ./container/group ./container/pool ./container/queue/codel ./egroup ./window
+CGO_ENABLED=0 GOOS=linux GOARCH=386 go test -c ./window -o /tmp/gkit-window-386.test
+```
+
+若本机已有 386 emulator 或 Docker binfmt，再执行：
+
+```bash
+/tmp/gkit-window-386.test -test.run 'TestAtomicArrayUsesNativePointerStride' -test.v
+```
+
+无法执行交叉架构 binary 时，保留成功的 386 test-binary 构建记录并明确运行时证据缺口。最终还需确认 `git diff --check`、限定包全量 race 测试和 vet 均通过，且 diff 未触及 Non-goals 中的文件。

--- a/window/array.go
+++ b/window/array.go
@@ -5,7 +5,6 @@ import (
 	"unsafe"
 
 	"github.com/songzhibin97/gkit/internal/clock"
-	"github.com/songzhibin97/gkit/sys/safe"
 )
 
 // AtomicArray 封装原子操作, 底层维护 []*Bucket
@@ -13,19 +12,16 @@ type AtomicArray struct {
 	// length: array长度
 	length uint64
 
-	// base: 数据基地址
-	base unsafe.Pointer
 	data []*Bucket
 }
 
 // offset 根据index获取底层的桶
 func (a *AtomicArray) offset(index uint64) (unsafe.Pointer, bool) {
-	if index < 0 {
+	if a.length == 0 {
 		return nil, false
 	}
 	index = index % a.length
-	base := a.base
-	return unsafe.Pointer(uintptr(base) + uintptr(index*PtrOffSize)), true
+	return unsafe.Pointer(&a.data[index]), true
 }
 
 // getBucket 根据index获取底层bucket
@@ -71,8 +67,6 @@ func NewAtomicArrayWithTime(length uint64, bucketSize uint64, now uint64, Builde
 		array.data[i] = b
 		startTime += bucketSize
 	}
-	header := (*safe.SliceModel)(unsafe.Pointer(&array.data))
-	array.base = header.Data
 	return array
 }
 

--- a/window/array_test.go
+++ b/window/array_test.go
@@ -39,11 +39,16 @@ func TestBucketSize(t *testing.T) {
 		Start: clock.GetTimeMillis(),
 		Value: atomic.Value{},
 	}
-	if !assert.Equal(t, int(unsafe.Sizeof(*b)), 24) {
-		t.Errorf("the size of Bucket is not equal 24.\n")
+	wantBucketSize := unsafe.Sizeof(uint64(0)) + unsafe.Sizeof(atomic.Value{})
+	if !assert.Equal(t, wantBucketSize, unsafe.Sizeof(*b)) {
+		t.Errorf("the size of Bucket is not equal to its fields.\n")
 	}
-	if !assert.Equal(t, int(unsafe.Sizeof(b)), 8) {
-		t.Errorf("the size of Bucket pointer is not equal 8.\n")
+	wantPointerSize := unsafe.Sizeof(uintptr(0))
+	if !assert.Equal(t, wantPointerSize, unsafe.Sizeof(b)) {
+		t.Errorf("the size of Bucket pointer is not native pointer size.\n")
+	}
+	if !assert.Equal(t, uint64(wantPointerSize), PtrOffSize) {
+		t.Errorf("PtrOffSize is not native pointer size.\n")
 	}
 }
 

--- a/window/bucket.go
+++ b/window/bucket.go
@@ -2,11 +2,12 @@ package window
 
 import (
 	"sync/atomic"
+	"unsafe"
 )
 
 const (
 	// PtrOffSize 指针偏移量大小
-	PtrOffSize = uint64(8)
+	PtrOffSize = uint64(unsafe.Sizeof(uintptr(0)))
 )
 
 // BucketBuilder Bucket 生成器

--- a/window/leap_array.go
+++ b/window/leap_array.go
@@ -21,11 +21,12 @@ type TimeChick func(uint64) bool
 // LeapArray 基于 Bucket 实现的 leap array
 // 例如: bucketSize == 200ms,intervalSize == 1000ms,所以n = 5
 // 假设当前是 时间是888ms 构建下图
-//   B0       B1      B2     B3      B4
-//   |_______|_______|_______|_______|_______|
-//  1000    1200    1400    1600    800    (1000)
-//                                        ^
-//                                      time=888
+//
+//	 B0       B1      B2     B3      B4
+//	 |_______|_______|_______|_______|_______|
+//	1000    1200    1400    1600    800    (1000)
+//	                                      ^
+//	                                    time=888
 type LeapArray struct {
 	// lock: 互斥自旋锁
 	mu mutex.Mutex
@@ -76,10 +77,14 @@ func (s *LeapArray) getBucketOfTime(now uint64, builder BucketBuilder) (*Bucket,
 
 			// 尝试获取锁
 			if s.mu.TryLock() {
-				// 重置
-				old = builder.Reset(old, start)
+				candidate := &Bucket{Start: start}
+				candidate.Value.Store(builder.NewEmptyBucket())
+				candidate = builder.Reset(candidate, start)
+				swapped := s.array.compareAndSwap(index, old, candidate)
 				s.mu.Unlock()
-				return old, nil
+				if swapped {
+					return candidate, nil
+				}
 			}
 			runtime.Gosched()
 		} else if start < atomic.LoadUint64(&old.Start) {

--- a/window/reset_atomic_issue80_test.go
+++ b/window/reset_atomic_issue80_test.go
@@ -1,0 +1,115 @@
+package window
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+	"unsafe"
+)
+
+type stagedResetValue struct {
+	name string
+}
+
+type stagedResetBuilder struct {
+	resetStarted chan struct{}
+	finishReset  chan struct{}
+}
+
+func (b *stagedResetBuilder) NewEmptyBucket() interface{} {
+	return &stagedResetValue{name: "old"}
+}
+
+func (b *stagedResetBuilder) Reset(bucket *Bucket, startTime uint64) *Bucket {
+	atomic.StoreUint64(&bucket.Start, startTime)
+	close(b.resetStarted)
+	<-b.finishReset
+	bucket.Value.Store(&stagedResetValue{name: "new"})
+	return bucket
+}
+
+func TestLeapArrayPublishesResetBucketAtomically(t *testing.T) {
+	const (
+		oldTime    = uint64(100)
+		bucketSize = uint64(10)
+	)
+	builder := &stagedResetBuilder{
+		resetStarted: make(chan struct{}),
+		finishReset:  make(chan struct{}),
+	}
+	array := NewAtomicArrayWithTime(1, bucketSize, oldTime, builder)
+	leap := &LeapArray{
+		bucketSize:   bucketSize,
+		intervalSize: bucketSize,
+		n:            1,
+		array:        array,
+	}
+	oldBucket := array.getBucket(0)
+
+	type result struct {
+		bucket *Bucket
+		err    error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		bucket, err := leap.getBucketOfTime(oldTime+bucketSize+1, builder)
+		resultCh <- result{bucket: bucket, err: err}
+	}()
+
+	select {
+	case <-builder.resetStarted:
+	case <-time.After(time.Second):
+		t.Fatal("Reset did not start")
+	}
+
+	publishedDuringReset := array.getBucket(0)
+	startDuringReset := atomic.LoadUint64(&publishedDuringReset.Start)
+	valueDuringReset := publishedDuringReset.Value.Load().(*stagedResetValue).name
+	close(builder.finishReset)
+
+	var got result
+	select {
+	case got = <-resultCh:
+	case <-time.After(time.Second):
+		t.Fatal("getBucketOfTime did not return")
+	}
+	if got.err != nil {
+		t.Fatalf("getBucketOfTime() error = %v", got.err)
+	}
+	if publishedDuringReset != oldBucket {
+		t.Fatal("partially reset candidate was published before Reset completed")
+	}
+	if startDuringReset != oldTime || valueDuringReset != "old" {
+		t.Fatalf("published bucket changed during Reset: start=%d value=%q", startDuringReset, valueDuringReset)
+	}
+
+	publishedAfterReset := array.getBucket(0)
+	if publishedAfterReset == oldBucket {
+		t.Fatal("reset reused the previously published bucket")
+	}
+	if got.bucket != publishedAfterReset {
+		t.Fatal("getBucketOfTime returned a bucket that was not published")
+	}
+	if start := atomic.LoadUint64(&publishedAfterReset.Start); start != oldTime+bucketSize {
+		t.Fatalf("published start = %d, want %d", start, oldTime+bucketSize)
+	}
+	if value := publishedAfterReset.Value.Load().(*stagedResetValue).name; value != "new" {
+		t.Fatalf("published value = %q, want new", value)
+	}
+}
+
+func TestAtomicArrayUsesNativePointerStride(t *testing.T) {
+	if want := uint64(unsafe.Sizeof(uintptr(0))); PtrOffSize != want {
+		t.Fatalf("PtrOffSize = %d, want native pointer size %d", PtrOffSize, want)
+	}
+	const length = uint64(4)
+	array := NewAtomicArrayWithTime(length, 10, 100, &Mock{})
+	for index := uint64(0); index < length; index++ {
+		if got, want := array.getBucket(index), array.data[index]; got != want {
+			t.Fatalf("getBucket(%d) = %p, want data[%d] = %p", index, got, index, want)
+		}
+		if !array.compareAndSwap(index, array.data[index], array.data[index]) {
+			t.Fatalf("compareAndSwap(%d) addressed the wrong slot", index)
+		}
+	}
+}


### PR DESCRIPTION
## What

- make pool capacity, waiter notification, cleaner reload, and shutdown lifecycle race-safe
- give each CoDel push a private buffered decision and serialize egroup registration with shutdown cancellation
- publish LeapArray resets atomically, use native pointer slots, and make Group reset a single transition
- make OrDone consistently return a signal-only channel for zero, one, or multiple inputs
- add issue-scoped PRODUCT/TECH specs and deterministic concurrency regressions

## Why

Issue #80 identified real lost wakeups, data races, deadlocks, cross-wired queue decisions, partially published buckets, and inconsistent completion-channel behavior. The other concurrent combinators listed in the issue are design tradeoffs and remain explicitly out of scope.

## How

Pool waiters observe close-and-replace generations, while a single resettable cleaner is joined during shutdown. Egroup registration uses the existing context-aware `AddTaskN`, so shutdown cancellation also releases a blocked admission before waiting. Window resets build an unpublished fresh bucket and CAS it into its native slice slot only after reset completes.

## Test plan

- `GOTOOLCHAIN=go1.20.14 go test -race -count=1 ./concurrent ./container/group ./container/pool ./container/queue/codel ./egroup ./window`
- `GOTOOLCHAIN=go1.20.14 go vet ./concurrent ./container/group ./container/pool ./container/queue/codel ./egroup ./window`
- focused regressions repeatedly under `-race` (up to `-count=20`)
- linux/386 window test binary built and `TestAtomicArrayUsesNativePointerStride` executed successfully in a container
- independent review: 0 critical, 0 important; mutations killed for pool wait, CoDel decision, egroup blocked registration, LeapArray reset, Group reset, and OrDone

One owner-side full-suite run reproduced the existing timing-boundary flake in `concurrent/TestSkipN` (one extra value at the 3-second deadline); the same untouched family had already failed on `master`. The independent full race run passed, and all new deterministic OrDone tests pass repeatedly.

## Compatibility

No exported signatures change. Pool shutdown remains idempotent with the existing error, CoDel keeps its algorithm and capacity contract, and the issue's FanIn/Merge/Pipeline/FanOut changes remain non-goals.

Fixes #80
