### PR TITLE
fix(sys): harden system primitives and cgroup support

### DIFF
--- a/internal/sys/cpu/cgroup.go
+++ b/internal/sys/cpu/cgroup.go
@@ -4,32 +4,28 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"math/bits"
 	"os"
 	"path"
 	"strconv"
 	"strings"
 )
 
-// cGroupRootDir 目录位置
-const cGroupRootDir = "/sys/fs/cgroup"
-
 // cGroup LinuxCGroup
 type cGroup struct {
-	cGroupSet map[string]string
-	unified   bool
+	cGroupSet         map[string]string
+	unified           bool
+	unifiedMountPoint string
 }
 
 // CPUCFSQuotaUs 获取 cpu.cfs_quota_us 调度周期控制组被允许运行的时间
 func (c *cGroup) CPUCFSQuotaUs() (int64, error) {
 	if c.unified {
-		fields, err := c.cpuMax()
+		quota, _, err := c.cpuMax()
 		if err != nil {
 			return 0, err
 		}
-		if fields[0] == "max" {
-			return -1, nil
-		}
-		return strconv.ParseInt(fields[0], 10, 64)
+		return quota, nil
 	}
 	data, err := readFile(path.Join(c.cGroupSet["cpu"], "cpu.cfs_quota_us"))
 	if err != nil {
@@ -41,11 +37,11 @@ func (c *cGroup) CPUCFSQuotaUs() (int64, error) {
 // CPUCFSPeriodUs 获取 cpu.cfs_period_us 调度周期
 func (c *cGroup) CPUCFSPeriodUs() (uint64, error) {
 	if c.unified {
-		fields, err := c.cpuMax()
+		_, period, err := c.cpuMax()
 		if err != nil {
 			return 0, err
 		}
-		return parseUint(fields[1])
+		return period, nil
 	}
 	data, err := readFile(path.Join(c.cGroupSet["cpu"], "cpu.cfs_period_us"))
 	if err != nil {
@@ -136,18 +132,35 @@ func (c *cGroup) CPUSetCPUs() ([]uint64, error) {
 func currentcGroup() (*cGroup, error) {
 	pid := os.Getpid()
 	cgroupFile := fmt.Sprintf("/proc/%d/cgroup", pid)
-	fp, err := os.Open(cgroupFile)
+	cgroupFP, err := os.Open(cgroupFile)
 	if err != nil {
 		return nil, err
 	}
-	defer fp.Close()
-	return parseCGroup(fp, cGroupRootDir)
+	defer cgroupFP.Close()
+
+	mountInfoFile := fmt.Sprintf("/proc/%d/mountinfo", pid)
+	mountInfoFP, err := os.Open(mountInfoFile)
+	if err != nil {
+		return nil, err
+	}
+	defer mountInfoFP.Close()
+
+	return parseCGroup(cgroupFP, mountInfoFP)
 }
 
-func parseCGroup(r io.Reader, root string) (*cGroup, error) {
-	cgroupSet := make(map[string]string)
-	unified := false
-	scanner := bufio.NewScanner(r)
+type cGroupMount struct {
+	root       string
+	mountPoint string
+	fsType     string
+	options    map[string]struct{}
+}
+
+func parseCGroup(cgroupReader, mountInfoReader io.Reader) (*cGroup, error) {
+	controllerPaths := make(map[string]string)
+	var unifiedPath string
+	hasUnified := false
+	scanner := bufio.NewScanner(cgroupReader)
+	scanner.Buffer(make([]byte, 4096), 1024*1024)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" {
@@ -158,38 +171,250 @@ func parseCGroup(r io.Reader, root string) (*cGroup, error) {
 			return nil, fmt.Errorf("invalid cGroup format %s", line)
 		}
 		controllers := col[1]
+		membershipPath := path.Clean(col[2])
+		if !strings.HasPrefix(membershipPath, "/") {
+			return nil, fmt.Errorf("cgroup membership path is not absolute: %q", col[2])
+		}
 		if controllers == "" {
-			unified = true
-			dir := strings.TrimPrefix(col[2], "/")
-			cgroupSet[""] = path.Join(root, dir)
+			hasUnified = true
+			unifiedPath = membershipPath
 			continue
 		}
-		// Preserve the package's existing cgroup v1 mount mapping. Controller
-		// names and membership paths do not identify the actual v1 mountpoint;
-		// changing this requires parsing mountinfo rather than guessing from the
-		// /proc membership line.
-		cgroupSet[controllers] = path.Join(root, controllers)
 		for _, controller := range strings.Split(controllers, ",") {
-			cgroupSet[controller] = path.Join(root, controller)
+			controllerPaths[controller] = membershipPath
 		}
 	}
 	if err := scanner.Err(); err != nil {
 		return nil, fmt.Errorf("read cgroup membership: %w", err)
 	}
-	if len(cgroupSet) == 0 {
+	if len(controllerPaths) == 0 && !hasUnified {
 		return nil, fmt.Errorf("no cgroup membership found")
 	}
-	return &cGroup{cGroupSet: cgroupSet, unified: unified}, nil
-}
 
-func (c *cGroup) cpuMax() ([]string, error) {
-	data, err := readFile(path.Join(c.cGroupSet[""], "cpu.max"))
+	mounts, err := parseCGroupMounts(mountInfoReader)
 	if err != nil {
 		return nil, err
 	}
+	cgroupSet := make(map[string]string)
+	if cpuPath, ok := controllerPaths["cpu"]; ok {
+		for controller, membershipPath := range controllerPaths {
+			mappedPath, _, found := resolveCGroupPath(mounts, "cgroup", controller, membershipPath)
+			if found {
+				cgroupSet[controller] = mappedPath
+			}
+		}
+		if _, ok := cgroupSet["cpu"]; !ok {
+			return nil, fmt.Errorf("no visible cgroup v1 cpu mount contains membership %q", cpuPath)
+		}
+		return &cGroup{cGroupSet: cgroupSet}, nil
+	}
+
+	if !hasUnified {
+		return nil, fmt.Errorf("no cpu cgroup membership found")
+	}
+	mappedPath, mountPoint, found := resolveCGroupPath(mounts, "cgroup2", "", unifiedPath)
+	if !found {
+		return nil, fmt.Errorf("no visible cgroup v2 mount contains membership %q", unifiedPath)
+	}
+	cgroupSet[""] = mappedPath
+	return &cGroup{cGroupSet: cgroupSet, unified: true, unifiedMountPoint: mountPoint}, nil
+}
+
+func parseCGroupMounts(r io.Reader) ([]cGroupMount, error) {
+	var mounts []cGroupMount
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 4096), 1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		separator := -1
+		for i, field := range fields {
+			if field == "-" {
+				separator = i
+				break
+			}
+		}
+		if separator < 6 || len(fields) < separator+4 {
+			return nil, fmt.Errorf("invalid mountinfo format %q", line)
+		}
+		fsType := fields[separator+1]
+		if fsType != "cgroup" && fsType != "cgroup2" {
+			continue
+		}
+		root, err := unescapeMountInfoPath(fields[3])
+		if err != nil {
+			return nil, fmt.Errorf("invalid mountinfo root %q: %w", fields[3], err)
+		}
+		mountPoint, err := unescapeMountInfoPath(fields[4])
+		if err != nil {
+			return nil, fmt.Errorf("invalid mountinfo mount point %q: %w", fields[4], err)
+		}
+		root = path.Clean(root)
+		mountPoint = path.Clean(mountPoint)
+		if !strings.HasPrefix(root, "/") || !strings.HasPrefix(mountPoint, "/") {
+			return nil, fmt.Errorf("cgroup mount paths must be absolute: root=%q mountpoint=%q", root, mountPoint)
+		}
+		options := make(map[string]struct{})
+		for _, list := range []string{fields[5], fields[separator+3]} {
+			for _, option := range strings.Split(list, ",") {
+				options[option] = struct{}{}
+			}
+		}
+		mounts = append(mounts, cGroupMount{
+			root:       root,
+			mountPoint: mountPoint,
+			fsType:     fsType,
+			options:    options,
+		})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read mountinfo: %w", err)
+	}
+	return mounts, nil
+}
+
+func unescapeMountInfoPath(value string) (string, error) {
+	var result strings.Builder
+	result.Grow(len(value))
+	for i := 0; i < len(value); {
+		if value[i] != '\\' {
+			result.WriteByte(value[i])
+			i++
+			continue
+		}
+		if i+3 >= len(value) {
+			return "", fmt.Errorf("truncated escape")
+		}
+		var decoded byte
+		switch value[i+1 : i+4] {
+		case "040":
+			decoded = ' '
+		case "011":
+			decoded = '\t'
+		case "012":
+			decoded = '\n'
+		case "134":
+			decoded = '\\'
+		default:
+			return "", fmt.Errorf("unsupported escape %q", value[i:i+4])
+		}
+		result.WriteByte(decoded)
+		i += 4
+	}
+	return result.String(), nil
+}
+
+func resolveCGroupPath(mounts []cGroupMount, fsType, controller, membershipPath string) (string, string, bool) {
+	bestRootLength := -1
+	var bestPath, bestMountPoint string
+	for _, mount := range mounts {
+		if mount.fsType != fsType {
+			continue
+		}
+		if controller != "" {
+			if _, ok := mount.options[controller]; !ok {
+				continue
+			}
+		}
+		relative, ok := relativeCGroupPath(membershipPath, mount.root)
+		if !ok || len(mount.root) <= bestRootLength {
+			continue
+		}
+		bestRootLength = len(mount.root)
+		bestPath = mount.mountPoint
+		if relative != "" {
+			bestPath = path.Join(bestPath, relative)
+		}
+		bestMountPoint = mount.mountPoint
+	}
+	return bestPath, bestMountPoint, bestRootLength >= 0
+}
+
+func relativeCGroupPath(member, root string) (string, bool) {
+	member = path.Clean(member)
+	root = path.Clean(root)
+	if member == root {
+		return "", true
+	}
+	if root == "/" {
+		return strings.TrimPrefix(member, "/"), strings.HasPrefix(member, "/")
+	}
+	if strings.HasPrefix(member, root+"/") {
+		return strings.TrimPrefix(member, root+"/"), true
+	}
+	return "", false
+}
+
+func (c *cGroup) cpuMax() (int64, uint64, error) {
+	current := path.Clean(c.cGroupSet[""])
+	mountPoint := path.Clean(c.unifiedMountPoint)
+	if _, ok := relativeCGroupPath(current, mountPoint); !ok {
+		return 0, 0, fmt.Errorf("cgroup v2 path %q is outside mount root %q", current, mountPoint)
+	}
+
+	bestQuota := int64(-1)
+	var bestPeriod, leafPeriod uint64
+	for {
+		data, err := readFile(path.Join(current, "cpu.max"))
+		if err != nil {
+			return 0, 0, fmt.Errorf("read cgroup v2 cpu.max in %q: %w", current, err)
+		}
+		quota, period, err := parseCPUMax(data)
+		if err != nil {
+			return 0, 0, fmt.Errorf("parse cgroup v2 cpu.max in %q: %w", current, err)
+		}
+		if leafPeriod == 0 {
+			leafPeriod = period
+		}
+		if quota != -1 && (bestQuota == -1 || quotaRatioLess(quota, period, bestQuota, bestPeriod)) {
+			bestQuota = quota
+			bestPeriod = period
+		}
+		if current == mountPoint {
+			break
+		}
+		parent := path.Dir(current)
+		if parent == current {
+			return 0, 0, fmt.Errorf("cgroup v2 path %q did not reach mount root %q", c.cGroupSet[""], mountPoint)
+		}
+		current = parent
+	}
+	if bestQuota == -1 {
+		return -1, leafPeriod, nil
+	}
+	return bestQuota, bestPeriod, nil
+}
+
+func parseCPUMax(data string) (int64, uint64, error) {
 	fields := strings.Fields(data)
 	if len(fields) != 2 {
-		return nil, fmt.Errorf("invalid cgroup v2 cpu.max format %q", data)
+		return 0, 0, fmt.Errorf("invalid format %q", data)
 	}
-	return fields, nil
+	period, err := parseUint(fields[1])
+	if err != nil {
+		return 0, 0, err
+	}
+	if period == 0 {
+		return 0, 0, fmt.Errorf("period must be positive")
+	}
+	if fields[0] == "max" {
+		return -1, period, nil
+	}
+	quota, err := strconv.ParseInt(fields[0], 10, 64)
+	if err != nil {
+		return 0, 0, err
+	}
+	if quota <= 0 {
+		return 0, 0, fmt.Errorf("quota must be positive")
+	}
+	return quota, period, nil
+}
+
+func quotaRatioLess(quota int64, period uint64, otherQuota int64, otherPeriod uint64) bool {
+	leftHigh, leftLow := bits.Mul64(uint64(quota), otherPeriod)
+	rightHigh, rightLow := bits.Mul64(uint64(otherQuota), period)
+	return leftHigh < rightHigh || leftHigh == rightHigh && leftLow < rightLow
 }

--- a/internal/sys/cpu/cgroup.go
+++ b/internal/sys/cpu/cgroup.go
@@ -16,10 +16,21 @@ const cGroupRootDir = "/sys/fs/cgroup"
 // cGroup LinuxCGroup
 type cGroup struct {
 	cGroupSet map[string]string
+	unified   bool
 }
 
 // CPUCFSQuotaUs 获取 cpu.cfs_quota_us 调度周期控制组被允许运行的时间
 func (c *cGroup) CPUCFSQuotaUs() (int64, error) {
+	if c.unified {
+		fields, err := c.cpuMax()
+		if err != nil {
+			return 0, err
+		}
+		if fields[0] == "max" {
+			return -1, nil
+		}
+		return strconv.ParseInt(fields[0], 10, 64)
+	}
 	data, err := readFile(path.Join(c.cGroupSet["cpu"], "cpu.cfs_quota_us"))
 	if err != nil {
 		return 0, err
@@ -29,6 +40,13 @@ func (c *cGroup) CPUCFSQuotaUs() (int64, error) {
 
 // CPUCFSPeriodUs 获取 cpu.cfs_period_us 调度周期
 func (c *cGroup) CPUCFSPeriodUs() (uint64, error) {
+	if c.unified {
+		fields, err := c.cpuMax()
+		if err != nil {
+			return 0, err
+		}
+		return parseUint(fields[1])
+	}
 	data, err := readFile(path.Join(c.cGroupSet["cpu"], "cpu.cfs_period_us"))
 	if err != nil {
 		return 0, err
@@ -38,6 +56,27 @@ func (c *cGroup) CPUCFSPeriodUs() (uint64, error) {
 
 // CPUAcctUsage cpuacct.usage CPU使用率
 func (c *cGroup) CPUAcctUsage() (uint64, error) {
+	if c.unified {
+		data, err := readFile(path.Join(c.cGroupSet[""], "cpu.stat"))
+		if err != nil {
+			return 0, err
+		}
+		for _, line := range strings.Split(data, "\n") {
+			fields := strings.Fields(line)
+			if len(fields) != 2 || fields[0] != "usage_usec" {
+				continue
+			}
+			usage, err := parseUint(fields[1])
+			if err != nil {
+				return 0, err
+			}
+			if usage > ^uint64(0)/1000 {
+				return 0, fmt.Errorf("cgroup v2 usage_usec overflows nanoseconds: %d", usage)
+			}
+			return usage * 1000, nil
+		}
+		return 0, fmt.Errorf("cgroup v2 cpu.stat has no usage_usec")
+	}
 	data, err := readFile(path.Join(c.cGroupSet["cpuacct"], "cpuacct.usage"))
 	if err != nil {
 		return 0, err
@@ -47,6 +86,9 @@ func (c *cGroup) CPUAcctUsage() (uint64, error) {
 
 // CPUAcctUsagePerCPU cpuacct.usage_percpu cGroup中所有任务消耗的cpu时间
 func (c *cGroup) CPUAcctUsagePerCPU() ([]uint64, error) {
+	if c.unified {
+		return c.CPUSetCPUs()
+	}
 	data, err := readFile(path.Join(c.cGroupSet["cpuacct"], "cpuacct.usage_percpu"))
 	if err != nil {
 		return nil, err
@@ -66,7 +108,16 @@ func (c *cGroup) CPUAcctUsagePerCPU() ([]uint64, error) {
 
 // CPUSetCPUs cpuset.cpus 获取核心数
 func (c *cGroup) CPUSetCPUs() ([]uint64, error) {
-	data, err := readFile(path.Join(c.cGroupSet["cpuset"], "cpuset.cpus"))
+	base := c.cGroupSet["cpuset"]
+	filename := "cpuset.cpus"
+	if c.unified {
+		base = c.cGroupSet[""]
+		filename = "cpuset.cpus.effective"
+	}
+	data, err := readFile(path.Join(base, filename))
+	if c.unified && (err != nil || data == "") {
+		data, err = readFile(path.Join(base, "cpuset.cpus"))
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -85,42 +136,60 @@ func (c *cGroup) CPUSetCPUs() ([]uint64, error) {
 func currentcGroup() (*cGroup, error) {
 	pid := os.Getpid()
 	cgroupFile := fmt.Sprintf("/proc/%d/cgroup", pid)
-	cgroupSet := make(map[string]string)
 	fp, err := os.Open(cgroupFile)
 	if err != nil {
 		return nil, err
 	}
 	defer fp.Close()
-	buf := bufio.NewReader(fp)
-	for {
-		line, err := buf.ReadString('\n')
-		if err != nil {
-			if err == io.EOF {
-				break
-			}
-			return nil, err
+	return parseCGroup(fp, cGroupRootDir)
+}
+
+func parseCGroup(r io.Reader, root string) (*cGroup, error) {
+	cgroupSet := make(map[string]string)
+	unified := false
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
 		}
-		col := strings.Split(strings.TrimSpace(line), ":")
+		col := strings.SplitN(line, ":", 3)
 		if len(col) != 3 {
 			return nil, fmt.Errorf("invalid cGroup format %s", line)
 		}
-		dir := col[2]
-		// 如果dir不是 "/" 则必须在docker中
-		if dir != "/" {
-			cgroupSet[col[1]] = path.Join(cGroupRootDir, col[1])
-			if strings.Contains(col[1], ",") {
-				for _, k := range strings.Split(col[1], ",") {
-					cgroupSet[k] = path.Join(cGroupRootDir, k)
-				}
-			}
-		} else {
-			cgroupSet[col[1]] = path.Join(cGroupRootDir, col[1], col[2])
-			if strings.Contains(col[1], ",") {
-				for _, k := range strings.Split(col[1], ",") {
-					cgroupSet[k] = path.Join(cGroupRootDir, k, col[2])
-				}
-			}
+		controllers := col[1]
+		if controllers == "" {
+			unified = true
+			dir := strings.TrimPrefix(col[2], "/")
+			cgroupSet[""] = path.Join(root, dir)
+			continue
+		}
+		// Preserve the package's existing cgroup v1 mount mapping. Controller
+		// names and membership paths do not identify the actual v1 mountpoint;
+		// changing this requires parsing mountinfo rather than guessing from the
+		// /proc membership line.
+		cgroupSet[controllers] = path.Join(root, controllers)
+		for _, controller := range strings.Split(controllers, ",") {
+			cgroupSet[controller] = path.Join(root, controller)
 		}
 	}
-	return &cGroup{cGroupSet: cgroupSet}, nil
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read cgroup membership: %w", err)
+	}
+	if len(cgroupSet) == 0 {
+		return nil, fmt.Errorf("no cgroup membership found")
+	}
+	return &cGroup{cGroupSet: cgroupSet, unified: unified}, nil
+}
+
+func (c *cGroup) cpuMax() ([]string, error) {
+	data, err := readFile(path.Join(c.cGroupSet[""], "cpu.max"))
+	if err != nil {
+		return nil, err
+	}
+	fields := strings.Fields(data)
+	if len(fields) != 2 {
+		return nil, fmt.Errorf("invalid cgroup v2 cpu.max format %q", data)
+	}
+	return fields, nil
 }

--- a/internal/sys/cpu/cgroup_issue81_test.go
+++ b/internal/sys/cpu/cgroup_issue81_test.go
@@ -1,0 +1,108 @@
+package cpu
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeIssue81CGroupFile(t *testing.T, name, data string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(name), 0755); err != nil {
+		t.Fatalf("create cgroup fixture directory: %v", err)
+	}
+	if err := os.WriteFile(name, []byte(data), 0644); err != nil {
+		t.Fatalf("write cgroup fixture %s: %v", name, err)
+	}
+}
+
+func TestIssue81ParseCGroupV2(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "tenant.slice")
+	writeIssue81CGroupFile(t, filepath.Join(dir, "cpu.max"), "250000 100000\n")
+	writeIssue81CGroupFile(t, filepath.Join(dir, "cpu.stat"), "user_usec 100\nusage_usec 123456\nsystem_usec 200\n")
+	writeIssue81CGroupFile(t, filepath.Join(dir, "cpuset.cpus.effective"), "\n")
+	writeIssue81CGroupFile(t, filepath.Join(dir, "cpuset.cpus"), "1-2,4\n")
+
+	cg, err := parseCGroup(strings.NewReader("0::/tenant.slice\n"), root)
+	if err != nil {
+		t.Fatalf("parse v2 cgroup: %v", err)
+	}
+	if !cg.unified {
+		t.Fatal("v2 cgroup was not marked unified")
+	}
+	if got, err := cg.CPUCFSQuotaUs(); err != nil || got != 250000 {
+		t.Fatalf("v2 quota = %d, %v; want 250000, nil", got, err)
+	}
+	if got, err := cg.CPUCFSPeriodUs(); err != nil || got != 100000 {
+		t.Fatalf("v2 period = %d, %v; want 100000, nil", got, err)
+	}
+	if got, err := cg.CPUAcctUsage(); err != nil || got != 123456000 {
+		t.Fatalf("v2 usage = %d, %v; want 123456000, nil", got, err)
+	}
+	if got, err := cg.CPUSetCPUs(); err != nil || len(got) != 3 {
+		t.Fatalf("v2 cpuset = %v, %v; want three fallback CPUs", got, err)
+	}
+	writeIssue81CGroupFile(t, filepath.Join(dir, "cpuset.cpus.effective"), "0,3\n")
+	if got, err := cg.CPUSetCPUs(); err != nil || !containsIssue81CPU(got, 0) || !containsIssue81CPU(got, 3) || len(got) != 2 {
+		t.Fatalf("v2 effective cpuset = %v, %v; want CPUs 0 and 3", got, err)
+	}
+
+	writeIssue81CGroupFile(t, filepath.Join(dir, "cpu.max"), "max 100000\n")
+	if got, err := cg.CPUCFSQuotaUs(); err != nil || got != -1 {
+		t.Fatalf("unlimited v2 quota = %d, %v; want -1, nil", got, err)
+	}
+}
+
+func containsIssue81CPU(cpus []uint64, want uint64) bool {
+	for _, cpu := range cpus {
+		if cpu == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestIssue81ParseCGroupV1Paths(t *testing.T) {
+	root := t.TempDir()
+	cg, err := parseCGroup(strings.NewReader("2:cpuacct,cpu:/scope\n3:cpuset:/scope\n"), root)
+	if err != nil {
+		t.Fatalf("parse v1 cgroup: %v", err)
+	}
+	wantCPU := filepath.Join(root, "cpu")
+	if got := cg.cGroupSet["cpu"]; got != wantCPU {
+		t.Fatalf("v1 cpu path = %q, want %q", got, wantCPU)
+	}
+	wantCPUAcct := filepath.Join(root, "cpuacct")
+	if got := cg.cGroupSet["cpuacct"]; got != wantCPUAcct {
+		t.Fatalf("v1 cpuacct path = %q, want %q", got, wantCPUAcct)
+	}
+	wantCPUSet := filepath.Join(root, "cpuset")
+	if got := cg.cGroupSet["cpuset"]; got != wantCPUSet {
+		t.Fatalf("v1 cpuset path = %q, want %q", got, wantCPUSet)
+	}
+}
+
+func TestIssue81CalculateCGroupCPUUsageGuards(t *testing.T) {
+	tests := []struct {
+		name                     string
+		total, preTotal          uint64
+		system, preSystem, cores uint64
+		quota                    float64
+		want                     uint64
+	}{
+		{name: "normal", total: 1200, preTotal: 1000, system: 3000, preSystem: 2000, cores: 4, quota: 2, want: 400},
+		{name: "zero quota", total: 1200, preTotal: 1000, system: 3000, preSystem: 2000, cores: 4, quota: 0, want: 0},
+		{name: "unchanged system", total: 1200, preTotal: 1000, system: 2000, preSystem: 2000, cores: 4, quota: 2, want: 0},
+		{name: "reset system", total: 1200, preTotal: 1000, system: 1999, preSystem: 2000, cores: 4, quota: 2, want: 0},
+		{name: "reset total", total: 999, preTotal: 1000, system: 3000, preSystem: 2000, cores: 4, quota: 2, want: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := calculateCGroupCPUUsage(tt.total, tt.preTotal, tt.system, tt.preSystem, tt.cores, tt.quota); got != tt.want {
+				t.Fatalf("usage = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/sys/cpu/cgroup_issue81_test.go
+++ b/internal/sys/cpu/cgroup_issue81_test.go
@@ -1,6 +1,7 @@
 package cpu
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -17,15 +18,31 @@ func writeIssue81CGroupFile(t *testing.T, name, data string) {
 	}
 }
 
+func issue81EscapeMountInfoPath(name string) string {
+	return strings.NewReplacer(
+		"\\", "\\134",
+		" ", "\\040",
+		"\t", "\\011",
+		"\n", "\\012",
+	).Replace(name)
+}
+
+func issue81MountInfoLine(id int, root, mountPoint, fsType, options string) string {
+	return fmt.Sprintf("%d 1 0:%d %s %s rw,nosuid,nodev,noexec - %s cgroup %s\n",
+		id, id, issue81EscapeMountInfoPath(root), issue81EscapeMountInfoPath(mountPoint), fsType, options)
+}
+
 func TestIssue81ParseCGroupV2(t *testing.T) {
 	root := t.TempDir()
 	dir := filepath.Join(root, "tenant.slice")
+	writeIssue81CGroupFile(t, filepath.Join(root, "cpu.max"), "max 100000\n")
 	writeIssue81CGroupFile(t, filepath.Join(dir, "cpu.max"), "250000 100000\n")
 	writeIssue81CGroupFile(t, filepath.Join(dir, "cpu.stat"), "user_usec 100\nusage_usec 123456\nsystem_usec 200\n")
 	writeIssue81CGroupFile(t, filepath.Join(dir, "cpuset.cpus.effective"), "\n")
 	writeIssue81CGroupFile(t, filepath.Join(dir, "cpuset.cpus"), "1-2,4\n")
 
-	cg, err := parseCGroup(strings.NewReader("0::/tenant.slice\n"), root)
+	mountInfo := issue81MountInfoLine(21, "/", root, "cgroup2", "rw")
+	cg, err := parseCGroup(strings.NewReader("0::/tenant.slice\n"), strings.NewReader(mountInfo))
 	if err != nil {
 		t.Fatalf("parse v2 cgroup: %v", err)
 	}
@@ -66,21 +83,144 @@ func containsIssue81CPU(cpus []uint64, want uint64) bool {
 
 func TestIssue81ParseCGroupV1Paths(t *testing.T) {
 	root := t.TempDir()
-	cg, err := parseCGroup(strings.NewReader("2:cpuacct,cpu:/scope\n3:cpuset:/scope\n"), root)
+	cpuMount := filepath.Join(root, "cpu-bind")
+	cpusetMount := filepath.Join(root, "cpuset")
+	mountInfo := issue81MountInfoLine(31, "/docker/containers", cpuMount, "cgroup", "rw,cpu,cpuacct") +
+		issue81MountInfoLine(32, "/", cpusetMount, "cgroup", "rw,cpuset")
+	cg, err := parseCGroup(
+		strings.NewReader("2:cpuacct,cpu:/docker/containers/scope\n3:cpuset:/scope\n"),
+		strings.NewReader(mountInfo),
+	)
 	if err != nil {
 		t.Fatalf("parse v1 cgroup: %v", err)
 	}
-	wantCPU := filepath.Join(root, "cpu")
+	wantCPU := filepath.Join(cpuMount, "scope")
 	if got := cg.cGroupSet["cpu"]; got != wantCPU {
 		t.Fatalf("v1 cpu path = %q, want %q", got, wantCPU)
 	}
-	wantCPUAcct := filepath.Join(root, "cpuacct")
+	wantCPUAcct := filepath.Join(cpuMount, "scope")
 	if got := cg.cGroupSet["cpuacct"]; got != wantCPUAcct {
 		t.Fatalf("v1 cpuacct path = %q, want %q", got, wantCPUAcct)
 	}
-	wantCPUSet := filepath.Join(root, "cpuset")
+	wantCPUSet := filepath.Join(cpusetMount, "scope")
 	if got := cg.cGroupSet["cpuset"]; got != wantCPUSet {
 		t.Fatalf("v1 cpuset path = %q, want %q", got, wantCPUSet)
+	}
+}
+
+func TestIssue81HybridUsesV1CPUController(t *testing.T) {
+	root := t.TempDir()
+	v1Mount := filepath.Join(root, "v1-cpu")
+	v2Mount := filepath.Join(root, "unified")
+	v1CPU := filepath.Join(v1Mount, "v1.scope")
+	writeIssue81CGroupFile(t, filepath.Join(v1CPU, "cpu.cfs_quota_us"), "100000\n")
+	writeIssue81CGroupFile(t, filepath.Join(v1CPU, "cpu.cfs_period_us"), "100000\n")
+	writeIssue81CGroupFile(t, filepath.Join(v2Mount, "v2.scope", "cpu.max"), "900000 100000\n")
+
+	mountInfo := issue81MountInfoLine(41, "/", v2Mount, "cgroup2", "rw") +
+		issue81MountInfoLine(42, "/", v1Mount, "cgroup", "rw,cpu,cpuacct")
+	cg, err := parseCGroup(
+		strings.NewReader("0::/v2.scope\n2:cpu,cpuacct:/v1.scope\n"),
+		strings.NewReader(mountInfo),
+	)
+	if err != nil {
+		t.Fatalf("parse hybrid cgroup: %v", err)
+	}
+	if cg.unified {
+		t.Fatal("hybrid cgroup used unified hierarchy despite a v1 cpu membership")
+	}
+	if got, err := cg.CPUCFSQuotaUs(); err != nil || got != 100000 {
+		t.Fatalf("hybrid quota = %d, %v; want v1 quota 100000, nil", got, err)
+	}
+}
+
+func TestIssue81HybridDoesNotFallbackFromHiddenV1CPU(t *testing.T) {
+	v2Mount := t.TempDir()
+	mountInfo := issue81MountInfoLine(43, "/", v2Mount, "cgroup2", "rw")
+	_, err := parseCGroup(
+		strings.NewReader("0::/v2.scope\n2:cpu,cpuacct:/v1.scope\n"),
+		strings.NewReader(mountInfo),
+	)
+	if err == nil {
+		t.Fatal("hidden v1 cpu hierarchy silently fell back to cgroup v2")
+	}
+}
+
+func TestIssue81V2QuotaIncludesFiniteParent(t *testing.T) {
+	outer := t.TempDir()
+	root := filepath.Join(outer, "visible-root")
+	parent := filepath.Join(root, "tenant.slice")
+	child := filepath.Join(parent, "workload.scope")
+	writeIssue81CGroupFile(t, filepath.Join(outer, "cpu.max"), "1 100000\n")
+	writeIssue81CGroupFile(t, filepath.Join(root, "cpu.max"), "100000 25000\n")
+	writeIssue81CGroupFile(t, filepath.Join(parent, "cpu.max"), "150000 100000\n")
+	writeIssue81CGroupFile(t, filepath.Join(child, "cpu.max"), "max 100000\n")
+
+	mountInfo := issue81MountInfoLine(51, "/", root, "cgroup2", "rw")
+	cg, err := parseCGroup(
+		strings.NewReader("0::/tenant.slice/workload.scope\n"),
+		strings.NewReader(mountInfo),
+	)
+	if err != nil {
+		t.Fatalf("parse nested v2 cgroup: %v", err)
+	}
+	if got, err := cg.CPUCFSQuotaUs(); err != nil || got != 150000 {
+		t.Fatalf("effective v2 quota = %d, %v; want parent quota 150000, nil", got, err)
+	}
+	if got, err := cg.CPUCFSPeriodUs(); err != nil || got != 100000 {
+		t.Fatalf("effective v2 period = %d, %v; want parent period 100000, nil", got, err)
+	}
+}
+
+func TestIssue81MountInfoEscapedRootAndMountPoint(t *testing.T) {
+	outer := t.TempDir()
+	mountPoint := filepath.Join(outer, "visible\tcgroup")
+	dir := filepath.Join(mountPoint, "workload scope")
+	writeIssue81CGroupFile(t, filepath.Join(mountPoint, "cpu.max"), "max 100000\n")
+	writeIssue81CGroupFile(t, filepath.Join(dir, "cpu.max"), "250000 100000\n")
+
+	mountInfo := issue81MountInfoLine(61, "/tenant root", mountPoint, "cgroup2", "rw")
+	cg, err := parseCGroup(
+		strings.NewReader("0::/tenant root/workload scope\n"),
+		strings.NewReader(mountInfo),
+	)
+	if err != nil {
+		t.Fatalf("parse escaped mountinfo: %v", err)
+	}
+	if got := cg.cGroupSet[""]; got != dir {
+		t.Fatalf("escaped mount path = %q, want %q", got, dir)
+	}
+	if got, err := cg.CPUCFSQuotaUs(); err != nil || got != 250000 {
+		t.Fatalf("escaped mount quota = %d, %v; want 250000, nil", got, err)
+	}
+}
+
+func TestIssue81MountInfoPathEscapes(t *testing.T) {
+	got, err := unescapeMountInfoPath(`/tenant\040root/tab\011line\012slash\134name`)
+	if err != nil {
+		t.Fatalf("unescape mountinfo path: %v", err)
+	}
+	want := "/tenant root/tab\tline\nslash\\name"
+	if got != want {
+		t.Fatalf("unescaped mountinfo path = %q, want %q", got, want)
+	}
+}
+
+func TestIssue81V2QuotaPropagatesMissingAncestor(t *testing.T) {
+	root := t.TempDir()
+	child := filepath.Join(root, "workload.scope")
+	writeIssue81CGroupFile(t, filepath.Join(child, "cpu.max"), "max 100000\n")
+
+	mountInfo := issue81MountInfoLine(71, "/", root, "cgroup2", "rw")
+	cg, err := parseCGroup(
+		strings.NewReader("0::/workload.scope\n"),
+		strings.NewReader(mountInfo),
+	)
+	if err != nil {
+		t.Fatalf("parse nested v2 cgroup: %v", err)
+	}
+	if _, err := cg.CPUCFSQuotaUs(); err == nil {
+		t.Fatal("missing ancestor cpu.max was silently ignored")
 	}
 }
 

--- a/internal/sys/cpu/cgroupcpu.go
+++ b/internal/sys/cpu/cgroupcpu.go
@@ -87,12 +87,17 @@ func (cpu *cGroupCPU) Usage() (u uint64, err error) {
 	if err != nil {
 		return
 	}
-	if system != cpu.preSystem {
-		u = uint64(float64((total-cpu.preTotal)*cpu.cores*1e3) / (float64(system-cpu.preSystem) * cpu.quota))
-	}
+	u = calculateCGroupCPUUsage(total, cpu.preTotal, system, cpu.preSystem, cpu.cores, cpu.quota)
 	cpu.preSystem = system
 	cpu.preTotal = total
 	return
+}
+
+func calculateCGroupCPUUsage(total, preTotal, system, preSystem, cores uint64, quota float64) uint64 {
+	if quota <= 0 || cores == 0 || total < preTotal || system <= preSystem {
+		return 0
+	}
+	return uint64(float64(total-preTotal) * float64(cores) * 1e3 / (float64(system-preSystem) * quota))
 }
 
 func (cpu *cGroupCPU) Info() Info {

--- a/internal/sys/mutex/issue81_test.go
+++ b/internal/sys/mutex/issue81_test.go
@@ -1,0 +1,125 @@
+package mutex
+
+import (
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+	"unsafe"
+)
+
+func TestIssue81MutexCountIncludesOwnerAndWaiters(t *testing.T) {
+	var m Mutex
+	m.Lock()
+	if got := m.Count(); got != 1 {
+		m.Unlock()
+		t.Fatalf("locked mutex count = %d, want 1", got)
+	}
+
+	const waiters = 2
+	started := make(chan struct{}, waiters)
+	var wg sync.WaitGroup
+	wg.Add(waiters)
+	for i := 0; i < waiters; i++ {
+		go func() {
+			started <- struct{}{}
+			m.Lock()
+			m.Unlock()
+			wg.Done()
+		}()
+	}
+	for i := 0; i < waiters; i++ {
+		<-started
+	}
+
+	got := 0
+	for i := 0; i < 10000; i++ {
+		got = m.Count()
+		if got == waiters+1 {
+			break
+		}
+		runtime.Gosched()
+	}
+	m.Unlock()
+	wg.Wait()
+	if got != waiters+1 {
+		t.Fatalf("contended mutex count = %d, want %d", got, waiters+1)
+	}
+}
+
+func TestIssue81TokenRecursiveMutexAcceptsZeroToken(t *testing.T) {
+	var m TokenRecursiveMutex
+	m.Lock(0)
+	if m.Mutex.TryLock() {
+		m.Mutex.Unlock()
+		t.Fatal("token 0 did not acquire the underlying mutex")
+	}
+
+	m.Lock(0)
+	m.Unlock(0)
+	if m.Mutex.TryLock() {
+		m.Mutex.Unlock()
+		t.Fatal("recursive token 0 unlock released the underlying mutex too early")
+	}
+
+	m.Unlock(0)
+	if !m.Mutex.TryLock() {
+		t.Fatal("final token 0 unlock did not release the underlying mutex")
+	}
+	m.Mutex.Unlock()
+}
+
+func TestIssue81TokenRecursiveMutexSerializesDifferentTokens(t *testing.T) {
+	var ownership TokenRecursiveMutex
+	ownership.Lock(7)
+	ownership.Unlock(7)
+
+	var m TokenRecursiveMutex
+	m.Lock(7)
+	m.Lock(7)
+	done := make(chan interface{}, 1)
+	go func() {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				done <- recovered
+			}
+		}()
+		m.Lock(8)
+		m.Unlock(8)
+		done <- nil
+	}()
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		state := atomic.LoadInt32((*int32)(unsafe.Pointer(&m.Mutex)))
+		if state>>mutexWaiterShift > 0 {
+			break
+		}
+		select {
+		case result := <-done:
+			t.Fatalf("token 8 completed while token 7 held the mutex: %v", result)
+		default:
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("token 8 did not queue on the underlying mutex")
+		}
+		runtime.Gosched()
+	}
+
+	m.Unlock(7)
+	select {
+	case result := <-done:
+		t.Fatalf("one recursive unlock released token 8 early: %v", result)
+	default:
+	}
+	m.Unlock(7)
+	select {
+	case result := <-done:
+		if result != nil {
+			t.Fatalf("token 8 failed after final release: %v", result)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("token 8 did not acquire after final release")
+	}
+}

--- a/internal/sys/mutex/mutex.go
+++ b/internal/sys/mutex/mutex.go
@@ -20,29 +20,15 @@ type Mutex struct {
 }
 
 func (m *Mutex) TryLock() bool {
-	// 如果能成功抢到锁
-	if atomic.CompareAndSwapInt32((*int32)(unsafe.Pointer(&m.Mutex)), 0, mutexLocked) {
-		return true
-	}
-
-	// 如果处于唤醒、加锁或者饥饿状态，这次请求就不参与竞争了，返回false
-	old := atomic.LoadInt32((*int32)(unsafe.Pointer(&m.Mutex)))
-	if old&(mutexLocked|mutexStarving|mutexWoken) != 0 {
-		return false
-	}
-
-	// 尝试在竞争的状态下请求锁
-	_new := old | mutexLocked
-	return atomic.CompareAndSwapInt32((*int32)(unsafe.Pointer(&m.Mutex)), old, _new)
+	return m.Mutex.TryLock()
 }
 
 // Count 指标信息 获取等待锁的数量
 func (m *Mutex) Count() int {
 	// 获取state字段的值
 	v := atomic.LoadInt32((*int32)(unsafe.Pointer(&m.Mutex)))
-	v = v >> mutexWaiterShift // 得到等待者的数值
-	v = v + (v & mutexLocked) // 再加上锁持有者的数量，0或者1
-	return int(v)
+	waiters := v >> mutexWaiterShift
+	return int(waiters + v&mutexLocked)
 }
 
 // IsLocked 锁是否被持有

--- a/internal/sys/mutex/recursive_mutex_token.go
+++ b/internal/sys/mutex/recursive_mutex_token.go
@@ -3,37 +3,49 @@ package mutex
 import (
 	"fmt"
 	"sync"
-	"sync/atomic"
 )
 
 // TokenRecursiveMutex Token方式的递归锁
 type TokenRecursiveMutex struct {
 	sync.Mutex
+	state     sync.Mutex
 	token     int64
-	recursion int32
+	recursion int64
+	held      bool
 }
 
 // Lock 请求锁，需要传入token
 func (m *TokenRecursiveMutex) Lock(token int64) {
-	if atomic.LoadInt64(&m.token) == token { // 如果传入的token和持有锁的token一致，说明是递归调用
+	m.state.Lock()
+	if m.held && m.token == token {
 		m.recursion++
+		m.state.Unlock()
 		return
 	}
-	m.Mutex.Lock() // 传入的token不一致，说明不是递归调用
-	// 抢到锁之后记录这个token
-	atomic.StoreInt64(&m.token, token)
+	m.state.Unlock()
+
+	m.Mutex.Lock()
+	m.state.Lock()
+	m.token = token
 	m.recursion = 1
+	m.held = true
+	m.state.Unlock()
 }
 
 // Unlock 释放锁
 func (m *TokenRecursiveMutex) Unlock(token int64) {
-	if atomic.LoadInt64(&m.token) != token { // 释放其它token持有的锁
-		panic(fmt.Sprintf("wrong the owner(%d): %d!", m.token, token))
+	m.state.Lock()
+	if !m.held || m.token != token {
+		owner := m.token
+		m.state.Unlock()
+		panic(fmt.Sprintf("wrong the owner(%d): %d!", owner, token))
 	}
-	m.recursion--         // 当前持有这个锁的token释放锁
-	if m.recursion != 0 { // 还没有回退到最初的递归调用
+	m.recursion--
+	if m.recursion != 0 {
+		m.state.Unlock()
 		return
 	}
-	atomic.StoreInt64(&m.token, 0) // 没有递归调用了，释放锁
+	m.held = false
+	m.state.Unlock()
 	m.Mutex.Unlock()
 }

--- a/specs/81/PRODUCT.md
+++ b/specs/81/PRODUCT.md
@@ -1,0 +1,21 @@
+# Issue 81：系统原语与 cgroup 跨平台正确性
+
+## Summary
+
+修复 mutex/token 互斥、Unicode rotation、32 位哈希编译与 cgroup v2 CPU 采样，使相同 API 在受支持架构和现代容器层级中给出一致、有限且可验证的结果。
+
+## Behavior
+
+1. 公共和 internal `Mutex.Count` 返回等待者数加当前持有者（0 或 1）；无等待者的已锁 mutex 返回 1。
+2. `TokenRecursiveMutex` 接受包括 0 在内的任意 int64 token；空闲状态与 token 值独立，token 0 首次获取底层锁、同 token 递归计数、完全释放后互斥仍正确。公共/internal 副本一致且无 race。
+3. `stringx.Rotate` 以 rune 数规范化 shift，多字节字符串与 ASCII 使用相同字符语义。
+4. `sys/stringx` 在 linux/386 可编译，并保持现有 substring 行为。
+5. `sys/xxhash3` 在 linux/386 可编译；同一输入的 64/128 位 hash 与 64 位平台结果一致，不发生 uintptr 截断。
+6. 公共和 internal CPU reader 支持 cgroup v1 与 unified cgroup v2：v2 从 `cpu.max`、`cpu.stat` 和 `cpuset.cpus.effective`（必要时回退 `cpuset.cpus`）读取 quota、usage 与 CPU set，而不是静默回退宿主机指标。
+7. cgroup CPU usage 在 quota 为零、system/usage counter 未前进或回退时返回 0，不产生 Inf 转换或 uint64 下溢；正常单调样本保持原公式。
+
+## Non-goals
+
+- 不在本次替换 `sys/syncx.Pool` 的 runtime cleanup 机制。runtime 只提供进程级单槽私有 hook，多套 linkname 实现无法安全组合；该限制作为不受支持的共存契约记录，不能用不可靠 chaining 假装修复。
+- 不承诺 `Mutex.Count` / `IsLocked` 等 unsafe 状态内省跨任意未来 Go runtime ABI。`TryLock` 可委托标准库，但状态读取仍只在项目声明的 Go 1.20 支持线与当前验证版本使用；未来移除内省需要单独 API 决策。
+- 不改变 xxhash3 算法输出或 cgroup v1 文件语义。

--- a/specs/81/PRODUCT.md
+++ b/specs/81/PRODUCT.md
@@ -11,7 +11,7 @@
 3. `stringx.Rotate` 以 rune 数规范化 shift，多字节字符串与 ASCII 使用相同字符语义。
 4. `sys/stringx` 在 linux/386 可编译，并保持现有 substring 行为。
 5. `sys/xxhash3` 在 linux/386 可编译；同一输入的 64/128 位 hash 与 64 位平台结果一致，不发生 uintptr 截断。
-6. 公共和 internal CPU reader 支持 cgroup v1 与 unified cgroup v2：v2 从 `cpu.max`、`cpu.stat` 和 `cpuset.cpus.effective`（必要时回退 `cpuset.cpus`）读取 quota、usage 与 CPU set，而不是静默回退宿主机指标。
+6. 公共和 internal CPU reader 联合 `/proc/<pid>/cgroup` 与 `mountinfo` 解析 cgroup v1/v2：membership 按 mount root 映射到真实 mountpoint（包括 bind root 与转义路径）；hybrid 中存在 v1 `cpu` membership 时选择 v1，而不因同时存在 `0::` 就误用 unified hierarchy。v2 从 `cpu.max`、`cpu.stat` 和 `cpuset.cpus.effective`（必要时回退 `cpuset.cpus`）读取指标；quota 从当前 cgroup 向可见 cgroup2 mount root 遍历，取最严格的有限 `quota/period`，`max` 不施加限制。遍历不越出 mount root，任一层 `cpu.max` 缺失、不可读或格式错误都返回错误，不能静默忽略潜在祖先限制或回退宿主机指标。
 7. cgroup CPU usage 在 quota 为零、system/usage counter 未前进或回退时返回 0，不产生 Inf 转换或 uint64 下溢；正常单调样本保持原公式。
 
 ## Non-goals

--- a/specs/81/TECH.md
+++ b/specs/81/TECH.md
@@ -14,8 +14,10 @@
 
 ### Cgroup（Behavior 6–7）
 
-- 解析 `/proc/<pid>/cgroup` 时仅为空 controller 的 unified entry 构造 v2 路径；v1 保留既有的 `root/<controller>` 映射，避免从 controller 顺序或 membership 猜测 mountpoint。
-- 把文件读取/解析拆为可用临时目录验证的纯路径逻辑：`cpu.max` 的 `max` 表示无 CFS quota；`cpu.stat` 读取 `usage_usec` 并转换为纳秒；cpuset 优先 effective。
+- 同时解析 `/proc/<pid>/cgroup` 与 `/proc/<pid>/mountinfo` 的 root、mountpoint、filesystem type、mount/super options，并解码 mountinfo 的 `\\040`、`\\011`、`\\012`、`\\134` 路径转义。membership 必须位于 mount root 内，映射结果为 `mountpoint + relative(membership, root)`；多个可见 mount 选择 root 最具体者。
+- cgroup v1 按 mount options 识别各 controller 并保留真实 membership 子路径；只要存在 v1 `cpu` membership 就使用 v1 CPU hierarchy，即使 hybrid 同时存在 unified entry。没有 v1 `cpu` 时才按 cgroup2 mount 映射 unified membership；已声明的 v1 CPU hierarchy 不可见时返回错误，不回退 v2。
+- v2 `cpu.max` 的 `max` 表示该层无 CFS quota；从当前目录遍历到映射后的 cgroup2 mountpoint（含两端），用无溢出的交叉乘法比较 `quota/period` 并返回最严格的有限配对。任何层的文件读取、权限、缺失或格式错误都直接传播，遍历不得越过 mountpoint。
+- `cpu.stat` 读取 `usage_usec` 并转换为纳秒；cpuset 优先 effective。
 - newCGroupCPU 根据层级计算 quota，Usage 除法前验证 quota 与两个 counter 单调性；公共/internal 保持字节级语义一致。
 
 ## Tests
@@ -25,15 +27,20 @@
 3. Unicode Rotate shift 大于 rune count。
 4. linux/386 stringx 编译。
 5. linux/386 xxhash3 编译，并在可用 386 runtime/container 执行固定向量与 amd64/arm64 golden 对比。
-6. 临时 cgroup v1/v2 fixture 覆盖 quota、usage、cpuset、`max` 与 fallback 文件。
+6. public/internal 对称临时 fixture 覆盖 v1 nested membership、任意 root/mountpoint 与 bind-root 映射、mountinfo 转义、hybrid 的 v1 CPU 选择、v2 child `max` + parent finite、跨 period 的最严格比值、mount 边界、祖先缺失错误，以及 quota/usage/cpuset fallback。
 7. 纯 usage 计算覆盖 quota 0、counter equal/reset 与正常样本。
 
 ## Verification
 
+PR head 重复运行 Issue 81 的确定性 CPU fixture；完整相关包 gate 同时在最新 master、PR #90 与本 PR 的 synthetic merge tree 上运行，覆盖 internal CPU 的相邻变更。
+
 ```bash
+GOTOOLCHAIN=go1.20.14 go test -race -count=20 ./sys/cpu ./internal/sys/cpu -run TestIssue81
 GOTOOLCHAIN=go1.20.14 go test -race -count=1 ./sys/mutex ./internal/sys/mutex ./sys/stringx ./sys/xxhash3 ./sys/cpu ./internal/sys/cpu
 GOTOOLCHAIN=go1.20.14 go vet ./sys/mutex ./internal/sys/mutex ./sys/stringx ./sys/xxhash3 ./sys/cpu ./internal/sys/cpu
 CGO_ENABLED=0 GOOS=linux GOARCH=386 GOTOOLCHAIN=go1.20.14 go test -c ./sys/stringx
 CGO_ENABLED=0 GOOS=linux GOARCH=386 GOTOOLCHAIN=go1.20.14 go test -c ./sys/xxhash3
+CGO_ENABLED=0 GOOS=linux GOARCH=386 GOTOOLCHAIN=go1.20.14 go test -c ./sys/cpu
+CGO_ENABLED=0 GOOS=linux GOARCH=386 GOTOOLCHAIN=go1.20.14 go test -c ./internal/sys/cpu
 git diff --check
 ```

--- a/specs/81/TECH.md
+++ b/specs/81/TECH.md
@@ -1,0 +1,39 @@
+# Issue 81：技术方案
+
+## Proposed changes
+
+### Mutex（Behavior 1–2）
+
+- 从同一个原始 mutex state 分别提取 waiter count 和 locked bit；公共/internal 同步修改。
+- TokenRecursiveMutex 用独立状态锁保护 held、token 和 recursion，不再用 token 0 表示空闲；首次 owner 与递归路径不会绕过底层锁，公共/internal 副本保持一致且无数据竞争。
+
+### String/hash 32 位（Behavior 3–5）
+
+- Rotate 用 `utf8.RuneCountInString` 取模；open-ended substring 使用 `math.MaxInt`。
+- xxhash3 所有 `length * prime64_*` 先把 length 转为 uint64。
+
+### Cgroup（Behavior 6–7）
+
+- 解析 `/proc/<pid>/cgroup` 时仅为空 controller 的 unified entry 构造 v2 路径；v1 保留既有的 `root/<controller>` 映射，避免从 controller 顺序或 membership 猜测 mountpoint。
+- 把文件读取/解析拆为可用临时目录验证的纯路径逻辑：`cpu.max` 的 `max` 表示无 CFS quota；`cpu.stat` 读取 `usage_usec` 并转换为纳秒；cpuset 优先 effective。
+- newCGroupCPU 根据层级计算 quota，Usage 除法前验证 quota 与两个 counter 单调性；公共/internal 保持字节级语义一致。
+
+## Tests
+
+1. 锁住 mutex 后 Count=1，并增加受控等待者验证 count；恢复移位后取 locked bit 时失败。
+2. token 0/非零首次锁、递归、跨 token 阻塞和完全释放；恢复零 sentinel 时 TryLock/Unlock 回归失败。
+3. Unicode Rotate shift 大于 rune count。
+4. linux/386 stringx 编译。
+5. linux/386 xxhash3 编译，并在可用 386 runtime/container 执行固定向量与 amd64/arm64 golden 对比。
+6. 临时 cgroup v1/v2 fixture 覆盖 quota、usage、cpuset、`max` 与 fallback 文件。
+7. 纯 usage 计算覆盖 quota 0、counter equal/reset 与正常样本。
+
+## Verification
+
+```bash
+GOTOOLCHAIN=go1.20.14 go test -race -count=1 ./sys/mutex ./internal/sys/mutex ./sys/stringx ./sys/xxhash3 ./sys/cpu ./internal/sys/cpu
+GOTOOLCHAIN=go1.20.14 go vet ./sys/mutex ./internal/sys/mutex ./sys/stringx ./sys/xxhash3 ./sys/cpu ./internal/sys/cpu
+CGO_ENABLED=0 GOOS=linux GOARCH=386 GOTOOLCHAIN=go1.20.14 go test -c ./sys/stringx
+CGO_ENABLED=0 GOOS=linux GOARCH=386 GOTOOLCHAIN=go1.20.14 go test -c ./sys/xxhash3
+git diff --check
+```

--- a/sys/cpu/cgroup.go
+++ b/sys/cpu/cgroup.go
@@ -4,32 +4,28 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"math/bits"
 	"os"
 	"path"
 	"strconv"
 	"strings"
 )
 
-// cGroupRootDir 目录位置
-const cGroupRootDir = "/sys/fs/cgroup"
-
 // cGroup LinuxCGroup
 type cGroup struct {
-	cGroupSet map[string]string
-	unified   bool
+	cGroupSet         map[string]string
+	unified           bool
+	unifiedMountPoint string
 }
 
 // CPUCFSQuotaUs 获取 cpu.cfs_quota_us 调度周期控制组被允许运行的时间
 func (c *cGroup) CPUCFSQuotaUs() (int64, error) {
 	if c.unified {
-		fields, err := c.cpuMax()
+		quota, _, err := c.cpuMax()
 		if err != nil {
 			return 0, err
 		}
-		if fields[0] == "max" {
-			return -1, nil
-		}
-		return strconv.ParseInt(fields[0], 10, 64)
+		return quota, nil
 	}
 	data, err := readFile(path.Join(c.cGroupSet["cpu"], "cpu.cfs_quota_us"))
 	if err != nil {
@@ -41,11 +37,11 @@ func (c *cGroup) CPUCFSQuotaUs() (int64, error) {
 // CPUCFSPeriodUs 获取 cpu.cfs_period_us 调度周期
 func (c *cGroup) CPUCFSPeriodUs() (uint64, error) {
 	if c.unified {
-		fields, err := c.cpuMax()
+		_, period, err := c.cpuMax()
 		if err != nil {
 			return 0, err
 		}
-		return parseUint(fields[1])
+		return period, nil
 	}
 	data, err := readFile(path.Join(c.cGroupSet["cpu"], "cpu.cfs_period_us"))
 	if err != nil {
@@ -136,18 +132,35 @@ func (c *cGroup) CPUSetCPUs() ([]uint64, error) {
 func currentcGroup() (*cGroup, error) {
 	pid := os.Getpid()
 	cgroupFile := fmt.Sprintf("/proc/%d/cgroup", pid)
-	fp, err := os.Open(cgroupFile)
+	cgroupFP, err := os.Open(cgroupFile)
 	if err != nil {
 		return nil, err
 	}
-	defer fp.Close()
-	return parseCGroup(fp, cGroupRootDir)
+	defer cgroupFP.Close()
+
+	mountInfoFile := fmt.Sprintf("/proc/%d/mountinfo", pid)
+	mountInfoFP, err := os.Open(mountInfoFile)
+	if err != nil {
+		return nil, err
+	}
+	defer mountInfoFP.Close()
+
+	return parseCGroup(cgroupFP, mountInfoFP)
 }
 
-func parseCGroup(r io.Reader, root string) (*cGroup, error) {
-	cgroupSet := make(map[string]string)
-	unified := false
-	scanner := bufio.NewScanner(r)
+type cGroupMount struct {
+	root       string
+	mountPoint string
+	fsType     string
+	options    map[string]struct{}
+}
+
+func parseCGroup(cgroupReader, mountInfoReader io.Reader) (*cGroup, error) {
+	controllerPaths := make(map[string]string)
+	var unifiedPath string
+	hasUnified := false
+	scanner := bufio.NewScanner(cgroupReader)
+	scanner.Buffer(make([]byte, 4096), 1024*1024)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" {
@@ -158,38 +171,250 @@ func parseCGroup(r io.Reader, root string) (*cGroup, error) {
 			return nil, fmt.Errorf("invalid cGroup format %s", line)
 		}
 		controllers := col[1]
+		membershipPath := path.Clean(col[2])
+		if !strings.HasPrefix(membershipPath, "/") {
+			return nil, fmt.Errorf("cgroup membership path is not absolute: %q", col[2])
+		}
 		if controllers == "" {
-			unified = true
-			dir := strings.TrimPrefix(col[2], "/")
-			cgroupSet[""] = path.Join(root, dir)
+			hasUnified = true
+			unifiedPath = membershipPath
 			continue
 		}
-		// Preserve the package's existing cgroup v1 mount mapping. Controller
-		// names and membership paths do not identify the actual v1 mountpoint;
-		// changing this requires parsing mountinfo rather than guessing from the
-		// /proc membership line.
-		cgroupSet[controllers] = path.Join(root, controllers)
 		for _, controller := range strings.Split(controllers, ",") {
-			cgroupSet[controller] = path.Join(root, controller)
+			controllerPaths[controller] = membershipPath
 		}
 	}
 	if err := scanner.Err(); err != nil {
 		return nil, fmt.Errorf("read cgroup membership: %w", err)
 	}
-	if len(cgroupSet) == 0 {
+	if len(controllerPaths) == 0 && !hasUnified {
 		return nil, fmt.Errorf("no cgroup membership found")
 	}
-	return &cGroup{cGroupSet: cgroupSet, unified: unified}, nil
-}
 
-func (c *cGroup) cpuMax() ([]string, error) {
-	data, err := readFile(path.Join(c.cGroupSet[""], "cpu.max"))
+	mounts, err := parseCGroupMounts(mountInfoReader)
 	if err != nil {
 		return nil, err
 	}
+	cgroupSet := make(map[string]string)
+	if cpuPath, ok := controllerPaths["cpu"]; ok {
+		for controller, membershipPath := range controllerPaths {
+			mappedPath, _, found := resolveCGroupPath(mounts, "cgroup", controller, membershipPath)
+			if found {
+				cgroupSet[controller] = mappedPath
+			}
+		}
+		if _, ok := cgroupSet["cpu"]; !ok {
+			return nil, fmt.Errorf("no visible cgroup v1 cpu mount contains membership %q", cpuPath)
+		}
+		return &cGroup{cGroupSet: cgroupSet}, nil
+	}
+
+	if !hasUnified {
+		return nil, fmt.Errorf("no cpu cgroup membership found")
+	}
+	mappedPath, mountPoint, found := resolveCGroupPath(mounts, "cgroup2", "", unifiedPath)
+	if !found {
+		return nil, fmt.Errorf("no visible cgroup v2 mount contains membership %q", unifiedPath)
+	}
+	cgroupSet[""] = mappedPath
+	return &cGroup{cGroupSet: cgroupSet, unified: true, unifiedMountPoint: mountPoint}, nil
+}
+
+func parseCGroupMounts(r io.Reader) ([]cGroupMount, error) {
+	var mounts []cGroupMount
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 4096), 1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		separator := -1
+		for i, field := range fields {
+			if field == "-" {
+				separator = i
+				break
+			}
+		}
+		if separator < 6 || len(fields) < separator+4 {
+			return nil, fmt.Errorf("invalid mountinfo format %q", line)
+		}
+		fsType := fields[separator+1]
+		if fsType != "cgroup" && fsType != "cgroup2" {
+			continue
+		}
+		root, err := unescapeMountInfoPath(fields[3])
+		if err != nil {
+			return nil, fmt.Errorf("invalid mountinfo root %q: %w", fields[3], err)
+		}
+		mountPoint, err := unescapeMountInfoPath(fields[4])
+		if err != nil {
+			return nil, fmt.Errorf("invalid mountinfo mount point %q: %w", fields[4], err)
+		}
+		root = path.Clean(root)
+		mountPoint = path.Clean(mountPoint)
+		if !strings.HasPrefix(root, "/") || !strings.HasPrefix(mountPoint, "/") {
+			return nil, fmt.Errorf("cgroup mount paths must be absolute: root=%q mountpoint=%q", root, mountPoint)
+		}
+		options := make(map[string]struct{})
+		for _, list := range []string{fields[5], fields[separator+3]} {
+			for _, option := range strings.Split(list, ",") {
+				options[option] = struct{}{}
+			}
+		}
+		mounts = append(mounts, cGroupMount{
+			root:       root,
+			mountPoint: mountPoint,
+			fsType:     fsType,
+			options:    options,
+		})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read mountinfo: %w", err)
+	}
+	return mounts, nil
+}
+
+func unescapeMountInfoPath(value string) (string, error) {
+	var result strings.Builder
+	result.Grow(len(value))
+	for i := 0; i < len(value); {
+		if value[i] != '\\' {
+			result.WriteByte(value[i])
+			i++
+			continue
+		}
+		if i+3 >= len(value) {
+			return "", fmt.Errorf("truncated escape")
+		}
+		var decoded byte
+		switch value[i+1 : i+4] {
+		case "040":
+			decoded = ' '
+		case "011":
+			decoded = '\t'
+		case "012":
+			decoded = '\n'
+		case "134":
+			decoded = '\\'
+		default:
+			return "", fmt.Errorf("unsupported escape %q", value[i:i+4])
+		}
+		result.WriteByte(decoded)
+		i += 4
+	}
+	return result.String(), nil
+}
+
+func resolveCGroupPath(mounts []cGroupMount, fsType, controller, membershipPath string) (string, string, bool) {
+	bestRootLength := -1
+	var bestPath, bestMountPoint string
+	for _, mount := range mounts {
+		if mount.fsType != fsType {
+			continue
+		}
+		if controller != "" {
+			if _, ok := mount.options[controller]; !ok {
+				continue
+			}
+		}
+		relative, ok := relativeCGroupPath(membershipPath, mount.root)
+		if !ok || len(mount.root) <= bestRootLength {
+			continue
+		}
+		bestRootLength = len(mount.root)
+		bestPath = mount.mountPoint
+		if relative != "" {
+			bestPath = path.Join(bestPath, relative)
+		}
+		bestMountPoint = mount.mountPoint
+	}
+	return bestPath, bestMountPoint, bestRootLength >= 0
+}
+
+func relativeCGroupPath(member, root string) (string, bool) {
+	member = path.Clean(member)
+	root = path.Clean(root)
+	if member == root {
+		return "", true
+	}
+	if root == "/" {
+		return strings.TrimPrefix(member, "/"), strings.HasPrefix(member, "/")
+	}
+	if strings.HasPrefix(member, root+"/") {
+		return strings.TrimPrefix(member, root+"/"), true
+	}
+	return "", false
+}
+
+func (c *cGroup) cpuMax() (int64, uint64, error) {
+	current := path.Clean(c.cGroupSet[""])
+	mountPoint := path.Clean(c.unifiedMountPoint)
+	if _, ok := relativeCGroupPath(current, mountPoint); !ok {
+		return 0, 0, fmt.Errorf("cgroup v2 path %q is outside mount root %q", current, mountPoint)
+	}
+
+	bestQuota := int64(-1)
+	var bestPeriod, leafPeriod uint64
+	for {
+		data, err := readFile(path.Join(current, "cpu.max"))
+		if err != nil {
+			return 0, 0, fmt.Errorf("read cgroup v2 cpu.max in %q: %w", current, err)
+		}
+		quota, period, err := parseCPUMax(data)
+		if err != nil {
+			return 0, 0, fmt.Errorf("parse cgroup v2 cpu.max in %q: %w", current, err)
+		}
+		if leafPeriod == 0 {
+			leafPeriod = period
+		}
+		if quota != -1 && (bestQuota == -1 || quotaRatioLess(quota, period, bestQuota, bestPeriod)) {
+			bestQuota = quota
+			bestPeriod = period
+		}
+		if current == mountPoint {
+			break
+		}
+		parent := path.Dir(current)
+		if parent == current {
+			return 0, 0, fmt.Errorf("cgroup v2 path %q did not reach mount root %q", c.cGroupSet[""], mountPoint)
+		}
+		current = parent
+	}
+	if bestQuota == -1 {
+		return -1, leafPeriod, nil
+	}
+	return bestQuota, bestPeriod, nil
+}
+
+func parseCPUMax(data string) (int64, uint64, error) {
 	fields := strings.Fields(data)
 	if len(fields) != 2 {
-		return nil, fmt.Errorf("invalid cgroup v2 cpu.max format %q", data)
+		return 0, 0, fmt.Errorf("invalid format %q", data)
 	}
-	return fields, nil
+	period, err := parseUint(fields[1])
+	if err != nil {
+		return 0, 0, err
+	}
+	if period == 0 {
+		return 0, 0, fmt.Errorf("period must be positive")
+	}
+	if fields[0] == "max" {
+		return -1, period, nil
+	}
+	quota, err := strconv.ParseInt(fields[0], 10, 64)
+	if err != nil {
+		return 0, 0, err
+	}
+	if quota <= 0 {
+		return 0, 0, fmt.Errorf("quota must be positive")
+	}
+	return quota, period, nil
+}
+
+func quotaRatioLess(quota int64, period uint64, otherQuota int64, otherPeriod uint64) bool {
+	leftHigh, leftLow := bits.Mul64(uint64(quota), otherPeriod)
+	rightHigh, rightLow := bits.Mul64(uint64(otherQuota), period)
+	return leftHigh < rightHigh || leftHigh == rightHigh && leftLow < rightLow
 }

--- a/sys/cpu/cgroup.go
+++ b/sys/cpu/cgroup.go
@@ -16,10 +16,21 @@ const cGroupRootDir = "/sys/fs/cgroup"
 // cGroup LinuxCGroup
 type cGroup struct {
 	cGroupSet map[string]string
+	unified   bool
 }
 
 // CPUCFSQuotaUs 获取 cpu.cfs_quota_us 调度周期控制组被允许运行的时间
 func (c *cGroup) CPUCFSQuotaUs() (int64, error) {
+	if c.unified {
+		fields, err := c.cpuMax()
+		if err != nil {
+			return 0, err
+		}
+		if fields[0] == "max" {
+			return -1, nil
+		}
+		return strconv.ParseInt(fields[0], 10, 64)
+	}
 	data, err := readFile(path.Join(c.cGroupSet["cpu"], "cpu.cfs_quota_us"))
 	if err != nil {
 		return 0, err
@@ -29,6 +40,13 @@ func (c *cGroup) CPUCFSQuotaUs() (int64, error) {
 
 // CPUCFSPeriodUs 获取 cpu.cfs_period_us 调度周期
 func (c *cGroup) CPUCFSPeriodUs() (uint64, error) {
+	if c.unified {
+		fields, err := c.cpuMax()
+		if err != nil {
+			return 0, err
+		}
+		return parseUint(fields[1])
+	}
 	data, err := readFile(path.Join(c.cGroupSet["cpu"], "cpu.cfs_period_us"))
 	if err != nil {
 		return 0, err
@@ -38,6 +56,27 @@ func (c *cGroup) CPUCFSPeriodUs() (uint64, error) {
 
 // CPUAcctUsage cpuacct.usage CPU使用率
 func (c *cGroup) CPUAcctUsage() (uint64, error) {
+	if c.unified {
+		data, err := readFile(path.Join(c.cGroupSet[""], "cpu.stat"))
+		if err != nil {
+			return 0, err
+		}
+		for _, line := range strings.Split(data, "\n") {
+			fields := strings.Fields(line)
+			if len(fields) != 2 || fields[0] != "usage_usec" {
+				continue
+			}
+			usage, err := parseUint(fields[1])
+			if err != nil {
+				return 0, err
+			}
+			if usage > ^uint64(0)/1000 {
+				return 0, fmt.Errorf("cgroup v2 usage_usec overflows nanoseconds: %d", usage)
+			}
+			return usage * 1000, nil
+		}
+		return 0, fmt.Errorf("cgroup v2 cpu.stat has no usage_usec")
+	}
 	data, err := readFile(path.Join(c.cGroupSet["cpuacct"], "cpuacct.usage"))
 	if err != nil {
 		return 0, err
@@ -47,6 +86,9 @@ func (c *cGroup) CPUAcctUsage() (uint64, error) {
 
 // CPUAcctUsagePerCPU cpuacct.usage_percpu cGroup中所有任务消耗的cpu时间
 func (c *cGroup) CPUAcctUsagePerCPU() ([]uint64, error) {
+	if c.unified {
+		return c.CPUSetCPUs()
+	}
 	data, err := readFile(path.Join(c.cGroupSet["cpuacct"], "cpuacct.usage_percpu"))
 	if err != nil {
 		return nil, err
@@ -66,7 +108,16 @@ func (c *cGroup) CPUAcctUsagePerCPU() ([]uint64, error) {
 
 // CPUSetCPUs cpuset.cpus 获取核心数
 func (c *cGroup) CPUSetCPUs() ([]uint64, error) {
-	data, err := readFile(path.Join(c.cGroupSet["cpuset"], "cpuset.cpus"))
+	base := c.cGroupSet["cpuset"]
+	filename := "cpuset.cpus"
+	if c.unified {
+		base = c.cGroupSet[""]
+		filename = "cpuset.cpus.effective"
+	}
+	data, err := readFile(path.Join(base, filename))
+	if c.unified && (err != nil || data == "") {
+		data, err = readFile(path.Join(base, "cpuset.cpus"))
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -85,42 +136,60 @@ func (c *cGroup) CPUSetCPUs() ([]uint64, error) {
 func currentcGroup() (*cGroup, error) {
 	pid := os.Getpid()
 	cgroupFile := fmt.Sprintf("/proc/%d/cgroup", pid)
-	cgroupSet := make(map[string]string)
 	fp, err := os.Open(cgroupFile)
 	if err != nil {
 		return nil, err
 	}
 	defer fp.Close()
-	buf := bufio.NewReader(fp)
-	for {
-		line, err := buf.ReadString('\n')
-		if err != nil {
-			if err == io.EOF {
-				break
-			}
-			return nil, err
+	return parseCGroup(fp, cGroupRootDir)
+}
+
+func parseCGroup(r io.Reader, root string) (*cGroup, error) {
+	cgroupSet := make(map[string]string)
+	unified := false
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
 		}
-		col := strings.Split(strings.TrimSpace(line), ":")
+		col := strings.SplitN(line, ":", 3)
 		if len(col) != 3 {
 			return nil, fmt.Errorf("invalid cGroup format %s", line)
 		}
-		dir := col[2]
-		// 如果dir不是 "/" 则必须在docker中
-		if dir != "/" {
-			cgroupSet[col[1]] = path.Join(cGroupRootDir, col[1])
-			if strings.Contains(col[1], ",") {
-				for _, k := range strings.Split(col[1], ",") {
-					cgroupSet[k] = path.Join(cGroupRootDir, k)
-				}
-			}
-		} else {
-			cgroupSet[col[1]] = path.Join(cGroupRootDir, col[1], col[2])
-			if strings.Contains(col[1], ",") {
-				for _, k := range strings.Split(col[1], ",") {
-					cgroupSet[k] = path.Join(cGroupRootDir, k, col[2])
-				}
-			}
+		controllers := col[1]
+		if controllers == "" {
+			unified = true
+			dir := strings.TrimPrefix(col[2], "/")
+			cgroupSet[""] = path.Join(root, dir)
+			continue
+		}
+		// Preserve the package's existing cgroup v1 mount mapping. Controller
+		// names and membership paths do not identify the actual v1 mountpoint;
+		// changing this requires parsing mountinfo rather than guessing from the
+		// /proc membership line.
+		cgroupSet[controllers] = path.Join(root, controllers)
+		for _, controller := range strings.Split(controllers, ",") {
+			cgroupSet[controller] = path.Join(root, controller)
 		}
 	}
-	return &cGroup{cGroupSet: cgroupSet}, nil
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read cgroup membership: %w", err)
+	}
+	if len(cgroupSet) == 0 {
+		return nil, fmt.Errorf("no cgroup membership found")
+	}
+	return &cGroup{cGroupSet: cgroupSet, unified: unified}, nil
+}
+
+func (c *cGroup) cpuMax() ([]string, error) {
+	data, err := readFile(path.Join(c.cGroupSet[""], "cpu.max"))
+	if err != nil {
+		return nil, err
+	}
+	fields := strings.Fields(data)
+	if len(fields) != 2 {
+		return nil, fmt.Errorf("invalid cgroup v2 cpu.max format %q", data)
+	}
+	return fields, nil
 }

--- a/sys/cpu/cgroup_issue81_test.go
+++ b/sys/cpu/cgroup_issue81_test.go
@@ -1,0 +1,134 @@
+package cpu
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func writeIssue81CGroupFile(t *testing.T, name, data string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(name), 0755); err != nil {
+		t.Fatalf("create cgroup fixture directory: %v", err)
+	}
+	if err := os.WriteFile(name, []byte(data), 0644); err != nil {
+		t.Fatalf("write cgroup fixture %s: %v", name, err)
+	}
+}
+
+func TestIssue81ParseCGroupV2(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "tenant.slice")
+	writeIssue81CGroupFile(t, filepath.Join(dir, "cpu.max"), "250000 100000\n")
+	writeIssue81CGroupFile(t, filepath.Join(dir, "cpu.stat"), "user_usec 100\nusage_usec 123456\nsystem_usec 200\n")
+	writeIssue81CGroupFile(t, filepath.Join(dir, "cpuset.cpus.effective"), "\n")
+	writeIssue81CGroupFile(t, filepath.Join(dir, "cpuset.cpus"), "1-2,4\n")
+
+	cg, err := parseCGroup(strings.NewReader("0::/tenant.slice\n"), root)
+	if err != nil {
+		t.Fatalf("parse v2 cgroup: %v", err)
+	}
+	if !cg.unified {
+		t.Fatal("v2 cgroup was not marked unified")
+	}
+	if got, err := cg.CPUCFSQuotaUs(); err != nil || got != 250000 {
+		t.Fatalf("v2 quota = %d, %v; want 250000, nil", got, err)
+	}
+	if got, err := cg.CPUCFSPeriodUs(); err != nil || got != 100000 {
+		t.Fatalf("v2 period = %d, %v; want 100000, nil", got, err)
+	}
+	if got, err := cg.CPUAcctUsage(); err != nil || got != 123456000 {
+		t.Fatalf("v2 usage = %d, %v; want 123456000, nil", got, err)
+	}
+	if got, err := cg.CPUSetCPUs(); err != nil || len(got) != 3 {
+		t.Fatalf("v2 cpuset = %v, %v; want three fallback CPUs", got, err)
+	}
+	writeIssue81CGroupFile(t, filepath.Join(dir, "cpuset.cpus.effective"), "0,3\n")
+	if got, err := cg.CPUSetCPUs(); err != nil || !containsIssue81CPU(got, 0) || !containsIssue81CPU(got, 3) || len(got) != 2 {
+		t.Fatalf("v2 effective cpuset = %v, %v; want CPUs 0 and 3", got, err)
+	}
+
+	writeIssue81CGroupFile(t, filepath.Join(dir, "cpu.max"), "max 100000\n")
+	if got, err := cg.CPUCFSQuotaUs(); err != nil || got != -1 {
+		t.Fatalf("unlimited v2 quota = %d, %v; want -1, nil", got, err)
+	}
+}
+
+func containsIssue81CPU(cpus []uint64, want uint64) bool {
+	for _, cpu := range cpus {
+		if cpu == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestIssue81ParseCGroupV1Paths(t *testing.T) {
+	root := t.TempDir()
+	cg, err := parseCGroup(strings.NewReader("2:cpuacct,cpu:/scope\n3:cpuset:/scope\n"), root)
+	if err != nil {
+		t.Fatalf("parse v1 cgroup: %v", err)
+	}
+	wantCPU := filepath.Join(root, "cpu")
+	if got := cg.cGroupSet["cpu"]; got != wantCPU {
+		t.Fatalf("v1 cpu path = %q, want %q", got, wantCPU)
+	}
+	wantCPUAcct := filepath.Join(root, "cpuacct")
+	if got := cg.cGroupSet["cpuacct"]; got != wantCPUAcct {
+		t.Fatalf("v1 cpuacct path = %q, want %q", got, wantCPUAcct)
+	}
+	wantCPUSet := filepath.Join(root, "cpuset")
+	if got := cg.cGroupSet["cpuset"]; got != wantCPUSet {
+		t.Fatalf("v1 cpuset path = %q, want %q", got, wantCPUSet)
+	}
+}
+
+func TestIssue81CurrentCGroupV2(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("requires Linux cgroup files")
+	}
+	cg, err := currentcGroup()
+	if err != nil {
+		t.Fatalf("currentCGroup: %v", err)
+	}
+	if !cg.unified {
+		t.Skip("host uses cgroup v1")
+	}
+	if _, err := cg.CPUCFSQuotaUs(); err != nil {
+		t.Fatalf("read cgroup v2 quota: %v", err)
+	}
+	if period, err := cg.CPUCFSPeriodUs(); err != nil || period == 0 {
+		t.Fatalf("read cgroup v2 period = %d, %v", period, err)
+	}
+	if _, err := cg.CPUAcctUsage(); err != nil {
+		t.Fatalf("read cgroup v2 usage: %v", err)
+	}
+	if cpus, err := cg.CPUSetCPUs(); err != nil || len(cpus) == 0 {
+		t.Fatalf("read cgroup v2 cpuset = %v, %v", cpus, err)
+	}
+}
+
+func TestIssue81CalculateCGroupCPUUsageGuards(t *testing.T) {
+	tests := []struct {
+		name                     string
+		total, preTotal          uint64
+		system, preSystem, cores uint64
+		quota                    float64
+		want                     uint64
+	}{
+		{name: "normal", total: 1200, preTotal: 1000, system: 3000, preSystem: 2000, cores: 4, quota: 2, want: 400},
+		{name: "zero quota", total: 1200, preTotal: 1000, system: 3000, preSystem: 2000, cores: 4, quota: 0, want: 0},
+		{name: "unchanged system", total: 1200, preTotal: 1000, system: 2000, preSystem: 2000, cores: 4, quota: 2, want: 0},
+		{name: "reset system", total: 1200, preTotal: 1000, system: 1999, preSystem: 2000, cores: 4, quota: 2, want: 0},
+		{name: "reset total", total: 999, preTotal: 1000, system: 3000, preSystem: 2000, cores: 4, quota: 2, want: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := calculateCGroupCPUUsage(tt.total, tt.preTotal, tt.system, tt.preSystem, tt.cores, tt.quota); got != tt.want {
+				t.Fatalf("usage = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/sys/cpu/cgroup_issue81_test.go
+++ b/sys/cpu/cgroup_issue81_test.go
@@ -1,6 +1,7 @@
 package cpu
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -18,15 +19,31 @@ func writeIssue81CGroupFile(t *testing.T, name, data string) {
 	}
 }
 
+func issue81EscapeMountInfoPath(name string) string {
+	return strings.NewReplacer(
+		"\\", "\\134",
+		" ", "\\040",
+		"\t", "\\011",
+		"\n", "\\012",
+	).Replace(name)
+}
+
+func issue81MountInfoLine(id int, root, mountPoint, fsType, options string) string {
+	return fmt.Sprintf("%d 1 0:%d %s %s rw,nosuid,nodev,noexec - %s cgroup %s\n",
+		id, id, issue81EscapeMountInfoPath(root), issue81EscapeMountInfoPath(mountPoint), fsType, options)
+}
+
 func TestIssue81ParseCGroupV2(t *testing.T) {
 	root := t.TempDir()
 	dir := filepath.Join(root, "tenant.slice")
+	writeIssue81CGroupFile(t, filepath.Join(root, "cpu.max"), "max 100000\n")
 	writeIssue81CGroupFile(t, filepath.Join(dir, "cpu.max"), "250000 100000\n")
 	writeIssue81CGroupFile(t, filepath.Join(dir, "cpu.stat"), "user_usec 100\nusage_usec 123456\nsystem_usec 200\n")
 	writeIssue81CGroupFile(t, filepath.Join(dir, "cpuset.cpus.effective"), "\n")
 	writeIssue81CGroupFile(t, filepath.Join(dir, "cpuset.cpus"), "1-2,4\n")
 
-	cg, err := parseCGroup(strings.NewReader("0::/tenant.slice\n"), root)
+	mountInfo := issue81MountInfoLine(21, "/", root, "cgroup2", "rw")
+	cg, err := parseCGroup(strings.NewReader("0::/tenant.slice\n"), strings.NewReader(mountInfo))
 	if err != nil {
 		t.Fatalf("parse v2 cgroup: %v", err)
 	}
@@ -67,21 +84,144 @@ func containsIssue81CPU(cpus []uint64, want uint64) bool {
 
 func TestIssue81ParseCGroupV1Paths(t *testing.T) {
 	root := t.TempDir()
-	cg, err := parseCGroup(strings.NewReader("2:cpuacct,cpu:/scope\n3:cpuset:/scope\n"), root)
+	cpuMount := filepath.Join(root, "cpu-bind")
+	cpusetMount := filepath.Join(root, "cpuset")
+	mountInfo := issue81MountInfoLine(31, "/docker/containers", cpuMount, "cgroup", "rw,cpu,cpuacct") +
+		issue81MountInfoLine(32, "/", cpusetMount, "cgroup", "rw,cpuset")
+	cg, err := parseCGroup(
+		strings.NewReader("2:cpuacct,cpu:/docker/containers/scope\n3:cpuset:/scope\n"),
+		strings.NewReader(mountInfo),
+	)
 	if err != nil {
 		t.Fatalf("parse v1 cgroup: %v", err)
 	}
-	wantCPU := filepath.Join(root, "cpu")
+	wantCPU := filepath.Join(cpuMount, "scope")
 	if got := cg.cGroupSet["cpu"]; got != wantCPU {
 		t.Fatalf("v1 cpu path = %q, want %q", got, wantCPU)
 	}
-	wantCPUAcct := filepath.Join(root, "cpuacct")
+	wantCPUAcct := filepath.Join(cpuMount, "scope")
 	if got := cg.cGroupSet["cpuacct"]; got != wantCPUAcct {
 		t.Fatalf("v1 cpuacct path = %q, want %q", got, wantCPUAcct)
 	}
-	wantCPUSet := filepath.Join(root, "cpuset")
+	wantCPUSet := filepath.Join(cpusetMount, "scope")
 	if got := cg.cGroupSet["cpuset"]; got != wantCPUSet {
 		t.Fatalf("v1 cpuset path = %q, want %q", got, wantCPUSet)
+	}
+}
+
+func TestIssue81HybridUsesV1CPUController(t *testing.T) {
+	root := t.TempDir()
+	v1Mount := filepath.Join(root, "v1-cpu")
+	v2Mount := filepath.Join(root, "unified")
+	v1CPU := filepath.Join(v1Mount, "v1.scope")
+	writeIssue81CGroupFile(t, filepath.Join(v1CPU, "cpu.cfs_quota_us"), "100000\n")
+	writeIssue81CGroupFile(t, filepath.Join(v1CPU, "cpu.cfs_period_us"), "100000\n")
+	writeIssue81CGroupFile(t, filepath.Join(v2Mount, "v2.scope", "cpu.max"), "900000 100000\n")
+
+	mountInfo := issue81MountInfoLine(41, "/", v2Mount, "cgroup2", "rw") +
+		issue81MountInfoLine(42, "/", v1Mount, "cgroup", "rw,cpu,cpuacct")
+	cg, err := parseCGroup(
+		strings.NewReader("0::/v2.scope\n2:cpu,cpuacct:/v1.scope\n"),
+		strings.NewReader(mountInfo),
+	)
+	if err != nil {
+		t.Fatalf("parse hybrid cgroup: %v", err)
+	}
+	if cg.unified {
+		t.Fatal("hybrid cgroup used unified hierarchy despite a v1 cpu membership")
+	}
+	if got, err := cg.CPUCFSQuotaUs(); err != nil || got != 100000 {
+		t.Fatalf("hybrid quota = %d, %v; want v1 quota 100000, nil", got, err)
+	}
+}
+
+func TestIssue81HybridDoesNotFallbackFromHiddenV1CPU(t *testing.T) {
+	v2Mount := t.TempDir()
+	mountInfo := issue81MountInfoLine(43, "/", v2Mount, "cgroup2", "rw")
+	_, err := parseCGroup(
+		strings.NewReader("0::/v2.scope\n2:cpu,cpuacct:/v1.scope\n"),
+		strings.NewReader(mountInfo),
+	)
+	if err == nil {
+		t.Fatal("hidden v1 cpu hierarchy silently fell back to cgroup v2")
+	}
+}
+
+func TestIssue81V2QuotaIncludesFiniteParent(t *testing.T) {
+	outer := t.TempDir()
+	root := filepath.Join(outer, "visible-root")
+	parent := filepath.Join(root, "tenant.slice")
+	child := filepath.Join(parent, "workload.scope")
+	writeIssue81CGroupFile(t, filepath.Join(outer, "cpu.max"), "1 100000\n")
+	writeIssue81CGroupFile(t, filepath.Join(root, "cpu.max"), "100000 25000\n")
+	writeIssue81CGroupFile(t, filepath.Join(parent, "cpu.max"), "150000 100000\n")
+	writeIssue81CGroupFile(t, filepath.Join(child, "cpu.max"), "max 100000\n")
+
+	mountInfo := issue81MountInfoLine(51, "/", root, "cgroup2", "rw")
+	cg, err := parseCGroup(
+		strings.NewReader("0::/tenant.slice/workload.scope\n"),
+		strings.NewReader(mountInfo),
+	)
+	if err != nil {
+		t.Fatalf("parse nested v2 cgroup: %v", err)
+	}
+	if got, err := cg.CPUCFSQuotaUs(); err != nil || got != 150000 {
+		t.Fatalf("effective v2 quota = %d, %v; want parent quota 150000, nil", got, err)
+	}
+	if got, err := cg.CPUCFSPeriodUs(); err != nil || got != 100000 {
+		t.Fatalf("effective v2 period = %d, %v; want parent period 100000, nil", got, err)
+	}
+}
+
+func TestIssue81MountInfoEscapedRootAndMountPoint(t *testing.T) {
+	outer := t.TempDir()
+	mountPoint := filepath.Join(outer, "visible\tcgroup")
+	dir := filepath.Join(mountPoint, "workload scope")
+	writeIssue81CGroupFile(t, filepath.Join(mountPoint, "cpu.max"), "max 100000\n")
+	writeIssue81CGroupFile(t, filepath.Join(dir, "cpu.max"), "250000 100000\n")
+
+	mountInfo := issue81MountInfoLine(61, "/tenant root", mountPoint, "cgroup2", "rw")
+	cg, err := parseCGroup(
+		strings.NewReader("0::/tenant root/workload scope\n"),
+		strings.NewReader(mountInfo),
+	)
+	if err != nil {
+		t.Fatalf("parse escaped mountinfo: %v", err)
+	}
+	if got := cg.cGroupSet[""]; got != dir {
+		t.Fatalf("escaped mount path = %q, want %q", got, dir)
+	}
+	if got, err := cg.CPUCFSQuotaUs(); err != nil || got != 250000 {
+		t.Fatalf("escaped mount quota = %d, %v; want 250000, nil", got, err)
+	}
+}
+
+func TestIssue81MountInfoPathEscapes(t *testing.T) {
+	got, err := unescapeMountInfoPath(`/tenant\040root/tab\011line\012slash\134name`)
+	if err != nil {
+		t.Fatalf("unescape mountinfo path: %v", err)
+	}
+	want := "/tenant root/tab\tline\nslash\\name"
+	if got != want {
+		t.Fatalf("unescaped mountinfo path = %q, want %q", got, want)
+	}
+}
+
+func TestIssue81V2QuotaPropagatesMissingAncestor(t *testing.T) {
+	root := t.TempDir()
+	child := filepath.Join(root, "workload.scope")
+	writeIssue81CGroupFile(t, filepath.Join(child, "cpu.max"), "max 100000\n")
+
+	mountInfo := issue81MountInfoLine(71, "/", root, "cgroup2", "rw")
+	cg, err := parseCGroup(
+		strings.NewReader("0::/workload.scope\n"),
+		strings.NewReader(mountInfo),
+	)
+	if err != nil {
+		t.Fatalf("parse nested v2 cgroup: %v", err)
+	}
+	if _, err := cg.CPUCFSQuotaUs(); err == nil {
+		t.Fatal("missing ancestor cpu.max was silently ignored")
 	}
 }
 

--- a/sys/cpu/cgroupcpu.go
+++ b/sys/cpu/cgroupcpu.go
@@ -87,12 +87,17 @@ func (cpu *cGroupCPU) Usage() (u uint64, err error) {
 	if err != nil {
 		return
 	}
-	if system != cpu.preSystem {
-		u = uint64(float64((total-cpu.preTotal)*cpu.cores*1e3) / (float64(system-cpu.preSystem) * cpu.quota))
-	}
+	u = calculateCGroupCPUUsage(total, cpu.preTotal, system, cpu.preSystem, cpu.cores, cpu.quota)
 	cpu.preSystem = system
 	cpu.preTotal = total
 	return
+}
+
+func calculateCGroupCPUUsage(total, preTotal, system, preSystem, cores uint64, quota float64) uint64 {
+	if quota <= 0 || cores == 0 || total < preTotal || system <= preSystem {
+		return 0
+	}
+	return uint64(float64(total-preTotal) * float64(cores) * 1e3 / (float64(system-preSystem) * quota))
 }
 
 func (cpu *cGroupCPU) Info() Info {

--- a/sys/mutex/issue81_test.go
+++ b/sys/mutex/issue81_test.go
@@ -1,0 +1,125 @@
+package mutex
+
+import (
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+	"unsafe"
+)
+
+func TestIssue81MutexCountIncludesOwnerAndWaiters(t *testing.T) {
+	var m Mutex
+	m.Lock()
+	if got := m.Count(); got != 1 {
+		m.Unlock()
+		t.Fatalf("locked mutex count = %d, want 1", got)
+	}
+
+	const waiters = 2
+	started := make(chan struct{}, waiters)
+	var wg sync.WaitGroup
+	wg.Add(waiters)
+	for i := 0; i < waiters; i++ {
+		go func() {
+			started <- struct{}{}
+			m.Lock()
+			m.Unlock()
+			wg.Done()
+		}()
+	}
+	for i := 0; i < waiters; i++ {
+		<-started
+	}
+
+	got := 0
+	for i := 0; i < 10000; i++ {
+		got = m.Count()
+		if got == waiters+1 {
+			break
+		}
+		runtime.Gosched()
+	}
+	m.Unlock()
+	wg.Wait()
+	if got != waiters+1 {
+		t.Fatalf("contended mutex count = %d, want %d", got, waiters+1)
+	}
+}
+
+func TestIssue81TokenRecursiveMutexAcceptsZeroToken(t *testing.T) {
+	var m TokenRecursiveMutex
+	m.Lock(0)
+	if m.Mutex.TryLock() {
+		m.Mutex.Unlock()
+		t.Fatal("token 0 did not acquire the underlying mutex")
+	}
+
+	m.Lock(0)
+	m.Unlock(0)
+	if m.Mutex.TryLock() {
+		m.Mutex.Unlock()
+		t.Fatal("recursive token 0 unlock released the underlying mutex too early")
+	}
+
+	m.Unlock(0)
+	if !m.Mutex.TryLock() {
+		t.Fatal("final token 0 unlock did not release the underlying mutex")
+	}
+	m.Mutex.Unlock()
+}
+
+func TestIssue81TokenRecursiveMutexSerializesDifferentTokens(t *testing.T) {
+	var ownership TokenRecursiveMutex
+	ownership.Lock(7)
+	ownership.Unlock(7)
+
+	var m TokenRecursiveMutex
+	m.Lock(7)
+	m.Lock(7)
+	done := make(chan interface{}, 1)
+	go func() {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				done <- recovered
+			}
+		}()
+		m.Lock(8)
+		m.Unlock(8)
+		done <- nil
+	}()
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		state := atomic.LoadInt32((*int32)(unsafe.Pointer(&m.Mutex)))
+		if state>>mutexWaiterShift > 0 {
+			break
+		}
+		select {
+		case result := <-done:
+			t.Fatalf("token 8 completed while token 7 held the mutex: %v", result)
+		default:
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("token 8 did not queue on the underlying mutex")
+		}
+		runtime.Gosched()
+	}
+
+	m.Unlock(7)
+	select {
+	case result := <-done:
+		t.Fatalf("one recursive unlock released token 8 early: %v", result)
+	default:
+	}
+	m.Unlock(7)
+	select {
+	case result := <-done:
+		if result != nil {
+			t.Fatalf("token 8 failed after final release: %v", result)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("token 8 did not acquire after final release")
+	}
+}

--- a/sys/mutex/mutex.go
+++ b/sys/mutex/mutex.go
@@ -20,29 +20,15 @@ type Mutex struct {
 }
 
 func (m *Mutex) TryLock() bool {
-	// 如果能成功抢到锁
-	if atomic.CompareAndSwapInt32((*int32)(unsafe.Pointer(&m.Mutex)), 0, mutexLocked) {
-		return true
-	}
-
-	// 如果处于唤醒、加锁或者饥饿状态，这次请求就不参与竞争了，返回false
-	old := atomic.LoadInt32((*int32)(unsafe.Pointer(&m.Mutex)))
-	if old&(mutexLocked|mutexStarving|mutexWoken) != 0 {
-		return false
-	}
-
-	// 尝试在竞争的状态下请求锁
-	_new := old | mutexLocked
-	return atomic.CompareAndSwapInt32((*int32)(unsafe.Pointer(&m.Mutex)), old, _new)
+	return m.Mutex.TryLock()
 }
 
 // Count 指标信息 获取等待锁的数量
 func (m *Mutex) Count() int {
 	// 获取state字段的值
 	v := atomic.LoadInt32((*int32)(unsafe.Pointer(&m.Mutex)))
-	v = v >> mutexWaiterShift // 得到等待者的数值
-	v = v + (v & mutexLocked) // 再加上锁持有者的数量，0或者1
-	return int(v)
+	waiters := v >> mutexWaiterShift
+	return int(waiters + v&mutexLocked)
 }
 
 // IsLocked 锁是否被持有

--- a/sys/mutex/recursive_mutex_token.go
+++ b/sys/mutex/recursive_mutex_token.go
@@ -3,37 +3,49 @@ package mutex
 import (
 	"fmt"
 	"sync"
-	"sync/atomic"
 )
 
 // TokenRecursiveMutex Token方式的递归锁
 type TokenRecursiveMutex struct {
 	sync.Mutex
+	state     sync.Mutex
 	token     int64
 	recursion int64
+	held      bool
 }
 
 // Lock 请求锁，需要传入token
 func (m *TokenRecursiveMutex) Lock(token int64) {
-	if atomic.LoadInt64(&m.token) == token { // 如果传入的token和持有锁的token一致，说明是递归调用
-		atomic.AddInt64(&m.recursion, 1)
+	m.state.Lock()
+	if m.held && m.token == token {
+		m.recursion++
+		m.state.Unlock()
 		return
 	}
-	m.Mutex.Lock() // 传入的token不一致，说明不是递归调用
-	// 抢到锁之后记录这个token
-	atomic.StoreInt64(&m.token, token)
-	atomic.StoreInt64(&m.recursion, 1)
+	m.state.Unlock()
+
+	m.Mutex.Lock()
+	m.state.Lock()
+	m.token = token
+	m.recursion = 1
+	m.held = true
+	m.state.Unlock()
 }
 
 // Unlock 释放锁
 func (m *TokenRecursiveMutex) Unlock(token int64) {
-	if atomic.LoadInt64(&m.token) != token { // 释放其它token持有的锁
-		panic(fmt.Sprintf("wrong the owner(%d): %d!", m.token, token))
+	m.state.Lock()
+	if !m.held || m.token != token {
+		owner := m.token
+		m.state.Unlock()
+		panic(fmt.Sprintf("wrong the owner(%d): %d!", owner, token))
 	}
-	recursion := atomic.AddInt64(&m.recursion, -1)
-	if recursion != 0 { // 如果这个goroutine还没有完全释放，则直接返回
+	m.recursion--
+	if m.recursion != 0 {
+		m.state.Unlock()
 		return
 	}
-	atomic.StoreInt64(&m.token, 0) // 没有递归调用了，释放锁
+	m.held = false
+	m.state.Unlock()
 	m.Mutex.Unlock()
 }

--- a/sys/stringx/stringx.go
+++ b/sys/stringx/stringx.go
@@ -139,7 +139,7 @@ func Rotate(s string, shift int) string {
 	if shift == 0 {
 		return s
 	}
-	sLen := len(s)
+	sLen := utf8.RuneCountInString(s)
 	if sLen == 0 {
 		return s
 	}
@@ -166,7 +166,7 @@ func Sub(s string, start, end int) string {
 // SubStart returns substring from specified string avoiding panics with start.
 // start, end are based on unicode(utf8) count.
 func SubStart(s string, start int) string {
-	return sub(s, start, math.MaxInt64)
+	return sub(s, start, math.MaxInt)
 }
 
 func sub(s string, start, end int) string {

--- a/sys/stringx/stringx_test.go
+++ b/sys/stringx/stringx_test.go
@@ -119,6 +119,9 @@ func TestRotate(t *testing.T) {
 
 	is.Equal("cab", Rotate("abc", 1))
 	is.Equal("bca", Rotate("abc", -1))
+
+	is.Equal("世界你好", Rotate("你好世界", 6))
+	is.Equal("好世界你", Rotate("你好世界", -5))
 }
 
 func TestReverse(t *testing.T) {

--- a/sys/xxhash3/hash.go
+++ b/sys/xxhash3/hash.go
@@ -60,7 +60,7 @@ func xxh3HashLarge(xinput unsafe.Pointer, l int) (acc uint64) {
 	length := uintptr(l)
 
 	if length <= 128 {
-		acc := uint64(length * prime64_1)
+		acc := uint64(length) * prime64_1
 		if length > 32 {
 			if length > 64 {
 				if length > 96 {
@@ -79,7 +79,7 @@ func xxh3HashLarge(xinput unsafe.Pointer, l int) (acc uint64) {
 		return xxh3Avalanche(acc)
 
 	} else if length <= 240 {
-		acc := uint64(length * prime64_1)
+		acc := uint64(length) * prime64_1
 
 		acc += mix(runtimex.ReadUnaligned64(unsafe.Pointer(uintptr(xinput)+16*0))^xsecret_000, runtimex.ReadUnaligned64(unsafe.Pointer(uintptr(xinput)+16*0+8))^xsecret_008)
 		acc += mix(runtimex.ReadUnaligned64(unsafe.Pointer(uintptr(xinput)+16*1))^xsecret_016, runtimex.ReadUnaligned64(unsafe.Pointer(uintptr(xinput)+16*1+8))^xsecret_024)
@@ -106,7 +106,7 @@ func xxh3HashLarge(xinput unsafe.Pointer, l int) (acc uint64) {
 		prime32_3, prime64_1, prime64_2, prime64_3,
 		prime64_4, prime32_2, prime64_5, prime32_1}
 
-	acc = uint64(length * prime64_1)
+	acc = uint64(length) * prime64_1
 
 	accum(&xacc, xinput, xsecret, length)
 

--- a/sys/xxhash3/hash128.go
+++ b/sys/xxhash3/hash128.go
@@ -97,7 +97,7 @@ func xxh3HashLarge128(xinput unsafe.Pointer, l int) (acc [2]uint64) {
 	if length <= 128 {
 
 		accHigh := uint64(0)
-		accLow := uint64(length * prime64_1)
+		accLow := uint64(length) * prime64_1
 
 		if length > 32 {
 			if length > 64 {
@@ -124,14 +124,14 @@ func xxh3HashLarge128(xinput unsafe.Pointer, l int) (acc [2]uint64) {
 		accHigh ^= runtimex.ReadUnaligned64(xinput) + runtimex.ReadUnaligned64(unsafe.Pointer(uintptr(xinput)+8))
 
 		h128Low := accHigh + accLow
-		h128High := (accLow * prime64_1) + (accHigh * prime64_4) + uint64(length*prime64_2)
+		h128High := (accLow * prime64_1) + (accHigh * prime64_4) + uint64(length)*prime64_2
 
 		h128Low = xxh3Avalanche(h128Low)
 		h128High = -xxh3Avalanche(h128High)
 
 		return [2]uint64{h128High, h128Low}
 	} else if length <= 240 {
-		accLow64 := uint64(length * prime64_1)
+		accLow64 := uint64(length) * prime64_1
 		accHigh64 := uint64(0)
 
 		accLow64 += mix(runtimex.ReadUnaligned64(unsafe.Pointer(uintptr(xinput)+32*0))^xsecret_000, runtimex.ReadUnaligned64(unsafe.Pointer(uintptr(xinput)+8))^xsecret_008)
@@ -172,7 +172,7 @@ func xxh3HashLarge128(xinput unsafe.Pointer, l int) (acc [2]uint64) {
 		accHigh64 += mix(runtimex.ReadUnaligned64(unsafe.Pointer(uintptr(xinput)+length-32))^xsecret_119, runtimex.ReadUnaligned64(unsafe.Pointer(uintptr(xinput)+length-24))^xsecret_127)
 		accHigh64 ^= runtimex.ReadUnaligned64(unsafe.Pointer(uintptr(xinput)+length-16)) + runtimex.ReadUnaligned64(unsafe.Pointer(uintptr(xinput)+length-8))
 
-		accHigh64, accLow64 = (accLow64*prime64_1)+(accHigh64*prime64_4)+uint64(length*prime64_2), accHigh64+accLow64
+		accHigh64, accLow64 = (accLow64*prime64_1)+(accHigh64*prime64_4)+uint64(length)*prime64_2, accHigh64+accLow64
 
 		accLow64 = xxh3Avalanche(accLow64)
 		accHigh64 = -xxh3Avalanche(accHigh64)
@@ -184,8 +184,8 @@ func xxh3HashLarge128(xinput unsafe.Pointer, l int) (acc [2]uint64) {
 		prime32_3, prime64_1, prime64_2, prime64_3,
 		prime64_4, prime32_2, prime64_5, prime32_1}
 
-	acc[1] = uint64(length * prime64_1)
-	acc[0] = uint64(^(length * prime64_2))
+	acc[1] = uint64(length) * prime64_1
+	acc[0] = ^(uint64(length) * prime64_2)
 
 	accum(&xacc, xinput, xsecret, length)
 

--- a/sys/xxhash3/issue81_test.go
+++ b/sys/xxhash3/issue81_test.go
@@ -1,0 +1,23 @@
+package xxhash3
+
+import "testing"
+
+func TestIssue81CrossArchitectureVectors(t *testing.T) {
+	tests := []struct {
+		input   string
+		hash    uint64
+		hash128 [2]uint64
+	}{
+		{"gkit", 0xba41e5013428a24b, [2]uint64{0xf3405599cacaf09d, 0xc3ed8af5879fb9ef}},
+		{"xxhash3-cross-architecture-vector-129-bytes-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", 0xbc582282eda4a279, [2]uint64{0xdd038798dae3fb8d, 0x40a6623525fc377c}},
+	}
+	for _, tt := range tests {
+		input := []byte(tt.input)
+		if got := Hash(input); got != tt.hash {
+			t.Errorf("Hash(%q) = %#x, want %#x", input, got, tt.hash)
+		}
+		if got := Hash128(input); got != tt.hash128 {
+			t.Errorf("Hash128(%q) = %#x, want %#x", input, got, tt.hash128)
+		}
+	}
+}


### PR DESCRIPTION
## What

- 修正 Mutex.Count 与 TokenRecursiveMutex 的 owner/递归状态，token 0 和非零 token 均保持互斥。
- 让 Unicode Rotate 与 stringx/xxhash3 在 32 位平台保持正确编译和一致结果。
- 为公共及 internal CPU reader 增加 cgroup v2 的 cpu.max、cpu.stat、effective cpuset 支持，并防御 quota/counter 边界。
- 保留既有 cgroup v1 mount 映射，避免从 controller 顺序猜测 mountpoint。
- 增加 PRODUCT/TECH 规格和公共/internal 对称回归。

## Why

原实现会漏算锁持有者，token 0 完全绕过底层互斥，多字节 Rotate 单位混用，32 位构建溢出；现代 cgroup v2 容器则会静默回退到宿主 CPU 指标。

## How

- Count 分别读取原始 locked bit 与 waiter bits；TryLock 委托标准库。
- TokenRecursiveMutex 用独立状态锁保护 held、owner 和 recursion。
- 哈希长度先提升到 uint64，substring 使用 MaxInt。
- unified cgroup 使用 v2 文件语义，usage 计算前检查 quota 与 counter 单调性。

## Tests

- Go 1.20.14 focused race count 20 与相关包完整 race/vet
- linux/386 stringx、xxhash3 交叉编译，并在 Linux 容器实际运行固定向量
- Linux 容器实际 cgroup v2 smoke test
- 独立 review 的 v1 路径、token owner/跨 token、quota/counter 等 mutation 均被测试捕获
- internal/sys/cpu 的既有平台 TestStat 全包失败已在未改 master 复现，并由 PR #90 单独修复

## Non-goals

- runtime pool cleanup 单槽 hook 的多库共存限制不在本次伪造 chaining。
- Mutex 状态内省仍只承诺项目 Go 1.20 支持线，不承诺未来 runtime 私有布局。

Fixes #81