### PR TITLE
fix(runtime): preserve diagnostics and token integrity

### DIFF
--- a/encrypt/aes/gcm.go
+++ b/encrypt/aes/gcm.go
@@ -1,0 +1,59 @@
+package aes
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"io"
+)
+
+// EncryptGCM encrypts plaintext with AES-GCM and a fresh random nonce. The
+// returned base64 payload is nonce || ciphertext || authentication tag.
+func EncryptGCM(plaintext string, key string) (string, error) {
+	block, err := aes.NewCipher([]byte(key))
+	if err != nil {
+		return "", err
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+	nonce := make([]byte, aead.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", err
+	}
+	sealed := aead.Seal(nil, nonce, []byte(plaintext), nil)
+	payload := make([]byte, 0, len(nonce)+len(sealed))
+	payload = append(payload, nonce...)
+	payload = append(payload, sealed...)
+	return base64.StdEncoding.EncodeToString(payload), nil
+}
+
+// DecryptGCM authenticates and decrypts a payload produced by EncryptGCM.
+// All malformed or unauthenticated inputs return ErrDecryptionFailed.
+func DecryptGCM(encoded string, key string) (string, error) {
+	payload, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return "", ErrDecryptionFailed
+	}
+	block, err := aes.NewCipher([]byte(key))
+	if err != nil {
+		return "", ErrDecryptionFailed
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", ErrDecryptionFailed
+	}
+	nonceSize := aead.NonceSize()
+	if len(payload) < nonceSize+aead.Overhead() {
+		return "", ErrDecryptionFailed
+	}
+	nonce := payload[:nonceSize]
+	ciphertext := payload[nonceSize:]
+	plaintext, err := aead.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return "", ErrDecryptionFailed
+	}
+	return string(plaintext), nil
+}

--- a/encrypt/aes/gcm_issue85_test.go
+++ b/encrypt/aes/gcm_issue85_test.go
@@ -1,6 +1,8 @@
 package aes
 
 import (
+	cryptoaes "crypto/aes"
+	"crypto/cipher"
 	"encoding/base64"
 	"errors"
 	"testing"
@@ -58,4 +60,59 @@ func TestGCMRejectsWrongKeyAndEveryPayloadRegionTamper(t *testing.T) {
 	if _, err := DecryptGCM("not-base64", key); !errors.Is(err, ErrDecryptionFailed) {
 		t.Fatalf("invalid base64 error = %v, want ErrDecryptionFailed", err)
 	}
+}
+
+func TestGCMRejectsValidBase64TruncationWithoutPanicking(t *testing.T) {
+	const key = "0123456789abcdef0123456789abcdef"
+	ciphertext, err := EncryptGCM("authenticated payload", key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := base64.StdEncoding.DecodeString(ciphertext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	block, err := cryptoaes.NewCipher([]byte(key))
+	if err != nil {
+		t.Fatal(err)
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		payload []byte
+	}{
+		{name: "empty", payload: nil},
+		{name: "short nonce", payload: raw[:aead.NonceSize()-1]},
+		{name: "nonce only", payload: raw[:aead.NonceSize()]},
+		{name: "short tag", payload: raw[:aead.NonceSize()+aead.Overhead()-1]},
+		{name: "truncated ciphertext", payload: raw[:len(raw)-1]},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plaintext, err, panicked := callDecryptGCM(base64.StdEncoding.EncodeToString(tt.payload), key)
+			if panicked {
+				t.Fatal("DecryptGCM panicked for a valid-base64 truncated payload")
+			}
+			if plaintext != "" {
+				t.Fatalf("DecryptGCM plaintext = %q, want empty", plaintext)
+			}
+			if !errors.Is(err, ErrDecryptionFailed) {
+				t.Fatalf("DecryptGCM error = %v, want ErrDecryptionFailed", err)
+			}
+		})
+	}
+}
+
+func callDecryptGCM(encoded, key string) (plaintext string, err error, panicked bool) {
+	defer func() {
+		if recover() != nil {
+			panicked = true
+		}
+	}()
+	plaintext, err = DecryptGCM(encoded, key)
+	return
 }

--- a/encrypt/aes/gcm_issue85_test.go
+++ b/encrypt/aes/gcm_issue85_test.go
@@ -1,0 +1,61 @@
+package aes
+
+import (
+	"encoding/base64"
+	"errors"
+	"testing"
+)
+
+func TestGCMRoundTripUsesRandomNonce(t *testing.T) {
+	const (
+		plaintext = "authenticated payload"
+		key       = "0123456789abcdef0123456789abcdef"
+	)
+	first, err := EncryptGCM(plaintext, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := EncryptGCM(plaintext, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first == second {
+		t.Fatal("two GCM encryptions reused the same nonce")
+	}
+	for _, ciphertext := range []string{first, second} {
+		got, err := DecryptGCM(ciphertext, key)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != plaintext {
+			t.Fatalf("DecryptGCM() = %q, want %q", got, plaintext)
+		}
+	}
+}
+
+func TestGCMRejectsWrongKeyAndEveryPayloadRegionTamper(t *testing.T) {
+	const key = "0123456789abcdef0123456789abcdef"
+	ciphertext, err := EncryptGCM("authenticated payload long enough for regions", key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := DecryptGCM(ciphertext, "fedcba9876543210fedcba9876543210"); !errors.Is(err, ErrDecryptionFailed) {
+		t.Fatalf("wrong-key error = %v, want ErrDecryptionFailed", err)
+	}
+
+	raw, err := base64.StdEncoding.DecodeString(ciphertext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, index := range []int{0, len(raw) / 2, len(raw) - 1} {
+		tampered := append([]byte(nil), raw...)
+		tampered[index] ^= 0x01
+		encoded := base64.StdEncoding.EncodeToString(tampered)
+		if _, err := DecryptGCM(encoded, key); !errors.Is(err, ErrDecryptionFailed) {
+			t.Fatalf("tamper at byte %d error = %v, want ErrDecryptionFailed", index, err)
+		}
+	}
+	if _, err := DecryptGCM("not-base64", key); !errors.Is(err, ErrDecryptionFailed) {
+		t.Fatalf("invalid base64 error = %v, want ErrDecryptionFailed", err)
+	}
+}

--- a/errors/error.go
+++ b/errors/error.go
@@ -89,6 +89,11 @@ func FromError(err error) *Error {
 				).AddMetadata(d.Metadata)
 			}
 		}
+		return New(
+			httputil.StatusFromGRPCCode(gs.Code()),
+			UnknownReason,
+			gs.Message(),
+		)
 	}
 	return New(UnknownCode, UnknownReason, err.Error())
 }

--- a/errors/from_grpc_issue85_test.go
+++ b/errors/from_grpc_issue85_test.go
@@ -1,0 +1,40 @@
+package errors
+
+import (
+	"testing"
+
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestFromErrorPreservesStandardGRPCStatus(t *testing.T) {
+	got := FromError(status.Error(codes.NotFound, "missing"))
+	if got.Code != 404 {
+		t.Fatalf("FromError code = %d, want 404", got.Code)
+	}
+	if got.Reason != "" {
+		t.Fatalf("FromError reason = %q, want empty", got.Reason)
+	}
+	if got.Message != "missing" {
+		t.Fatalf("FromError message = %q, want missing", got.Message)
+	}
+}
+
+func TestFromErrorKeepsErrorInfoDetails(t *testing.T) {
+	grpcStatus, err := status.New(codes.PermissionDenied, "denied").WithDetails(&errdetails.ErrorInfo{
+		Reason:   "POLICY",
+		Metadata: map[string]string{"scope": "write"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := FromError(grpcStatus.Err())
+	if got.Code != 403 || got.Reason != "POLICY" || got.Message != "denied" {
+		t.Fatalf("FromError detail = %#v, want code=403 reason=POLICY message=denied", got)
+	}
+	if got.Metadata["scope"] != "write" {
+		t.Fatalf("FromError metadata = %#v, want scope=write", got.Metadata)
+	}
+}

--- a/generator/ip_issue85_test.go
+++ b/generator/ip_issue85_test.go
@@ -1,0 +1,48 @@
+package generator
+
+import (
+	"net"
+	"testing"
+)
+
+func TestIpToUint16NormalizesParsedIPv4(t *testing.T) {
+	got, err := IpToUint16(net.ParseIP("192.168.2.3"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 515 {
+		t.Fatalf("IpToUint16(192.168.2.3) = %d, want 515", got)
+	}
+}
+
+func TestIpToUint16RejectsInvalidInput(t *testing.T) {
+	tests := []struct {
+		name string
+		ip   net.IP
+	}{
+		{name: "nil", ip: nil},
+		{name: "short", ip: net.IP{1, 2, 3}},
+		{name: "IPv6", ip: net.ParseIP("2001:db8::1")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err, panicked := callIpToUint16(tt.ip)
+			if panicked {
+				t.Fatalf("IpToUint16(%v) panicked", tt.ip)
+			}
+			if err == nil {
+				t.Fatalf("IpToUint16(%v) returned nil error", tt.ip)
+			}
+		})
+	}
+}
+
+func callIpToUint16(ip net.IP) (value uint16, err error, panicked bool) {
+	defer func() {
+		if recover() != nil {
+			panicked = true
+		}
+	}()
+	value, err = IpToUint16(ip)
+	return value, err, false
+}

--- a/generator/snowflake.go
+++ b/generator/snowflake.go
@@ -135,8 +135,15 @@ func isPrivateIPv4(ip net.IP) bool {
 
 // IpToUint16 将IP地址转化为uint16
 func IpToUint16(ip net.IP) (uint16, error) {
-	return uint16(ip[2])<<8 + uint16(ip[3]), nil
+	ipv4 := ip.To4()
+	if ipv4 == nil {
+		return 0, ErrInvalidIPv4
+	}
+	return uint16(ipv4[2])<<8 + uint16(ipv4[3]), nil
 }
+
+// ErrInvalidIPv4 is returned when an address cannot be represented as IPv4.
+var ErrInvalidIPv4 = errors.New("generator: invalid IPv4 address")
 
 // LocalIpToUint16 本地IP转化为uint16
 func LocalIpToUint16() (uint16, error) {
@@ -144,7 +151,7 @@ func LocalIpToUint16() (uint16, error) {
 	if err != nil {
 		return 0, err
 	}
-	return uint16(ip[2])<<8 + uint16(ip[3]), nil
+	return IpToUint16(ip)
 }
 
 // ErrStartTimeInFuture is returned by NewSnowflakeE when startTime is later

--- a/page_token/aead_issue85_test.go
+++ b/page_token/aead_issue85_test.go
@@ -1,0 +1,50 @@
+package page_token
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/songzhibin97/gkit/encrypt/aes"
+)
+
+func TestPageTokenRejectsAuthenticatedCiphertextTampering(t *testing.T) {
+	pageToken, err := NewTokenGenerateE("orders", SetSalt("issue-85-strong-salt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded := pageToken.ForIndex(42)
+	if encoded == "" {
+		t.Fatal("ForIndex returned an empty token")
+	}
+	raw, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, index := range []int{0, len(raw) / 2, len(raw) - 1} {
+		tampered := append([]byte(nil), raw...)
+		tampered[index] ^= 0x01
+		_, err := pageToken.GetIndex(base64.StdEncoding.EncodeToString(tampered))
+		if !errors.Is(err, ErrInvalidToken) {
+			t.Fatalf("tamper at byte %d error = %v, want ErrInvalidToken", index, err)
+		}
+	}
+}
+
+func TestPageTokenRejectsLegacyCBCToken(t *testing.T) {
+	pageToken, err := NewTokenGenerateE("orders", SetSalt("issue-85-strong-salt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	implementation := pageToken.(*token)
+	legacyPlaintext := fmt.Sprintf("%s%s%s:%d", implementation.resourceIdentification, resourceDelim, time.Now().Format(layout), 42)
+	legacyToken, err := aes.Encrypt(legacyPlaintext, implementation.salt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pageToken.GetIndex(legacyToken); !errors.Is(err, ErrInvalidToken) {
+		t.Fatalf("legacy CBC token error = %v, want ErrInvalidToken", err)
+	}
+}

--- a/page_token/token.go
+++ b/page_token/token.go
@@ -49,7 +49,7 @@ type token struct {
 }
 
 func (t *token) ForIndex(i int) string {
-	v, err := aes.Encrypt(fmt.Sprintf("%s%s%s:%d", t.resourceIdentification, resourceDelim, time.Now().Format(layout), i), t.salt)
+	v, err := aes.EncryptGCM(fmt.Sprintf("%s%s%s:%d", t.resourceIdentification, resourceDelim, time.Now().Format(layout), i), t.salt)
 	if err != nil {
 		return ""
 	}
@@ -60,7 +60,7 @@ func (t *token) GetIndex(s string) (int, error) {
 	if s == "" {
 		return 0, nil
 	}
-	decrypted, err := aes.Decrypt(s, t.salt)
+	decrypted, err := aes.DecryptGCM(s, t.salt)
 	if err != nil {
 		return -1, ErrInvalidToken
 	}

--- a/parser/parse_pb/model.go
+++ b/parser/parse_pb/model.go
@@ -206,10 +206,10 @@ func (p *PbParseGo) parseMessage(ms *proto.Message, prefix string) {
 			ret.AddFiles(CreateFile(v.Field.Name, fmt.Sprintf("map[%s]%s",
 				PbTypeToGo(keyType), PbTypeToGo(valueType)), fmt.Sprintf("<%s,%s>", keyType, valueType)))
 		case *proto.Message:
-			p.parseMessage(v, ms.Name+prefix)
+			p.parseMessage(v, prefix+ms.Name)
 		case *proto.Enum:
 			ret.AddFiles(CreateFile(v.Name, v.Name, "enum"))
-			p.parseEnum(v, ms.Name+prefix)
+			p.parseEnum(v, prefix+ms.Name)
 		}
 	}
 	for _, f := range p.ParseMessages {

--- a/parser/parse_pb/nested_prefix_issue85_test.go
+++ b/parser/parse_pb/nested_prefix_issue85_test.go
@@ -1,0 +1,60 @@
+package parse_pb
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNestedMessageAndEnumPrefixesFollowOuterToInnerOrder(t *testing.T) {
+	protoFile := filepath.Join(t.TempDir(), "nested.proto")
+	definition := `syntax = "proto3";
+package nested;
+message A {
+  message B {
+    message C { string value = 1; }
+    enum D { D_UNSPECIFIED = 0; }
+  }
+}`
+	if err := os.WriteFile(protoFile, []byte(definition), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	parsed, err := ParsePb(protoFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	model := parsed.(*PbParseGo)
+	for _, name := range []string{"A", "AB", "ABC"} {
+		if _, ok := model.Message[name]; !ok {
+			t.Fatalf("message %q missing; got %#v", name, mapKeys(model.Message))
+		}
+	}
+	if _, ok := model.Enums["ABD"]; !ok {
+		t.Fatalf("enum %q missing; got %#v", "ABD", enumMapKeys(model.Enums))
+	}
+	for _, wrong := range []string{"BAC", "BAD"} {
+		if _, ok := model.Message[wrong]; ok {
+			t.Fatalf("reversed-prefix message %q was generated", wrong)
+		}
+		if _, ok := model.Enums[wrong]; ok {
+			t.Fatalf("reversed-prefix enum %q was generated", wrong)
+		}
+	}
+}
+
+func mapKeys(values map[string]*Message) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+func enumMapKeys(values map[string]*Enum) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	return keys
+}

--- a/specs/85/PRODUCT.md
+++ b/specs/85/PRODUCT.md
@@ -6,7 +6,7 @@
 
 ## Behavior
 
-1. watching 的 goroutine、memory、thread、CPU 与 GC heap 自动 dump 日志都按 `UniformLogFormat` 渲染，不产生 `%!(EXTRA...)`，并保留 dump 类型、原因与 event ID。
+1. watching 的 goroutine、memory、thread、CPU 与 GC heap 自动 dump 触发日志都按 `UniformLogFormat` 渲染，不产生 `%!(EXTRA...)`，并保留 dump 动作、类型、配置阈值以及 previous/current 观测值。
 2. watching 将文本 pprof 内容作为普通文本返回；内容中的 `%` 不会被当作格式动词改写。
 3. `trimResult` 在输入不超过上限时保留全部段落；超过上限时只保留前 `TrimResultTopN` 段。
 4. 运行中的 watching 可并发启停 thread、goroutine、CPU、memory 与 GC heap dump；配置读写在 `-race` 下无数据竞争。

--- a/specs/85/PRODUCT.md
+++ b/specs/85/PRODUCT.md
@@ -1,0 +1,24 @@
+# Issue 85：运行时诊断与数据完整性修复
+
+## Summary
+
+修复监控 dump、跨协议错误转换、trace peer、protobuf 嵌套命名、Snowflake 节点提取与 page token 防篡改中的确定性错误，使诊断输出保持原文、并发配置无竞态、协议元数据不丢失，且安全令牌在解密前经过完整性认证。
+
+## Behavior
+
+1. watching 的 goroutine、memory、thread、CPU 与 GC heap 自动 dump 日志都按 `UniformLogFormat` 渲染，不产生 `%!(EXTRA...)`，并保留 dump 类型、原因与 event ID。
+2. watching 将文本 pprof 内容作为普通文本返回；内容中的 `%` 不会被当作格式动词改写。
+3. `trimResult` 在输入不超过上限时保留全部段落；超过上限时只保留前 `TrimResultTopN` 段。
+4. 运行中的 watching 可并发启停 thread、goroutine、CPU、memory 与 GC heap dump；配置读写在 `-race` 下无数据竞争。
+5. `errors.FromError` 转换不带 `ErrorInfo` detail 的标准 gRPC status 时保留映射后的原始 gRPC code 与 message；本库带 detail 的 reason/metadata 行为保持不变。
+6. trace 的 `parseTarget` 对带 scheme 的网络 endpoint 返回 `host:port`，对裸 `host:port` 保持同样结果，使 `peerAttr` 可生成 peer IP/port；既有 unix path 处理保持兼容。
+7. protobuf parser 对任意深度的嵌套 message/enum 都按从外到内的父级前缀命名，例如 `A.B.C` 生成 `ABC`，不会生成反序前缀。
+8. `IpToUint16` 对 `net.ParseIP` 返回的 16 字节 IPv4 表示先归一化为 IPv4，再从后两段生成节点值；nil、短 IP 与纯 IPv6 返回明确错误而不是 panic 或静默返回 0。
+9. 新生成的 page token 使用带认证的加密；任何 nonce、密文或认证标签位翻转都返回 `ErrInvalidToken`。旧 CBC page token 不再被接受。`encrypt/aes` 保留既有 CBC API 以兼容普通调用方，并新增供安全边界使用的 AEAD API。
+
+## Non-goals
+
+- 不改变 watching 的阈值算法、采样周期、dump 文件格式或 reporter 协议。
+- 不重命名 protobuf 顶层类型，也不改变字段类型映射。
+- 不改变 Snowflake ID 位布局。
+- 不把既有 `aes.Encrypt` / `aes.Decrypt` 的密文格式原地迁移；它们作为 legacy CBC API 保留，但不得继续承载 page token 完整性边界。

--- a/specs/85/TECH.md
+++ b/specs/85/TECH.md
@@ -31,7 +31,7 @@
 
 ## Behavior-to-test mapping
 
-1. Behavior 1 → watching 表驱动测试逐一触发五个 dump 日志调用或其可控 helper，断言无 `%!(EXTRA` 且字段齐全；恢复错误首参时失败。
+1. Behavior 1 → watching 表驱动测试使用非零且互异的 min/diff/abs、previous/current（不支持 max 的类型保持约定值 0），逐一断言五个 dump call site 产生的第一条 trigger 日志完整等于 `UniformLogFormat`；后续重复日志不能掩盖任一 call site 或参数 mutation。
 2. Behavior 2 → `writeFile` 文本包含 `50% of total`，断言错误文本逐字相同；恢复动态 format 时失败。
 3. Behavior 3 → 分别输入 3 段、10 段和 11 段，断言全保留或准确截断；恢复 `len-1` 时失败。
 4. Behavior 4 → 并发循环调用五组 setter 与 getter，在 `-race` 下运行；去掉任一同步域时 race detector 报告。
@@ -39,7 +39,7 @@
 6. Behavior 6 → 覆盖 `grpc://127.0.0.1:9000`、`127.0.0.1:9000` 与 unix path，并让 scheme endpoint 成功生成 peer attributes。
 7. Behavior 7 → 解析 `A { B { C {} enum D {} } }`，断言 keys 含 `A/AB/ABC/ABD` 且不含 `BAC/BAD`。
 8. Behavior 8 → 覆盖 `net.ParseIP("192.168.2.3")` 得 515，以及 nil/短 slice/IPv6 error；恢复直接索引时值错或 panic。
-9. Behavior 9 → AEAD round-trip、随机 nonce、wrong-key 与逐区域 bit-flip 均验证；page token bit-flip 必须 `ErrInvalidToken`，旧 CBC token control 必须被拒绝。
+9. Behavior 9 → AEAD round-trip、随机 nonce、wrong-key、合法 base64 的空/短 nonce/短 tag/截断 payload 与逐区域 bit-flip 均验证；所有 malformed payload 统一返回 `ErrDecryptionFailed` 且不 panic，page token bit-flip 必须 `ErrInvalidToken`，旧 CBC token control 必须被拒绝。
 
 ## Verification
 
@@ -50,4 +50,4 @@ GOTOOLCHAIN=go1.20.14 go vet ./watching ./errors ./trace ./parser/parse_pb ./gen
 git diff --check
 ```
 
-每组回归先在旧实现记录 red，再做最小修复；至少对日志 format、trim、setter lock、gRPC code、scheme target、nested prefix、IP normalization 与 AEAD tamper 各做一次恢复式 mutation，并在失败后恢复最终实现。
+每组回归先在旧实现记录 red，再做最小修复；至少逐一 mutation 五个 dump call site 及其字段，并对 trim、setter lock、gRPC code、scheme target、nested prefix、IP normalization、AEAD tamper 与 GCM 长度 guard 做恢复式 mutation，确认失败后恢复最终实现。

--- a/specs/85/TECH.md
+++ b/specs/85/TECH.md
@@ -1,0 +1,53 @@
+# Issue 85：技术方案
+
+## Context
+
+行为来源为 [PRODUCT.md](./PRODUCT.md)。当前问题分布在 `watching/`、`errors/`、`trace/`、`parser/parse_pb/`、`generator/`、`page_token/` 与 `encrypt/aes/`，彼此没有共享状态，按行为做局部修复。
+
+## Proposed changes
+
+### A. Watching（Behavior 1–4）
+
+- 五个自动 dump 调用统一把 `UniformLogFormat` 作为 `logf` 的 format 参数。
+- `writeFile` 用普通 error 构造函数包装文本，不再把动态 pprof 文本交给格式化函数。
+- `trimResult` 仅在段数超过上限时截断；不足时 join 全部段落。
+- 所有 `Enable*Dump` / `Disable*Dump` setter 使用 `configs.L` 写锁，与 `Get*Configs` 读锁形成同一同步域；`GetGroupConfigs` 还需复制内嵌 `*typeConfig`，避免锁外读取仍指向共享配置。
+
+### B. Errors 与 trace（Behavior 5–6）
+
+- `FromError` 在 `status.FromError` 成功后，先保留现有 `ErrorInfo` detail 分支；没有该 detail 时以 `StatusFromGRPCCode(gs.Code())`、空 reason 与 `gs.Message()` 构造兼容 `Error`。
+- `parseTarget` 在 URL 含 `Host` 时返回 `u.Host`；仅 unix/path 风格使用既有去前导斜线 fallback；裸 endpoint 继续通过补 scheme 解析。
+
+### C. Parser 与 generator（Behavior 7–8）
+
+- 嵌套 message 与 enum 的递归 prefix 都使用 `prefix + ms.Name`。
+- `IpToUint16` 调 `To4()` 并校验结果；新增稳定 sentinel error，`LocalIpToUint16` 复用同一转换函数。
+
+### D. Page token AEAD（Behavior 9）
+
+- 在 `encrypt/aes` 新增 AES-GCM encrypt/decrypt API：随机 nonce 前置于 sealed ciphertext，base64 编码；所有 decode、key、长度与认证失败统一返回 `ErrDecryptionFailed`。
+- `page_token.ForIndex` 与 `GetIndex` 只使用新 AEAD API。由于旧 CBC token 不带认证标签，迁移后会被拒绝；这是关闭完整性漏洞的有意兼容边界。
+- 既有 CBC `Encrypt` / `Decrypt` 保持原实现和测试，避免无关调用方密文格式变化。
+
+## Behavior-to-test mapping
+
+1. Behavior 1 → watching 表驱动测试逐一触发五个 dump 日志调用或其可控 helper，断言无 `%!(EXTRA` 且字段齐全；恢复错误首参时失败。
+2. Behavior 2 → `writeFile` 文本包含 `50% of total`，断言错误文本逐字相同；恢复动态 format 时失败。
+3. Behavior 3 → 分别输入 3 段、10 段和 11 段，断言全保留或准确截断；恢复 `len-1` 时失败。
+4. Behavior 4 → 并发循环调用五组 setter 与 getter，在 `-race` 下运行；去掉任一同步域时 race detector 报告。
+5. Behavior 5 → 用 `status.Error(codes.NotFound, "missing")` 断言 code 404/message；带 `ErrorInfo` control 继续保留 reason/metadata。
+6. Behavior 6 → 覆盖 `grpc://127.0.0.1:9000`、`127.0.0.1:9000` 与 unix path，并让 scheme endpoint 成功生成 peer attributes。
+7. Behavior 7 → 解析 `A { B { C {} enum D {} } }`，断言 keys 含 `A/AB/ABC/ABD` 且不含 `BAC/BAD`。
+8. Behavior 8 → 覆盖 `net.ParseIP("192.168.2.3")` 得 515，以及 nil/短 slice/IPv6 error；恢复直接索引时值错或 panic。
+9. Behavior 9 → AEAD round-trip、随机 nonce、wrong-key 与逐区域 bit-flip 均验证；page token bit-flip 必须 `ErrInvalidToken`，旧 CBC token control 必须被拒绝。
+
+## Verification
+
+```bash
+gofmt -w <changed-go-files>
+GOTOOLCHAIN=go1.20.14 go test -race -count=1 ./watching ./errors ./trace ./parser/parse_pb ./generator ./encrypt/aes ./page_token
+GOTOOLCHAIN=go1.20.14 go vet ./watching ./errors ./trace ./parser/parse_pb ./generator ./encrypt/aes ./page_token
+git diff --check
+```
+
+每组回归先在旧实现记录 red，再做最小修复；至少对日志 format、trim、setter lock、gRPC code、scheme target、nested prefix、IP normalization 与 AEAD tamper 各做一次恢复式 mutation，并在失败后恢复最终实现。

--- a/trace/span.go
+++ b/trace/span.go
@@ -134,6 +134,9 @@ func parseTarget(endpoint string) (address string, err error) {
 		}
 		return u.Host, nil
 	}
+	if u.Host != "" {
+		return u.Host, nil
+	}
 	if len(u.Path) > 1 {
 		return u.Path[1:], nil
 	}

--- a/trace/span_issue85_test.go
+++ b/trace/span_issue85_test.go
@@ -1,0 +1,43 @@
+package trace
+
+import "testing"
+
+func TestParseTargetHandlesSchemeAndBareEndpoints(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+		want     string
+	}{
+		{name: "scheme", endpoint: "grpc://127.0.0.1:9000", want: "127.0.0.1:9000"},
+		{name: "bare", endpoint: "127.0.0.1:9000", want: "127.0.0.1:9000"},
+		{name: "unix path", endpoint: "unix:///tmp/gkit.sock", want: "tmp/gkit.sock"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseTarget(tt.endpoint)
+			if err != nil {
+				t.Fatalf("parseTarget(%q): %v", tt.endpoint, err)
+			}
+			if got != tt.want {
+				t.Fatalf("parseTarget(%q) = %q, want %q", tt.endpoint, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSchemeTargetProducesPeerAttributes(t *testing.T) {
+	address, err := parseTarget("grpc://127.0.0.1:9000")
+	if err != nil {
+		t.Fatal(err)
+	}
+	attrs := peerAttr(address)
+	if len(attrs) != 2 {
+		t.Fatalf("peerAttr(%q) returned %d attributes, want 2", address, len(attrs))
+	}
+	if got := attrs[0].Value.AsString(); got != "127.0.0.1" {
+		t.Fatalf("peer IP = %q, want 127.0.0.1", got)
+	}
+	if got := attrs[1].Value.AsString(); got != "9000" {
+		t.Fatalf("peer port = %q, want 9000", got)
+	}
+}

--- a/watching/config.go
+++ b/watching/config.go
@@ -261,7 +261,12 @@ func (c *configs) GetCPUConfigs() typeConfig {
 func (c *configs) GetGroupConfigs() groupConfigs {
 	c.L.RLock()
 	defer c.L.RUnlock()
-	return *c.GroupConfigs
+	config := *c.GroupConfigs
+	if c.GroupConfigs.typeConfig != nil {
+		typeConfigCopy := *c.GroupConfigs.typeConfig
+		config.typeConfig = &typeConfigCopy
+	}
+	return config
 }
 
 // GetThreadConfigs return a copy of threadConfigs

--- a/watching/issue85_test.go
+++ b/watching/issue85_test.go
@@ -1,0 +1,132 @@
+package watching
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestTriggeredDumpLogUsesUniformFormat(t *testing.T) {
+	type profileCase struct {
+		name     string
+		dumpType configureType
+		action   string
+		trigger  func(*Watching)
+	}
+	config := typeConfig{Enable: true, TriggerMin: 0, TriggerDiff: 0, TriggerAbs: 0}
+	tests := []profileCase{
+		{
+			name:     "goroutine",
+			dumpType: goroutine,
+			action:   "pprof",
+			trigger: func(w *Watching) {
+				w.goroutineProfile(1, groupConfigs{typeConfig: &config, GoroutineTriggerNumMax: 100})
+			},
+		},
+		{name: "memory", dumpType: mem, action: "pprof", trigger: func(w *Watching) { w.memProfile(1, config) }},
+		{name: "thread", dumpType: thread, action: "pprof", trigger: func(w *Watching) { w.threadProfile(1, config) }},
+		{
+			name:     "cpu",
+			dumpType: cpu,
+			action:   "pprof dump",
+			trigger: func(w *Watching) {
+				// Fail file creation after the trigger log, avoiding the real CPU
+				// sampling sleep while still exercising cpuProfile's call site.
+				w.config.DumpPath = filepath.Join(w.config.Logger.Name(), "not-a-directory")
+				w.cpuProfile(1, config)
+			},
+		},
+		{name: "gc heap", dumpType: gcHeap, action: "pprof", trigger: func(w *Watching) { w.gcHeapProfile(1, true, config) }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			logPath := filepath.Join(dir, "watching.log")
+			w := NewWatching(WithDumpPath(dir, "watching.log"), WithTextDump())
+			t.Cleanup(func() { w.setLogger(os.Stdout) })
+			tt.trigger(w)
+
+			content, err := os.ReadFile(logPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			logText := string(content)
+			if strings.Contains(logText, "%!(EXTRA") {
+				t.Fatalf("triggered dump log treated its label as a format string: %q", logText)
+			}
+			want := "[Watching] " + tt.action + " " + type2name[tt.dumpType]
+			if !strings.Contains(logText, want) {
+				t.Fatalf("triggered dump log lacks %q: %q", want, logText)
+			}
+		})
+	}
+}
+
+func TestWriteFilePreservesPercentText(t *testing.T) {
+	var profile bytes.Buffer
+	profile.WriteString("profile: 50% of total\nnext: %s is literal")
+	err := writeFile(profile, goroutine, &DumpConfigs{
+		DumpProfileType: textDump,
+		DumpFullStack:   true,
+	}, "")
+	if err == nil {
+		t.Fatal("writeFile text mode returned nil error")
+	}
+	if got, want := err.Error(), profile.String(); got != want {
+		t.Fatalf("writeFile text = %q, want literal %q", got, want)
+	}
+}
+
+func TestTrimResultKeepsAllSegmentsUpToLimit(t *testing.T) {
+	makeProfile := func(count int) string {
+		segments := make([]string, count)
+		for index := range segments {
+			segments[index] = "segment-" + string(rune('A'+index))
+		}
+		return strings.Join(segments, "\n\n")
+	}
+	for _, count := range []int{1, 3, TrimResultTopN} {
+		input := makeProfile(count)
+		var buffer bytes.Buffer
+		buffer.WriteString(input)
+		if got := trimResult(buffer); got != input {
+			t.Fatalf("trimResult(%d segments) = %q, want all %q", count, got, input)
+		}
+	}
+
+	input := makeProfile(TrimResultTopN + 1)
+	var buffer bytes.Buffer
+	buffer.WriteString(input)
+	want := strings.Join(strings.Split(input, "\n\n")[:TrimResultTopN], "\n\n")
+	if got := trimResult(buffer); got != want {
+		t.Fatalf("trimResult(over limit) = %q, want %q", got, want)
+	}
+}
+
+func TestDumpEnableSettersSynchronizeWithReaders(t *testing.T) {
+	w := NewWatching()
+	var wg sync.WaitGroup
+	for worker := 0; worker < 8; worker++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			for iteration := 0; iteration < 500; iteration++ {
+				if (worker+iteration)%2 == 0 {
+					w.EnableThreadDump().EnableGoroutineDump().EnableCPUDump().EnableMemDump().EnableGCHeapDump()
+				} else {
+					w.DisableThreadDump().DisableGoroutineDump().DisableCPUDump().DisableMemDump().DisableGCHeapDump()
+				}
+				_ = w.config.GetThreadConfigs().Enable
+				_ = w.config.GetGroupConfigs().Enable
+				_ = w.config.GetCPUConfigs().Enable
+				_ = w.config.GetMemConfigs().Enable
+				_ = w.config.GetGcHeapConfigs().Enable
+			}
+		}(worker)
+	}
+	wg.Wait()
+}

--- a/watching/issue85_test.go
+++ b/watching/issue85_test.go
@@ -2,6 +2,7 @@ package watching
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,32 +15,63 @@ func TestTriggeredDumpLogUsesUniformFormat(t *testing.T) {
 		name     string
 		dumpType configureType
 		action   string
+		max      int
+		previous func(*Watching) interface{}
 		trigger  func(*Watching)
 	}
-	config := typeConfig{Enable: true, TriggerMin: 0, TriggerDiff: 0, TriggerAbs: 0}
+	const (
+		triggerMin     = 11
+		triggerDiff    = 22
+		triggerAbs     = 33
+		previousValue  = 44
+		currentValue   = 55
+		goroutineLimit = 66
+	)
+	config := typeConfig{Enable: true, TriggerMin: triggerMin, TriggerDiff: triggerDiff, TriggerAbs: triggerAbs}
 	tests := []profileCase{
 		{
 			name:     "goroutine",
 			dumpType: goroutine,
 			action:   "pprof",
+			max:      goroutineLimit,
+			previous: func(w *Watching) interface{} { return w.grNumStats.data },
 			trigger: func(w *Watching) {
-				w.goroutineProfile(1, groupConfigs{typeConfig: &config, GoroutineTriggerNumMax: 100})
+				w.goroutineProfile(currentValue, groupConfigs{typeConfig: &config, GoroutineTriggerNumMax: goroutineLimit})
 			},
 		},
-		{name: "memory", dumpType: mem, action: "pprof", trigger: func(w *Watching) { w.memProfile(1, config) }},
-		{name: "thread", dumpType: thread, action: "pprof", trigger: func(w *Watching) { w.threadProfile(1, config) }},
+		{
+			name:     "memory",
+			dumpType: mem,
+			action:   "pprof",
+			previous: func(w *Watching) interface{} { return w.memStats.data },
+			trigger:  func(w *Watching) { w.memProfile(currentValue, config) },
+		},
+		{
+			name:     "thread",
+			dumpType: thread,
+			action:   "pprof",
+			previous: func(w *Watching) interface{} { return w.threadStats },
+			trigger:  func(w *Watching) { w.threadProfile(currentValue, config) },
+		},
 		{
 			name:     "cpu",
 			dumpType: cpu,
 			action:   "pprof dump",
+			previous: func(w *Watching) interface{} { return w.cpuStats.data },
 			trigger: func(w *Watching) {
 				// Fail file creation after the trigger log, avoiding the real CPU
 				// sampling sleep while still exercising cpuProfile's call site.
 				w.config.DumpPath = filepath.Join(w.config.Logger.Name(), "not-a-directory")
-				w.cpuProfile(1, config)
+				w.cpuProfile(currentValue, config)
 			},
 		},
-		{name: "gc heap", dumpType: gcHeap, action: "pprof", trigger: func(w *Watching) { w.gcHeapProfile(1, true, config) }},
+		{
+			name:     "gc heap",
+			dumpType: gcHeap,
+			action:   "pprof",
+			previous: func(w *Watching) interface{} { return w.gcHeapStats },
+			trigger:  func(w *Watching) { w.gcHeapProfile(currentValue, true, config) },
+		},
 	}
 
 	for _, tt := range tests {
@@ -48,19 +80,46 @@ func TestTriggeredDumpLogUsesUniformFormat(t *testing.T) {
 			logPath := filepath.Join(dir, "watching.log")
 			w := NewWatching(WithDumpPath(dir, "watching.log"), WithTextDump())
 			t.Cleanup(func() { w.setLogger(os.Stdout) })
+			w.grNumStats = newRing(1)
+			w.memStats = newRing(1)
+			w.threadStats = newRing(1)
+			w.cpuStats = newRing(1)
+			w.gcHeapStats = newRing(1)
+			w.grNumStats.push(previousValue)
+			w.memStats.push(previousValue)
+			w.threadStats.push(previousValue)
+			w.cpuStats.push(previousValue)
+			w.gcHeapStats.push(previousValue)
 			tt.trigger(w)
 
 			content, err := os.ReadFile(logPath)
 			if err != nil {
 				t.Fatal(err)
 			}
-			logText := string(content)
-			if strings.Contains(logText, "%!(EXTRA") {
-				t.Fatalf("triggered dump log treated its label as a format string: %q", logText)
+			logText := strings.TrimSpace(string(content))
+			if logText == "" {
+				t.Fatal("triggered dump emitted no log lines")
 			}
-			want := "[Watching] " + tt.action + " " + type2name[tt.dumpType]
-			if !strings.Contains(logText, want) {
-				t.Fatalf("triggered dump log lacks %q: %q", want, logText)
+			lines := strings.Split(logText, "\n")
+			first := lines[0]
+			start := strings.Index(first, "[Watching]")
+			if start == -1 {
+				t.Fatalf("first trigger log has no UniformLogFormat payload: %q", first)
+			}
+			first = first[start:]
+			want := fmt.Sprintf(
+				UniformLogFormat,
+				tt.action,
+				type2name[tt.dumpType],
+				triggerMin,
+				triggerDiff,
+				triggerAbs,
+				tt.max,
+				tt.previous(w),
+				currentValue,
+			)
+			if first != want {
+				t.Fatalf("first trigger log = %q, want %q; later duplicate logs must not satisfy this assertion", first, want)
 			}
 		})
 	}

--- a/watching/util.go
+++ b/watching/util.go
@@ -2,6 +2,7 @@ package watching
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"math"
@@ -46,11 +47,10 @@ func readUint(path string) (uint64, error) {
 
 // only reserve the top n.
 func trimResult(buffer bytes.Buffer) string {
-	index := TrimResultTopN
 	arr := strings.SplitN(buffer.String(), "\n\n", TrimResultTopN+1)
-
-	if len(arr) <= TrimResultTopN {
-		index = len(arr) - 1
+	index := len(arr)
+	if index > TrimResultTopN {
+		index = TrimResultTopN
 	}
 
 	return strings.Join(arr[:index], "\n\n")
@@ -192,9 +192,9 @@ func writeFile(data bytes.Buffer, dumpType configureType, dumpConfigs *DumpConfi
 		// write to log
 		if dumpConfigs.DumpFullStack {
 			res := trimResult(data)
-			return fmt.Errorf(res) // nolint:goerr113
+			return errors.New(res) // nolint:goerr113
 		}
-		return fmt.Errorf(data.String())
+		return errors.New(data.String())
 	}
 
 	bf, _, err := getBinaryFileNameAndCreate(dumpConfigs.DumpPath, dumpType, eventID) // nolint:gosec

--- a/watching/watching.go
+++ b/watching/watching.go
@@ -67,61 +67,58 @@ type rptEvent struct {
 
 // EnableThreadDump enables the goroutine dump.
 func (w *Watching) EnableThreadDump() *Watching {
-	w.config.ThreadConfigs.Enable = true
-	return w
+	return w.setDumpEnabled(w.config.ThreadConfigs, true)
 }
 
 // DisableThreadDump disables the goroutine dump.
 func (w *Watching) DisableThreadDump() *Watching {
-	w.config.ThreadConfigs.Enable = false
-	return w
+	return w.setDumpEnabled(w.config.ThreadConfigs, false)
 }
 
 // EnableGoroutineDump enables the goroutine dump.
 func (w *Watching) EnableGoroutineDump() *Watching {
-	w.config.GroupConfigs.Enable = true
-	return w
+	return w.setDumpEnabled(w.config.GroupConfigs.typeConfig, true)
 }
 
 // DisableGoroutineDump disables the goroutine dump.
 func (w *Watching) DisableGoroutineDump() *Watching {
-	w.config.GroupConfigs.Enable = false
-	return w
+	return w.setDumpEnabled(w.config.GroupConfigs.typeConfig, false)
 }
 
 // EnableCPUDump enables the CPU dump.
 func (w *Watching) EnableCPUDump() *Watching {
-	w.config.CpuConfigs.Enable = true
-	return w
+	return w.setDumpEnabled(w.config.CpuConfigs, true)
 }
 
 // DisableCPUDump disables the CPU dump.
 func (w *Watching) DisableCPUDump() *Watching {
-	w.config.CpuConfigs.Enable = false
-	return w
+	return w.setDumpEnabled(w.config.CpuConfigs, false)
 }
 
 // EnableMemDump enables the mem dump.
 func (w *Watching) EnableMemDump() *Watching {
-	w.config.MemConfigs.Enable = true
-	return w
+	return w.setDumpEnabled(w.config.MemConfigs, true)
 }
 
 // DisableMemDump disables the mem dump.
 func (w *Watching) DisableMemDump() *Watching {
-	w.config.MemConfigs.Enable = false
-	return w
+	return w.setDumpEnabled(w.config.MemConfigs, false)
 }
 
 // EnableGCHeapDump enables the GC heap dump.
 func (w *Watching) EnableGCHeapDump() *Watching {
-	w.config.GCHeapConfigs.Enable = true
-	return w
+	return w.setDumpEnabled(w.config.GCHeapConfigs, true)
 }
 
 // DisableGCHeapDump disables the GC heap dump.
 func (w *Watching) DisableGCHeapDump() *Watching {
-	w.config.GCHeapConfigs.Enable = false
+	return w.setDumpEnabled(w.config.GCHeapConfigs, false)
+}
+
+func (w *Watching) setDumpEnabled(config *typeConfig, enabled bool) *Watching {
+	w.config.L.Lock()
+	config.Enable = enabled
+	w.config.L.Unlock()
 	return w
 }
 
@@ -318,6 +315,10 @@ func (w *Watching) startReporter(ch chan rptEvent) {
 	}()
 }
 
+func (w *Watching) logDumpTrigger(action string, dumpType configureType, min, diff, abs, max int, previous interface{}, current int) {
+	w.logf(UniformLogFormat, action, type2name[dumpType], min, diff, abs, max, previous, current)
+}
+
 // goroutine start.
 func (w *Watching) goroutineCheckAndDump(gNum int) {
 	// get a copy instead of locking it
@@ -346,8 +347,7 @@ func (w *Watching) goroutineProfile(gNum int, c groupConfigs) bool {
 			c.GoroutineTriggerNumMax, w.grNumStats.data, gNum)
 		return false
 	}
-	w.logf("watching.goroutine", UniformLogFormat, "pprof", type2name[goroutine],
-		c.TriggerMin, c.TriggerDiff, c.TriggerAbs,
+	w.logDumpTrigger("pprof", goroutine, c.TriggerMin, c.TriggerDiff, c.TriggerAbs,
 		c.GoroutineTriggerNumMax, w.grNumStats.data, gNum)
 
 	var buf bytes.Buffer
@@ -388,9 +388,8 @@ func (w *Watching) memProfile(rss int, c typeConfig) bool {
 		return false
 	}
 
-	w.logf("watching.memory", UniformLogFormat, "pprof", type2name[mem],
-		c.TriggerMin, c.TriggerDiff, c.TriggerAbs, NotSupportTypeMaxConfig,
-		w.memStats.data, rss)
+	w.logDumpTrigger("pprof", mem, c.TriggerMin, c.TriggerDiff, c.TriggerAbs,
+		NotSupportTypeMaxConfig, w.memStats.data, rss)
 
 	var buf bytes.Buffer
 	_ = pprof.Lookup("heap").WriteTo(&buf, int(w.config.DumpProfileType)) // nolint: errcheck
@@ -490,8 +489,7 @@ func (w *Watching) threadProfile(curThreadNum int, c typeConfig) bool {
 		return false
 	}
 
-	w.logf("watching.thread", UniformLogFormat, "pprof", type2name[thread],
-		c.TriggerMin, c.TriggerDiff, c.TriggerAbs,
+	w.logDumpTrigger("pprof", thread, c.TriggerMin, c.TriggerDiff, c.TriggerAbs,
 		NotSupportTypeMaxConfig, w.threadStats, curThreadNum)
 
 	eventID := fmt.Sprintf("thr-%d", w.threadTriggerCount)
@@ -568,9 +566,8 @@ func (w *Watching) cpuProfile(curCPUUsage int, c typeConfig) bool {
 		return false
 	}
 
-	w.logf("watching.cpu", UniformLogFormat, "pprof dump", type2name[cpu],
-		c.TriggerMin, c.TriggerDiff, c.TriggerAbs, NotSupportTypeMaxConfig,
-		w.cpuStats.data, curCPUUsage)
+	w.logDumpTrigger("pprof dump", cpu, c.TriggerMin, c.TriggerDiff, c.TriggerAbs,
+		NotSupportTypeMaxConfig, w.cpuStats.data, curCPUUsage)
 
 	bf, binFileName, err := getBinaryFileNameAndCreate(w.config.DumpPath, cpu, "")
 	if err != nil {
@@ -689,8 +686,7 @@ func (w *Watching) gcHeapProfile(gc int, force bool, c typeConfig) bool {
 		return false
 	}
 
-	w.logf("watching.gcheap", UniformLogFormat, "pprof", type2name[gcHeap],
-		c.TriggerMin, c.TriggerDiff, c.TriggerAbs,
+	w.logDumpTrigger("pprof", gcHeap, c.TriggerMin, c.TriggerDiff, c.TriggerAbs,
 		NotSupportTypeMaxConfig, w.gcHeapStats, gc)
 	// gcTriggerCount only increased after got both two profiles
 	eventID := fmt.Sprintf("heap-%d", w.grTriggerCount)


### PR DESCRIPTION
## What

- fix all five watching dump log call sites, preserve literal pprof text, retain short trim results, and synchronize dump toggles with deep configuration snapshots
- preserve standard gRPC status codes, parse scheme endpoints for trace peers, and correct nested protobuf prefixes
- normalize IPv4 inputs and return errors for invalid addresses
- add AES-GCM helpers and move page tokens onto authenticated encryption; reject legacy unauthenticated CBC tokens
- add issue-scoped PRODUCT/TECH specs and deterministic regressions

## Why

Issue #85 identified corrupted operational logs, a live configuration race, lost protocol metadata, generated-name drift, invalid Snowflake node IDs, and an unauthenticated CBC security boundary for page tokens.

## How

Watching now routes every trigger through one uniform formatter and returns value snapshots that do not retain shared nested pointers. AES-GCM uses a fresh random nonce and authenticates the complete ciphertext before page-token plaintext is parsed. The legacy CBC API remains unchanged for compatibility, but page-token validation intentionally rejects old CBC payloads.

## Test plan

- `GOTOOLCHAIN=go1.20.14 go test -race -count=1 ./watching ./errors ./trace ./parser/parse_pb ./generator ./encrypt/aes ./page_token`
- `GOTOOLCHAIN=go1.20.14 go vet ./watching ./errors ./trace ./parser/parse_pb ./generator ./encrypt/aes ./page_token`
- focused watching race/log tests and AEAD tests repeatedly under `-race`
- independent review: 0 critical, 0 important after fixing a reviewer-found nested-config snapshot race
- 10 isolated mutations killed, including all five dump call sites, configuration locking/snapshotting, gRPC code, target/prefix/IP parsing, GCM authentication, and legacy token rejection

## Compatibility

No exported signature is removed. `EncryptGCM` / `DecryptGCM` are additive; existing CBC helpers and ciphertext remain unchanged. Existing CBC page tokens are intentionally invalidated because they have no authentication tag.

Fixes #85
