### PR TITLE
fix(zset): correct rank and level boundaries

### DIFF
--- a/internal/sys/cpu/cpu_test.go
+++ b/internal/sys/cpu/cpu_test.go
@@ -31,6 +31,8 @@ func TestStat(t *testing.T) {
 	i = GetInfo()
 
 	assert.NotZero(t, s.Usage)
-	assert.NotZero(t, i.Frequency)
+	if i.Frequency == 0 {
+		t.Skip("CPU Frequency/Quota unavailable on this platform")
+	}
 	assert.NotZero(t, i.Quota)
 }

--- a/internal/sys/cpu/psutil_issue82_test.go
+++ b/internal/sys/cpu/psutil_issue82_test.go
@@ -1,0 +1,29 @@
+package cpu
+
+import (
+	"testing"
+
+	psutil "github.com/shirou/gopsutil/cpu"
+)
+
+func TestBuildCPUInfoHandlesEmptyStats(t *testing.T) {
+	if got := buildCPUInfo(nil, 8); got != (Info{}) {
+		t.Fatalf("buildCPUInfo(nil) = %#v, want zero Info", got)
+	}
+	got := buildCPUInfo([]psutil.InfoStat{{Mhz: 2400}}, 8)
+	if got.Frequency != 2400 || got.Quota != 8 {
+		t.Fatalf("buildCPUInfo() = %#v, want frequency=2400 quota=8", got)
+	}
+}
+
+func TestPercentToUsageHandlesEmptySamples(t *testing.T) {
+	if got := percentToUsage(nil); got != 0 {
+		t.Fatalf("percentToUsage(nil) = %d, want 0", got)
+	}
+	if got := percentToUsage([]float64{}); got != 0 {
+		t.Fatalf("percentToUsage(empty) = %d, want 0", got)
+	}
+	if got := percentToUsage([]float64{12.5}); got != 125 {
+		t.Fatalf("percentToUsage(12.5) = %d, want 125", got)
+	}
+}

--- a/internal/sys/cpu/psutilcpu.go
+++ b/internal/sys/cpu/psutilcpu.go
@@ -22,24 +22,36 @@ func newPsutilCPU(interval time.Duration) (cpu *psutilCPU, err error) {
 func (ps *psutilCPU) Usage() (u uint64, err error) {
 	var percents []float64
 	percents, err = c.Percent(ps.interval, false)
-	if err == nil {
-		u = uint64(percents[0] * 10)
+	if err != nil {
+		return 0, err
 	}
+	u = percentToUsage(percents)
 	return
+}
+
+func percentToUsage(percents []float64) uint64 {
+	if len(percents) == 0 {
+		return 0
+	}
+	return uint64(percents[0] * 10)
 }
 
 func (ps *psutilCPU) Info() (info Info) {
 	stats, err := c.Info()
-	if err != nil {
+	if err != nil || len(stats) == 0 {
 		return
 	}
 	cores, err := c.Counts(true)
 	if err != nil {
 		return
 	}
-	info = Info{
-		Frequency: uint64(stats[0].Mhz),
-		Quota:     float64(cores),
-	}
+	info = buildCPUInfo(stats, cores)
 	return
+}
+
+func buildCPUInfo(stats []c.InfoStat, cores int) Info {
+	if len(stats) == 0 {
+		return Info{}
+	}
+	return Info{Frequency: uint64(stats[0].Mhz), Quota: float64(cores)}
 }

--- a/specs/82/PRODUCT.md
+++ b/specs/82/PRODUCT.md
@@ -1,0 +1,17 @@
+# Issue 82：ZSet 层级与越界安全
+
+## Summary
+
+修复跳表删除后的层级维护和 rank 越界规范化，并同步 internal CPU 副本的跨平台防御，使 ZSet 不退化、不泄漏内部哨兵，平台能力缺失也不会造成 panic 或伪失败。
+
+## Behavior
+
+1. 删除节点后只收缩已经为空的跳表顶层；仍含节点的索引层保持可达，删除最后一个高层节点时空层会正确收缩。
+2. `Range` / `RevRange` 的负索引按集合长度换算：过小起点限制为首元素，换算后仍为负的终点判空，超过集合尾部的起点返回空，过大终点限制为尾元素；任何输入都不会返回 `__HEADER`。内部 `GetNodeByRank` 对非正 rank 返回 nil。
+3. `internal/sys/cpu` 在 gopsutil 返回 error 或空 slice 的平台不索引空结果；平台测试只断言可用指标，与公共 `sys/cpu` 副本保持一致。
+
+## Non-goals
+
+- 不改变 ZSet 的排序、同分值字典序或合法 rank 结果。
+- 不清理 `internal/wyhash.byteToSlice`；逃逸分析已证明其不是悬垂指针 bug。
+- 不把未被生产代码引用的 `internal/sys/cpu` 提升为新公共 API。

--- a/specs/82/TECH.md
+++ b/specs/82/TECH.md
@@ -1,0 +1,21 @@
+# Issue 82：技术方案
+
+## Proposed changes
+
+- `deleteNode` 的层高循环改为仅在 `header.next(top) == nil` 时降层。
+- `GetNodeByRank(rank <= 0)` 直接返回 nil；Range/RevRange 在取节点前完成负索引换算、起终点边界与空范围判断。
+- 将公共 `sys/cpu` 已有的空 slice guard 与平台能力测试策略同步到 `internal/sys/cpu`。
+
+## Tests
+
+1. 手工构造确定性的两层跳表，删除一个两层节点后仍有高层节点，断言 `highestLevel` 和 top link 保留；再删除最后高层节点断言正确收缩。恢复反条件时第一步失败。
+2. 三元素集合覆盖 `Range(-4,-1)`、`Range(0,-4)` 及其反向版本、超大 stop、空集合与 direct rank 0，断言无 header 且换算后仍为负的 stop 判空。
+3. internal CPU 的 Usage/Info 空 slice 路径通过防御性 helper 覆盖，现有 `TestStat` 在指标不可用时跳过相应断言。
+
+## Verification
+
+```bash
+GOTOOLCHAIN=go1.20.14 go test -race -count=1 ./structure/zset ./internal/sys/cpu
+GOTOOLCHAIN=go1.20.14 go vet ./structure/zset ./internal/sys/cpu
+git diff --check
+```

--- a/structure/zset/issue82_test.go
+++ b/structure/zset/issue82_test.go
@@ -1,0 +1,68 @@
+package zset
+
+import "testing"
+
+func TestDeleteNodePreservesNonEmptyTopLevel(t *testing.T) {
+	list := newFloat64List()
+	first := newFloat64ListNode(1, "first", 2)
+	second := newFloat64ListNode(2, "second", 2)
+
+	list.header.storeNextAndSpan(0, first, 1)
+	list.header.storeNextAndSpan(1, first, 1)
+	first.storeNextAndSpan(0, second, 1)
+	first.storeNextAndSpan(1, second, 1)
+	second.prev = first
+	list.tail = second
+	list.length = 2
+	list.highestLevel = 2
+
+	var update [maxLevel]*float64ListNode
+	update[0] = list.header
+	update[1] = list.header
+	list.deleteNode(first, &update)
+
+	if list.highestLevel != 2 {
+		t.Fatalf("highestLevel after deleting first = %d, want 2", list.highestLevel)
+	}
+	if got := list.header.loadNext(1); got != second {
+		t.Fatalf("top-level link = %p, want remaining node %p", got, second)
+	}
+
+	list.deleteNode(second, &update)
+	if list.highestLevel != 1 {
+		t.Fatalf("highestLevel after deleting final top node = %d, want 1", list.highestLevel)
+	}
+}
+
+func TestRangeBoundariesNeverExposeHeader(t *testing.T) {
+	set := NewFloat64()
+	set.Add(1, "a")
+	set.Add(2, "b")
+	set.Add(3, "c")
+
+	assertValues := func(name string, got []Float64Node, want ...string) {
+		t.Helper()
+		if len(got) != len(want) {
+			t.Fatalf("%s length = %d (%#v), want %d", name, len(got), got, len(want))
+		}
+		for index := range want {
+			if got[index].Value != want[index] {
+				t.Fatalf("%s[%d] = %q, want %q", name, index, got[index].Value, want[index])
+			}
+			if got[index].Value == "__HEADER" {
+				t.Fatalf("%s exposed the header sentinel", name)
+			}
+		}
+	}
+
+	assertValues("Range(-4,-1)", set.Range(-4, -1), "a", "b", "c")
+	assertValues("Range(0,-4)", set.Range(0, -4))
+	assertValues("Range(0,99)", set.Range(0, 99), "a", "b", "c")
+	assertValues("Range(3,3)", set.Range(3, 3))
+	assertValues("RevRange(-4,-1)", set.RevRange(-4, -1), "c", "b", "a")
+	assertValues("RevRange(0,-4)", set.RevRange(0, -4))
+	assertValues("RevRange(3,3)", set.RevRange(3, 3))
+	if node := set.list.GetNodeByRank(0); node != nil {
+		t.Fatalf("GetNodeByRank(0) = %q, want nil", node.value)
+	}
+}

--- a/structure/zset/issue82_test.go
+++ b/structure/zset/issue82_test.go
@@ -34,6 +34,36 @@ func TestDeleteNodePreservesNonEmptyTopLevel(t *testing.T) {
 	}
 }
 
+func TestDeleteNodeShrinksAllEmptyTopLevels(t *testing.T) {
+	list := newFloat64List()
+	only := newFloat64ListNode(1, "only", 4)
+	var update [maxLevel]*float64ListNode
+	for level := 0; level < 4; level++ {
+		list.header.storeNextAndSpan(level, only, 1)
+		update[level] = list.header
+	}
+	list.tail = only
+	list.length = 1
+	list.highestLevel = 4
+
+	list.deleteNode(only, &update)
+
+	if list.highestLevel != 1 {
+		t.Fatalf("highestLevel after deleting only level-4 node = %d, want 1", list.highestLevel)
+	}
+	if list.length != 0 || list.tail != nil {
+		t.Fatalf("list after final delete = length %d, tail %p; want empty", list.length, list.tail)
+	}
+	for level := 0; level < 4; level++ {
+		if next, span := list.header.loadNextAndSpan(level); next != nil || span != 0 {
+			t.Fatalf("header level %d after final delete = next %p, span %d; want nil, 0", level, next, span)
+		}
+	}
+	if node := list.GetNodeByRank(1); node != nil {
+		t.Fatalf("GetNodeByRank(1) after final delete = %q, want nil", node.value)
+	}
+}
+
 func TestRangeBoundariesNeverExposeHeader(t *testing.T) {
 	set := NewFloat64()
 	set.Add(1, "a")

--- a/structure/zset/skiplist.go
+++ b/structure/zset/skiplist.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -240,7 +240,7 @@ func (l *float64List) deleteNode(x *float64ListNode, update *[maxLevel]*float64L
 	} else {
 		l.tail = x.prev
 	}
-	for l.highestLevel > 1 && l.header.loadNext(l.highestLevel-1) != nil {
+	for l.highestLevel > 1 && l.header.loadNext(l.highestLevel-1) == nil {
 		// Clear the pointer and span for safety.
 		l.header.storeNextAndSpan(l.highestLevel-1, nil, 0)
 		l.highestLevel--
@@ -411,6 +411,9 @@ func (l *float64List) DeleteRangeByRank(start, end int, dict map[string]float64)
 
 // GetNodeByRank finds an element by its rank. The rank argument needs to be 1-based.
 func (l *float64List) GetNodeByRank(rank int) *float64ListNode {
+	if rank <= 0 {
+		return nil
+	}
 	var traversed int
 
 	x := l.header

--- a/structure/zset/zset.go
+++ b/structure/zset/zset.go
@@ -262,12 +262,9 @@ func (z *Float64Set) Range(start, stop int) []Float64Node {
 	z.mu.RLock()
 	defer z.mu.RUnlock()
 
-	// Convert negative rank to positive.
-	if start < 0 {
-		start = z.list.length + start
-	}
-	if stop < 0 {
-		stop = z.list.length + stop
+	start, stop, ok := normalizeRankRange(z.list.length, start, stop)
+	if !ok {
+		return nil
 	}
 
 	var res []Float64Node
@@ -327,12 +324,9 @@ func (z *Float64Set) RevRange(start, stop int) []Float64Node {
 	z.mu.RLock()
 	defer z.mu.RUnlock()
 
-	// Convert negative rank to positive.
-	if start < 0 {
-		start = z.list.length + start
-	}
-	if stop < 0 {
-		stop = z.list.length + stop
+	start, stop, ok := normalizeRankRange(z.list.length, start, stop)
+	if !ok {
+		return nil
 	}
 
 	var res []Float64Node
@@ -346,6 +340,28 @@ func (z *Float64Set) RevRange(start, stop int) []Float64Node {
 		x = x.prev
 	}
 	return res
+}
+
+func normalizeRankRange(length, start, stop int) (int, int, bool) {
+	if length == 0 {
+		return 0, 0, false
+	}
+	if start < 0 {
+		start += length
+	}
+	if stop < 0 {
+		stop += length
+	}
+	if start < 0 {
+		start = 0
+	}
+	if start >= length || start > stop {
+		return 0, 0, false
+	}
+	if stop >= length {
+		stop = length - 1
+	}
+	return start, stop, true
 }
 
 // RevRangeByScore returns all the elements in the sorted set with a


### PR DESCRIPTION
## What

- 修正跳表删除后的顶层收缩条件，保留仍有节点的索引层。
- 统一 Range 与 RevRange 的 Redis rank 边界语义，禁止泄漏内部 header 哨兵。
- 为 internal CPU 的空采样与平台不可用指标补充防御。
- 增加 PRODUCT/TECH 规格及确定性回归测试。

## Why

错误的层高条件会在一次删除后把跳表退化成链表；越界 rank 会把内部哨兵暴露给调用方。部分平台的 CPU 信息为空时，internal 副本还会越界或产生伪失败。

## How

- 仅在顶层 next 为空时降低 highestLevel。
- 在节点查询前规范化 start/stop；换算后仍为负的 stop 判空。
- 非正 rank 直接返回 nil。
- 通过纯 helper 防御空百分比与空 Info 样本。

## Tests

- Go 1.20.14 focused race count 20
- Go 1.20.14 full race: structure/zset, internal/sys/cpu
- go vet 与 git diff --check
- 独立 reviewer mutation：恢复错误 stop 钳位、删除空样本 guard 均被测试捕获

Fixes #82