### PR TITLE
fix(network): harden transport and subset boundaries

### DIFF
--- a/net/arp/arp.go
+++ b/net/arp/arp.go
@@ -2,6 +2,7 @@ package arp
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"time"
 
@@ -10,6 +11,20 @@ import (
 	"github.com/google/gopacket/pcap"
 	"github.com/google/gopacket/routing"
 )
+
+const (
+	arpCaptureReadTimeout = 50 * time.Millisecond
+	arpReplyTimeout       = time.Second
+)
+
+var errARPReplyTimeout = errors.New("timeout getting ARP reply")
+
+type arpHandle interface {
+	WritePacketData([]byte) error
+	ReadPacketData() ([]byte, gopacket.CaptureInfo, error)
+}
+
+type openLiveFunc func(string, int32, bool, time.Duration) (*pcap.Handle, error)
 
 type ExtraInfo struct {
 	IFace     *net.Interface
@@ -30,9 +45,9 @@ func GetRouterInfo(dstIp net.IP) (*ExtraInfo, error) {
 	}
 	extraInfo.IFace = iFace
 	extraInfo.SrcIP = preferredSrc
-	handle, err := pcap.OpenLive(iFace.Name, 1024, true, pcap.BlockForever)
+	handle, err := openARPHandle(iFace.Name, pcap.OpenLive)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("open ARP capture on %s: %w", iFace.Name, err)
 	}
 	defer handle.Close()
 	dstHWAddr, err := getHWAddr(dstIp, gateway, preferredSrc, iFace, handle)
@@ -43,7 +58,11 @@ func GetRouterInfo(dstIp net.IP) (*ExtraInfo, error) {
 	return extraInfo, nil
 }
 
-func getHWAddr(ip, gateway, srcIP net.IP, networkInterface *net.Interface, handle *pcap.Handle) (net.HardwareAddr, error) {
+func openARPHandle(interfaceName string, open openLiveFunc) (*pcap.Handle, error) {
+	return open(interfaceName, 1024, true, arpCaptureReadTimeout)
+}
+
+func getHWAddr(ip, gateway, srcIP net.IP, networkInterface *net.Interface, handle arpHandle) (net.HardwareAddr, error) {
 	arpDst := ip
 	if gateway != nil {
 		arpDst = gateway
@@ -78,19 +97,24 @@ func getHWAddr(ip, gateway, srcIP net.IP, networkInterface *net.Interface, handl
 		return nil, err
 	}
 	if err := handle.WritePacketData(buf.Bytes()); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("write ARP request: %w", err)
 	}
 
-	start := time.Now()
+	return readARPReply(handle, arpDst, time.Now().Add(arpReplyTimeout), time.Now)
+}
+
+func readARPReply(handle interface {
+	ReadPacketData() ([]byte, gopacket.CaptureInfo, error)
+}, arpDst net.IP, deadline time.Time, now func() time.Time) (net.HardwareAddr, error) {
 	for {
-		if time.Since(start) > time.Millisecond*time.Duration(1000) {
-			return nil, errors.New("timeout getting ARP reply")
+		if !now().Before(deadline) {
+			return nil, errARPReplyTimeout
 		}
 		data, _, err := handle.ReadPacketData()
 		if errors.Is(err, pcap.NextErrorTimeoutExpired) {
 			continue
 		} else if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("read ARP reply: %w", err)
 		}
 		packet := gopacket.NewPacket(data, layers.LayerTypeEthernet, gopacket.NoCopy)
 		if arpLayer := packet.Layer(layers.LayerTypeARP); arpLayer != nil {

--- a/net/arp/issue83_test.go
+++ b/net/arp/issue83_test.go
@@ -1,0 +1,63 @@
+package arp
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/pcap"
+)
+
+type timeoutPacketReader struct {
+	reads int
+}
+
+func (r *timeoutPacketReader) ReadPacketData() ([]byte, gopacket.CaptureInfo, error) {
+	r.reads++
+	return nil, gopacket.CaptureInfo{}, pcap.NextErrorTimeoutExpired
+}
+
+func TestOpenARPHandleUsesFiniteReadTimeout(t *testing.T) {
+	sentinel := errors.New("stop after observing options")
+	var gotTimeout time.Duration
+
+	_, err := openARPHandle("eth-test", func(name string, snaplen int32, promisc bool, timeout time.Duration) (*pcap.Handle, error) {
+		if name != "eth-test" {
+			t.Fatalf("interface name = %q, want eth-test", name)
+		}
+		if snaplen != 1024 {
+			t.Fatalf("snaplen = %d, want 1024", snaplen)
+		}
+		if !promisc {
+			t.Fatal("promisc = false, want true")
+		}
+		gotTimeout = timeout
+		return nil, sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("openARPHandle error = %v, want %v", err, sentinel)
+	}
+	if gotTimeout <= 0 {
+		t.Fatalf("capture timeout = %s, want a finite positive timeout", gotTimeout)
+	}
+}
+
+func TestReadARPReplyStopsAfterDeadlineOnSilentCapture(t *testing.T) {
+	reader := &timeoutPacketReader{}
+	start := time.Unix(1, 0)
+	now := start
+	nowFn := func() time.Time {
+		current := now
+		now = now.Add(50 * time.Millisecond)
+		return current
+	}
+
+	_, err := readARPReply(reader, []byte{192, 0, 2, 1}, start.Add(125*time.Millisecond), nowFn)
+	if !errors.Is(err, errARPReplyTimeout) {
+		t.Fatalf("readARPReply error = %v, want %v", err, errARPReplyTimeout)
+	}
+	if reader.reads != 3 {
+		t.Fatalf("ReadPacketData calls = %d, want 3 before the deadline", reader.reads)
+	}
+}

--- a/net/ip/ip.go
+++ b/net/ip/ip.go
@@ -18,7 +18,7 @@ func HasLocalIPAddr(ip string) bool {
 }
 
 func HasLocalIP(ip net.IP) bool {
-	if ip.IsLoopback() {
+	if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
 		return true
 	}
 

--- a/net/ip/issue83_test.go
+++ b/net/ip/issue83_test.go
@@ -1,0 +1,43 @@
+package ip
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestHasLocalIPAddrIPv6(t *testing.T) {
+	tests := []struct {
+		name string
+		ip   string
+		want bool
+	}{
+		{name: "loopback", ip: "::1", want: true},
+		{name: "ula fc", ip: "fc00::1", want: true},
+		{name: "ula fd", ip: "fd12:3456:789a::1", want: true},
+		{name: "link local unicast", ip: "fe80::1", want: true},
+		{name: "link local multicast", ip: "ff02::1", want: true},
+		{name: "global", ip: "2001:4860:4860::8888", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := HasLocalIPAddr(tt.ip); got != tt.want {
+				t.Fatalf("HasLocalIPAddr(%q) = %v, want %v", tt.ip, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClientPublicIPSkipsLocalIPv6(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "http://example.test", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set(xForwardedFor, "fd12:3456:789a::1")
+	req.Header.Set(xRealIP, "2001:4860:4860::8888")
+	req.RemoteAddr = "[fe80::1]:443"
+
+	if got := ClientPublicIP(req); got != "2001:4860:4860::8888" {
+		t.Fatalf("ClientPublicIP() = %q, want the first non-local IPv6 address", got)
+	}
+}

--- a/net/tcp/conn.go
+++ b/net/tcp/conn.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"crypto/tls"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"time"
@@ -48,130 +49,161 @@ func (c *Conn) Send(data []byte, retry *Retry) error {
 		var local Retry
 		retry = &local
 	}
-	for {
-		_, err := c.Write(data)
-		switch {
-		case err != nil && errors.Is(err, io.EOF):
-			// EOF 处理
-			return nil
-		case err != nil && retry.Count > 0:
-			// 触发重试
-			retry.Count--
-			if retry.Interval == 0 {
-				retry.Interval = DefaultRetryInterval
+	for offset := 0; offset < len(data); {
+		remaining := data[offset:]
+		n, err := c.Write(remaining)
+		if n < 0 || n > len(remaining) {
+			return fmt.Errorf("tcp send: invalid write count %d for %d remaining bytes", n, len(remaining))
+		}
+		offset += n
+		if err != nil {
+			if retry.Count > 0 && offset < len(data) {
+				retry.Count--
+				if retry.Interval == 0 {
+					retry.Interval = DefaultRetryInterval
+				}
+				time.Sleep(retry.Interval)
+				continue
 			}
-			time.Sleep(retry.Interval)
-		default:
-			return err
+			return fmt.Errorf("tcp send after %d of %d bytes: %w", offset, len(data), err)
+		}
+		if n == 0 {
+			return fmt.Errorf("tcp send after %d of %d bytes: %w", offset, len(data), io.ErrNoProgress)
 		}
 	}
+	return nil
 }
 
 // Recv 接受数据
 // length == 0 从 Conn一次读取立即返回
 // length < 0 从 Conn 接收所有数据，并将其返回，直到没有数据
 // length > 0 从 Conn 接收到对应的数据返回
-func (c *Conn) Recv(length int, retry *Retry) ([]byte, error) {
+func (c *Conn) Recv(length int, retry *Retry) (result []byte, retErr error) {
 	if retry == nil {
 		var local Retry
 		retry = &local
 	}
-	var (
-		// err: error
-		err error
-
-		// size: 返回一次读取的大小
-		size int
-
-		// index: 目前指向的索引的位置
-		index int
-
-		// bf: 读取后的缓冲区
-		bf []byte
-
-		// flag: 判断是否循环读
-		flag bool
-	)
-	if length > 0 {
-		// 读取指定的长度
-		bf = *buffer.GetBytes(length)
-	} else {
-		// 需要 eof 返回
-		bf = *buffer.GetBytes(DefaultReadBuffer)
-	}
-cycle:
-	for {
-		if length < 0 && index > 0 {
-			// length < 0 要接受所有的数据,直至EOF
-			flag = true
-			if err = c.SetReadDeadline(time.Now().Add(c.recvBufferInterval)); err != nil {
-				return nil, err
+	readWithRetry := func(dst []byte) (int, error) {
+		for {
+			n, err := c.reader.Read(dst)
+			if err == nil || errors.Is(err, io.EOF) || retry.Count == 0 {
+				return n, err
+			}
+			retry.Count--
+			if retry.Interval == 0 {
+				retry.Interval = DefaultRetryInterval
+			}
+			time.Sleep(retry.Interval)
+			if n > 0 {
+				// Preserve bytes returned with a retryable error. The caller
+				// advances its offset and the next read retries the remainder.
+				return n, nil
 			}
 		}
-		size, err = c.reader.Read(bf[index:])
-		if size > 0 {
-			index += size
-			if length > 0 {
-				if index == length {
-					break cycle
-				}
-			} else {
-				if index >= DefaultReadBuffer {
-					bf = append(bf, make([]byte, DefaultReadBuffer)...)
-				} else if !flag {
-					break cycle
-				}
+	}
+
+	if length > 0 {
+		bf := *buffer.GetBytes(length)
+		index := 0
+		for index < length {
+			n, err := readWithRetry(bf[index:])
+			index += n
+			if index == length {
+				return bf[:index], nil
 			}
+			if errors.Is(err, io.EOF) {
+				if index == 0 {
+					return bf[:0], io.EOF
+				}
+				return bf[:index], io.ErrUnexpectedEOF
+			}
+			if err != nil {
+				return bf[:index], fmt.Errorf("tcp receive %d of %d bytes: %w", index, length, err)
+			}
+			if n == 0 {
+				return bf[:index], fmt.Errorf("tcp receive %d of %d bytes: %w", index, length, io.ErrNoProgress)
+			}
+		}
+		return bf[:index], nil
+	}
+
+	bufferSize := DefaultReadBuffer
+	if bufferSize <= 0 {
+		bufferSize = 1
+	}
+	bf := *buffer.GetBytes(bufferSize)
+	if length == 0 {
+		n, err := readWithRetry(bf)
+		if errors.Is(err, io.EOF) {
+			return bf[:n], nil
+		}
+		return bf[:n], err
+	}
+
+	previousDeadline := c.recvTimeout
+	deadlineChanged := false
+	defer func() {
+		if !deadlineChanged {
+			return
+		}
+		if err := c.Conn.SetReadDeadline(previousDeadline); err != nil {
+			restoreErr := fmt.Errorf("tcp receive: restore read deadline: %w", err)
+			if retErr == nil {
+				retErr = restoreErr
+			} else {
+				retErr = errors.Join(retErr, restoreErr)
+			}
+		}
+	}()
+
+	index := 0
+	for {
+		if index == len(bf) {
+			bf = append(bf, make([]byte, bufferSize)...)
+		}
+		n, err := readWithRetry(bf[index:])
+		index += n
+		if errors.Is(err, io.EOF) {
+			return bf[:index], nil
 		}
 		if err != nil {
-			switch {
-			case errors.Is(err, io.EOF):
-				break cycle
-			case flag && isTimeout(err):
-				if err = c.SetReadDeadline(time.Now().Add(c.recvBufferInterval)); err != nil {
-					return nil, err
-				}
-				break cycle
-			case retry.Count > 0:
-				// 触发重试
-				retry.Count--
-				if retry.Interval == 0 {
-					retry.Interval = DefaultRetryInterval
-				}
-				time.Sleep(retry.Interval)
-				goto cycle
-			default:
-				return nil, err
+			if deadlineChanged && isTimeout(err) {
+				return bf[:index], nil
 			}
+			return bf[:index], fmt.Errorf("tcp receive stream after %d bytes: %w", index, err)
 		}
-		if length == 0 {
-			break cycle
+		if n == 0 {
+			return bf[:index], fmt.Errorf("tcp receive stream after %d bytes: %w", index, io.ErrNoProgress)
 		}
+		idleDeadline := time.Now().Add(c.recvBufferInterval)
+		if !previousDeadline.IsZero() && previousDeadline.Before(idleDeadline) {
+			idleDeadline = previousDeadline
+		}
+		if err := c.Conn.SetReadDeadline(idleDeadline); err != nil {
+			return bf[:index], fmt.Errorf("tcp receive stream: set idle deadline: %w", err)
+		}
+		deadlineChanged = true
 	}
-	return bf[:index], nil
 }
 
 // RecvLine 读取一行 '\n'
 func (c *Conn) RecvLine(retry *Retry) ([]byte, error) {
-	var (
-		// err
-		err error
-
-		data []byte
-
-		index int
-
-		bf = (*buffer.GetBytes(1024))[:0]
-	)
+	bf := (*buffer.GetBytes(1024))[:0]
 	for {
-		data, err = c.Recv(1, retry)
-		if err != nil || data[0] == '\n' {
-			break
+		data, err := c.Recv(1, retry)
+		if len(data) > 0 {
+			if data[0] == '\n' {
+				return bf, nil
+			}
+			bf = append(bf, data...)
 		}
-		index++
-		bf = append(bf, data...)
+		if err != nil {
+			return bf, err
+		}
+		if len(data) == 0 {
+			return bf, io.ErrNoProgress
+		}
 	}
-	return bf[:index], err
 }
 
 // RecvWithTimeout 读取已经超时的链接
@@ -217,19 +249,29 @@ func (c *Conn) SetDeadline(t time.Time) error {
 	return err
 }
 
-func (c *Conn) SetRecvDeadline(t time.Time) error {
-	err := c.SetReadDeadline(t)
+func (c *Conn) SetReadDeadline(t time.Time) error {
+	err := c.Conn.SetReadDeadline(t)
 	if err == nil {
 		c.recvTimeout = t
 	}
 	return err
 }
 
-func (c *Conn) SetSendDeadline(t time.Time) error {
-	err := c.SetWriteDeadline(t)
+func (c *Conn) SetWriteDeadline(t time.Time) error {
+	err := c.Conn.SetWriteDeadline(t)
 	if err == nil {
 		c.sendTimeout = t
 	}
+	return err
+}
+
+func (c *Conn) SetRecvDeadline(t time.Time) error {
+	err := c.SetReadDeadline(t)
+	return err
+}
+
+func (c *Conn) SetSendDeadline(t time.Time) error {
+	err := c.SetWriteDeadline(t)
 	return err
 }
 

--- a/net/tcp/issue83_test.go
+++ b/net/tcp/issue83_test.go
@@ -1,0 +1,276 @@
+package tcp
+
+import (
+	"errors"
+	"io"
+	"net"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+)
+
+type issue83ReadStep struct {
+	data []byte
+	err  error
+}
+
+type issue83ScriptedConn struct {
+	mu            sync.Mutex
+	reads         []issue83ReadStep
+	readIndex     int
+	write         func([]byte) (int, error)
+	readDeadlines []time.Time
+}
+
+func (c *issue83ScriptedConn) Read(p []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.readIndex >= len(c.reads) {
+		return 0, io.EOF
+	}
+	step := c.reads[c.readIndex]
+	c.readIndex++
+	return copy(p, step.data), step.err
+}
+
+func (c *issue83ScriptedConn) Write(p []byte) (int, error) {
+	if c.write == nil {
+		return len(p), nil
+	}
+	return c.write(p)
+}
+
+func (*issue83ScriptedConn) Close() error                     { return nil }
+func (*issue83ScriptedConn) LocalAddr() net.Addr              { return issue83Addr("local") }
+func (*issue83ScriptedConn) RemoteAddr() net.Addr             { return issue83Addr("remote") }
+func (c *issue83ScriptedConn) SetDeadline(t time.Time) error  { return c.SetReadDeadline(t) }
+func (*issue83ScriptedConn) SetWriteDeadline(time.Time) error { return nil }
+func (c *issue83ScriptedConn) SetReadDeadline(t time.Time) error {
+	c.mu.Lock()
+	c.readDeadlines = append(c.readDeadlines, t)
+	c.mu.Unlock()
+	return nil
+}
+
+type issue83Addr string
+
+func (a issue83Addr) Network() string { return string(a) }
+func (a issue83Addr) String() string  { return string(a) }
+
+type issue83TimeoutError struct{}
+
+func (issue83TimeoutError) Error() string   { return "read timeout" }
+func (issue83TimeoutError) Timeout() bool   { return true }
+func (issue83TimeoutError) Temporary() bool { return true }
+
+// Behavior 1: a line terminated by EOF returns its bytes and the EOF; an
+// empty EOF must not index an empty slice.
+func TestIssue83RecvLinePreservesPartialEOF(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+		want []byte
+	}{
+		{name: "partial", data: []byte("partial"), want: []byte("partial")},
+		{name: "empty", want: []byte{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reads := make([]issue83ReadStep, 0, 2)
+			if len(tt.data) > 0 {
+				reads = append(reads, issue83ReadStep{data: tt.data})
+			}
+			reads = append(reads, issue83ReadStep{err: io.EOF})
+			raw := &issue83ScriptedConn{reads: reads}
+			conn := NewConnByNetConn(raw)
+			var got []byte
+			var err error
+			func() {
+				defer func() {
+					if recovered := recover(); recovered != nil {
+						t.Fatalf("RecvLine panicked at EOF: %v", recovered)
+					}
+				}()
+				got, err = conn.RecvLine(nil)
+			}()
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("RecvLine() data = %q, want %q", got, tt.want)
+			}
+			if !errors.Is(err, io.EOF) {
+				t.Fatalf("RecvLine() error = %v, want EOF", err)
+			}
+		})
+	}
+}
+
+// Behavior 2: successful short writes continue from the first unwritten byte;
+// a retry after a partial error also receives only the remaining suffix.
+func TestIssue83SendTracksPartialWrites(t *testing.T) {
+	t.Run("short write without error", func(t *testing.T) {
+		var written []byte
+		raw := &issue83ScriptedConn{}
+		raw.write = func(p []byte) (int, error) {
+			n := 2
+			if len(p) < n {
+				n = len(p)
+			}
+			written = append(written, p[:n]...)
+			return n, nil
+		}
+		if err := NewConnByNetConn(raw).Send([]byte("abcdef"), nil); err != nil {
+			t.Fatalf("Send() error = %v", err)
+		}
+		if string(written) != "abcdef" {
+			t.Fatalf("written bytes = %q, want %q", written, "abcdef")
+		}
+	})
+
+	t.Run("partial error retries suffix", func(t *testing.T) {
+		transient := errors.New("transient write failure")
+		var calls [][]byte
+		raw := &issue83ScriptedConn{}
+		raw.write = func(p []byte) (int, error) {
+			calls = append(calls, append([]byte(nil), p...))
+			if len(calls) == 1 {
+				return 2, transient
+			}
+			return len(p), nil
+		}
+		retry := &Retry{Count: 1, Interval: time.Nanosecond}
+		if err := NewConnByNetConn(raw).Send([]byte("abcdef"), retry); err != nil {
+			t.Fatalf("Send() error = %v", err)
+		}
+		want := [][]byte{[]byte("abcdef"), []byte("cdef")}
+		if !reflect.DeepEqual(calls, want) {
+			t.Fatalf("Write calls = %q, want %q", calls, want)
+		}
+	})
+}
+
+func TestIssue83SendReturnsFinalErrors(t *testing.T) {
+	t.Run("EOF", func(t *testing.T) {
+		raw := &issue83ScriptedConn{write: func([]byte) (int, error) {
+			return 0, io.EOF
+		}}
+		err := NewConnByNetConn(raw).Send([]byte("x"), nil)
+		if !errors.Is(err, io.EOF) {
+			t.Fatalf("Send() error = %v, want EOF", err)
+		}
+	})
+
+	t.Run("error after all bytes", func(t *testing.T) {
+		writeErr := errors.New("write completed with terminal error")
+		raw := &issue83ScriptedConn{write: func(p []byte) (int, error) {
+			return len(p), writeErr
+		}}
+		err := NewConnByNetConn(raw).Send([]byte("done"), &Retry{Count: 1, Interval: time.Nanosecond})
+		if !errors.Is(err, writeErr) {
+			t.Fatalf("Send() error = %v, want %v", err, writeErr)
+		}
+	})
+
+	t.Run("zero progress", func(t *testing.T) {
+		raw := &issue83ScriptedConn{write: func([]byte) (int, error) {
+			return 0, nil
+		}}
+		err := NewConnByNetConn(raw).Send([]byte("x"), nil)
+		if !errors.Is(err, io.ErrNoProgress) {
+			t.Fatalf("Send() error = %v, want io.ErrNoProgress", err)
+		}
+	})
+}
+
+// Behavior 3: fixed reads surface premature EOF with their partial data.
+func TestIssue83RecvFixedLengthReportsEarlyEOF(t *testing.T) {
+	t.Run("partial", func(t *testing.T) {
+		raw := &issue83ScriptedConn{reads: []issue83ReadStep{
+			{data: []byte("abc")},
+			{err: io.EOF},
+		}}
+		got, err := NewConnByNetConn(raw).Recv(5, nil)
+		if string(got) != "abc" {
+			t.Fatalf("Recv(5) data = %q, want %q", got, "abc")
+		}
+		if !errors.Is(err, io.ErrUnexpectedEOF) {
+			t.Fatalf("Recv(5) error = %v, want io.ErrUnexpectedEOF", err)
+		}
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		got, err := NewConnByNetConn(&issue83ScriptedConn{reads: []issue83ReadStep{{err: io.EOF}}}).Recv(5, nil)
+		if len(got) != 0 {
+			t.Fatalf("Recv(5) data = %q, want empty", got)
+		}
+		if !errors.Is(err, io.EOF) {
+			t.Fatalf("Recv(5) error = %v, want EOF", err)
+		}
+	})
+}
+
+// Behavior 3: streaming reads drain all available segments and restore the
+// deadline that was active before their idle probe.
+func TestIssue83RecvStreamDrainsAndRestoresDeadline(t *testing.T) {
+	raw := &issue83ScriptedConn{reads: []issue83ReadStep{
+		{data: []byte("first-")},
+		{data: []byte("second")},
+		{err: issue83TimeoutError{}},
+	}}
+	conn := NewConnByNetConn(raw)
+	conn.SetRecvBufferInterval(20 * time.Millisecond)
+	original := time.Now().Add(time.Minute).Round(0)
+	if err := conn.SetReadDeadline(original); err != nil {
+		t.Fatalf("SetReadDeadline() error = %v", err)
+	}
+
+	got, err := conn.Recv(-1, nil)
+	if err != nil {
+		t.Fatalf("Recv(-1) error = %v", err)
+	}
+	if string(got) != "first-second" {
+		t.Fatalf("Recv(-1) data = %q, want %q", got, "first-second")
+	}
+	raw.mu.Lock()
+	deadlines := append([]time.Time(nil), raw.readDeadlines...)
+	raw.mu.Unlock()
+	if len(deadlines) < 3 {
+		t.Fatalf("read deadline calls = %v, want idle probes plus restoration", deadlines)
+	}
+	if !deadlines[len(deadlines)-1].Equal(original) {
+		t.Fatalf("final read deadline = %v, want restored %v", deadlines[len(deadlines)-1], original)
+	}
+	for _, deadline := range deadlines[1 : len(deadlines)-1] {
+		if deadline.Equal(original) {
+			t.Fatalf("idle deadline %v unexpectedly equals original deadline", deadline)
+		}
+	}
+}
+
+func TestIssue83RecvStreamDrainsUntilEOF(t *testing.T) {
+	raw := &issue83ScriptedConn{reads: []issue83ReadStep{
+		{data: []byte("one-")},
+		{data: []byte("two")},
+		{err: io.EOF},
+	}}
+	got, err := NewConnByNetConn(raw).Recv(-1, nil)
+	if err != nil {
+		t.Fatalf("Recv(-1) error = %v", err)
+	}
+	if string(got) != "one-two" {
+		t.Fatalf("Recv(-1) data = %q, want %q", got, "one-two")
+	}
+	raw.mu.Lock()
+	deadlines := append([]time.Time(nil), raw.readDeadlines...)
+	raw.mu.Unlock()
+	if len(deadlines) < 2 {
+		t.Fatalf("read deadline calls = %v, want idle probe plus restoration", deadlines)
+	}
+	if !deadlines[len(deadlines)-1].IsZero() {
+		t.Fatalf("final read deadline = %v, want cleared deadline", deadlines[len(deadlines)-1])
+	}
+
+	empty, err := NewConnByNetConn(&issue83ScriptedConn{reads: []issue83ReadStep{{err: io.EOF}}}).Recv(-1, nil)
+	if err != nil || len(empty) != 0 {
+		t.Fatalf("Recv(-1) empty EOF = (%q, %v), want empty success", empty, err)
+	}
+}

--- a/overload/bbr/bbr.go
+++ b/overload/bbr/bbr.go
@@ -322,12 +322,16 @@ func newLimiter(options ...options.Option) overload.Limiter {
 	cpu := func() int64 {
 		return atomic.LoadInt64(&cpu)
 	}
+	winBucketPerSec := int64(time.Second) / int64(bucketDuration)
+	if winBucketPerSec < 1 {
+		winBucketPerSec = 1
+	}
 	limiter := &BBR{
 		cpu:             cpu,
 		conf:            conf,
 		passStat:        passStat,
 		rtStat:          rtStat,
-		winBucketPerSec: int64(time.Second) / int64(bucketDuration),
+		winBucketPerSec: winBucketPerSec,
 	}
 	return limiter
 }

--- a/overload/bbr/issue83_test.go
+++ b/overload/bbr/issue83_test.go
@@ -1,0 +1,101 @@
+package bbr
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/songzhibin97/gkit/internal/stat"
+	"github.com/songzhibin97/gkit/overload"
+)
+
+func TestLongBucketKeepsPositiveCapacityFactor(t *testing.T) {
+	limiter := newLimiter(SetWindow(5*time.Minute), SetWinBucket(100)).(*BBR)
+	if limiter.winBucketPerSec != 1 {
+		t.Fatalf("winBucketPerSec = %d, want 1 for a three-second bucket", limiter.winBucketPerSec)
+	}
+
+	atomic.StoreInt64(&limiter.rawMaxPASS, 1000)
+	atomic.StoreInt64(&limiter.rawMinRt, 1)
+	if got := limiter.maxFlight(); got <= 0 {
+		t.Fatalf("maxFlight() = %d, want positive capacity for observed traffic", got)
+	}
+}
+
+func TestMiddlewareCountsCompletedBusinessErrorAsSuccess(t *testing.T) {
+	g := NewGroup()
+	wantErr := errors.New("business validation failed")
+	wrapped := newLimiterWithGroup(g)(func(context.Context, interface{}) (interface{}, error) {
+		time.Sleep(2 * time.Millisecond)
+		return "response", wantErr
+	})
+	ctx := context.WithValue(context.Background(), LimitKey, "business-error")
+
+	resp, err := wrapped(ctx, nil)
+	if resp != "response" {
+		t.Fatalf("response = %#v, want response", resp)
+	}
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("error = %v, want %v", err, wantErr)
+	}
+	limiter := g.Get("business-error").(*BBR)
+	if got := limiter.passStat.Reduce(stat.Count); got != 1 {
+		t.Fatalf("passStat count = %v, want 1 for a completed handler", got)
+	}
+	if got := limiter.rtStat.Reduce(stat.Sum); got <= 0 {
+		t.Fatalf("rtStat sum = %v, want > 0 for a completed handler", got)
+	}
+}
+
+func TestMiddlewarePreservesExplicitDropGate(t *testing.T) {
+	g := NewGroup()
+	wrapped := newLimiterWithGroup(g)(func(context.Context, interface{}) (interface{}, error) {
+		time.Sleep(2 * time.Millisecond)
+		return nil, nil
+	})
+	ctx := context.WithValue(context.Background(), LimitKey, "explicit-drop")
+	ctx = context.WithValue(ctx, LimitOp, overload.Drop)
+
+	if _, err := wrapped(ctx, nil); err != nil {
+		t.Fatalf("wrapped endpoint: %v", err)
+	}
+	limiter := g.Get("explicit-drop").(*BBR)
+	if got := limiter.passStat.Reduce(stat.Count); got != 0 {
+		t.Fatalf("passStat count = %v, want 0 for an explicit Drop", got)
+	}
+	if got := limiter.rtStat.Reduce(stat.Sum); got != 0 {
+		t.Fatalf("rtStat sum = %v, want 0 for an explicit Drop", got)
+	}
+}
+
+func TestMiddlewarePropagatesNilPanicAsDrop(t *testing.T) {
+	g := NewGroup()
+	wrapped := newLimiterWithGroup(g)(func(context.Context, interface{}) (interface{}, error) {
+		time.Sleep(2 * time.Millisecond)
+		panic(nil)
+	})
+	ctx := context.WithValue(context.Background(), LimitKey, "nil-panic")
+
+	returned := false
+	func() {
+		defer func() { _ = recover() }()
+		_, _ = wrapped(ctx, nil)
+		returned = true
+	}()
+	if returned {
+		t.Fatal("panic(nil) was swallowed by the middleware")
+	}
+
+	limiter := g.Get("nil-panic").(*BBR)
+	if got := atomic.LoadInt64(&limiter.inFlight); got != 0 {
+		t.Fatalf("inFlight = %d, want 0 after panic(nil)", got)
+	}
+	if got := limiter.passStat.Reduce(stat.Count); got != 0 {
+		t.Fatalf("passStat count = %v, want 0 after panic(nil)", got)
+	}
+	if got := limiter.rtStat.Reduce(stat.Sum); got != 0 {
+		t.Fatalf("rtStat sum = %v, want 0 after panic(nil)", got)
+	}
+}

--- a/overload/bbr/middle.go
+++ b/overload/bbr/middle.go
@@ -36,23 +36,23 @@ func newLimiterWithGroup(g *Group) middleware.MiddleWare {
 			if allowErr != nil {
 				return nil, allowErr
 			}
-			// Always release the inFlight slot, even if next panics. The
-			// previous code called f(...) inline after `next` returned, so a
-			// panic in any downstream middleware leaked the slot permanently
-			// — eventually inFlight > maxFlight for that key and every
-			// request to it was dropped.
+			completed := false
+			// Do not use recover() to detect this state: on Go 1.20 a
+			// panic(nil) is indistinguishable from no panic by its recovered
+			// value. A normal-completion flag lets every panic propagate while
+			// the defer still releases the in-flight slot as Drop.
 			defer func() {
-				if r := recover(); r != nil {
+				if !completed {
 					f(overload.DoneInfo{Op: overload.Drop})
-					panic(r)
+					return
 				}
-				if err != nil {
-					f(overload.DoneInfo{Op: overload.Drop})
-				} else {
-					f(overload.DoneInfo{Op: defaultOp})
-				}
+				// A normally-returning handler completed real work even when it
+				// reports a business error. Preserve the configured operation so
+				// only fail-fast or an explicit Drop skips success stats.
+				f(overload.DoneInfo{Op: defaultOp})
 			}()
 			resp, err = next(ctx, i)
+			completed = true
 			return resp, err
 		}
 	}

--- a/registry/issue83_test.go
+++ b/registry/issue83_test.go
@@ -1,0 +1,187 @@
+package registry
+
+import (
+	"context"
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+)
+
+func issue83Sorted(values []int) []int {
+	result := append([]int(nil), values...)
+	sort.Ints(result)
+	return result
+}
+
+// Behavior 4: GetServices visits every row exactly once, including the only
+// row for a single-client registry, and does not emit duplicate service IDs.
+func TestIssue83RockSteadierVisitsEveryRow(t *testing.T) {
+	tests := []struct {
+		name     string
+		clients  []int
+		services []int
+	}{
+		{name: "single client", clients: []int{1}, services: []int{10, 11, 12}},
+		{name: "last row", clients: []int{1, 2, 3}, services: []int{10, 11, 12}},
+		{name: "deduplicate", clients: []int{1}, services: []int{10, 10, 11}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewRockSteadierSubset(context.Background(), append([]int(nil), tt.clients...), tt.services, func() int64 { return 1 })
+			defer r.Close()
+			want := []int{10, 11, 12}
+			if tt.name == "deduplicate" {
+				want = []int{10, 11}
+			}
+			for _, client := range tt.clients {
+				first := r.GetServices(client)
+				got := issue83Sorted(first)
+				if !reflect.DeepEqual(got, want) {
+					t.Fatalf("GetServices(%d) = %v, want %v", client, got, want)
+				}
+				if again := r.GetServices(client); !reflect.DeepEqual(again, first) {
+					t.Fatalf("GetServices(%d) changed from %v to %v without a registry update", client, first, again)
+				}
+			}
+		})
+	}
+}
+
+// Behavior 5: a non-positive requested subset has no members and never enters
+// the division/shuffle path; positive-size selection remains intact.
+func TestIssue83SubsetRejectsNonPositiveSize(t *testing.T) {
+	instances := []interface{}{1, 2, 3, 4}
+	for _, size := range []int{0, -1} {
+		t.Run(string(rune('a'-size)), func(t *testing.T) {
+			var got []interface{}
+			func() {
+				defer func() {
+					if recovered := recover(); recovered != nil {
+						t.Fatalf("Subset(size=%d) panicked: %v", size, recovered)
+					}
+				}()
+				got = Subset(instances, 3, size)
+			}()
+			if len(got) != 0 {
+				t.Fatalf("Subset(size=%d) = %v, want empty", size, got)
+			}
+		})
+	}
+	if got := Subset(instances, 3, 2); len(got) != 2 {
+		t.Fatalf("Subset(size=2) len = %d, want 2", len(got))
+	}
+}
+
+// Behavior 6: every service owns one matrix position. Removal clears that
+// position, and subsequent churn reuses it rather than growing the matrix.
+func TestIssue83RockSteadierDeduplicatesAndReusesHoles(t *testing.T) {
+	r := NewRockSteadierSubset(context.Background(), []int{1}, []int{10, 10}, func() int64 { return 1 })
+	defer r.Close()
+
+	matrix := r.matrixServices.Load().([][]*int)
+	if len(matrix[0]) != 1 {
+		t.Fatalf("initial row length = %d, want one unique slot", len(matrix[0]))
+	}
+	r.addService([]int{10, 10})
+	matrix = r.matrixServices.Load().([][]*int)
+	if len(matrix[0]) != 1 {
+		t.Fatalf("row length after duplicate add = %d, want 1", len(matrix[0]))
+	}
+
+	r.removeService([]int{10})
+	if got := r.GetServices(1); len(got) != 0 {
+		t.Fatalf("services after remove = %v, want empty", got)
+	}
+
+	current := 20
+	r.addService([]int{current})
+	for next := 21; next < 121; next++ {
+		r.removeService([]int{current})
+		r.addService([]int{next, next})
+		current = next
+	}
+	matrix = r.matrixServices.Load().([][]*int)
+	if len(matrix[0]) != 1 {
+		t.Fatalf("row length after churn = %d, want reused single slot", len(matrix[0]))
+	}
+	if got := r.GetServices(1); !reflect.DeepEqual(got, []int{current}) {
+		t.Fatalf("services after churn = %v, want [%d]", got, current)
+	}
+}
+
+func TestIssue83RockSteadierReusesHolesAcrossRows(t *testing.T) {
+	r := NewRockSteadierSubset(context.Background(), []int{1, 2, 3}, []int{10, 11, 12}, func() int64 { return 1 })
+	defer r.Close()
+
+	const replacement = 99
+	var removed int
+	var hole [2]int
+	for id, position := range r.hasService {
+		if position[0] != r.appendIndex {
+			removed = id
+			hole = position
+			break
+		}
+	}
+	if removed == 0 {
+		t.Fatal("test setup did not find a hole outside appendIndex")
+	}
+	originalSlots := 0
+	for _, row := range r.matrixServices.Load().([][]*int) {
+		originalSlots += len(row)
+	}
+
+	r.removeService([]int{removed})
+	r.addService([]int{replacement})
+
+	if got := r.hasService[replacement]; got != hole {
+		t.Fatalf("replacement position = %v, want reused hole %v", got, hole)
+	}
+	currentSlots := 0
+	for _, row := range r.matrixServices.Load().([][]*int) {
+		currentSlots += len(row)
+	}
+	if currentSlots != originalSlots {
+		t.Fatalf("matrix slots after cross-row reuse = %d, want %d", currentSlots, originalSlots)
+	}
+	for _, service := range r.GetServices(1) {
+		if service == removed {
+			t.Fatalf("removed service %d remained visible", removed)
+		}
+	}
+}
+
+func TestIssue83RockSteadierPublicLifecycleIsIdempotent(t *testing.T) {
+	r := NewRockSteadierSubset(context.Background(), []int{1}, []int{10}, func() int64 { return 1 })
+	defer r.Close()
+	waitFor := func(want []int) {
+		t.Helper()
+		deadline := time.Now().Add(time.Second)
+		for time.Now().Before(deadline) {
+			if got := issue83Sorted(r.GetServices(1)); reflect.DeepEqual(got, want) {
+				return
+			}
+			time.Sleep(time.Millisecond)
+		}
+		t.Fatalf("GetServices(1) = %v, want %v", issue83Sorted(r.GetServices(1)), want)
+	}
+
+	if err := r.AddService(context.Background(), []int{10, 11, 11}); err != nil {
+		t.Fatalf("AddService() error = %v", err)
+	}
+	waitFor([]int{10, 11})
+	if err := r.RemoveService(context.Background(), []int{10}); err != nil {
+		t.Fatalf("RemoveService() error = %v", err)
+	}
+	waitFor([]int{11})
+	if err := r.AddService(context.Background(), []int{12, 12}); err != nil {
+		t.Fatalf("AddService() reuse error = %v", err)
+	}
+	waitFor([]int{11, 12})
+
+	matrix := r.matrixServices.Load().([][]*int)
+	if len(matrix[0]) != 2 {
+		t.Fatalf("row length after public lifecycle = %d, want reused two slots", len(matrix[0]))
+	}
+}

--- a/registry/rock_steadier_subset.go
+++ b/registry/rock_steadier_subset.go
@@ -141,13 +141,22 @@ func NewRockSteadierSubset(ctx context.Context, clients, services []int, magicNu
 
 	pad := len(clients)
 	matrix := make([][]*int, pad)
+	uniqueServices := make([]int, 0, len(services))
+	seenServices := make(map[int]struct{}, len(services))
+	for _, service := range services {
+		if _, ok := seenServices[service]; ok {
+			continue
+		}
+		seenServices[service] = struct{}{}
+		uniqueServices = append(uniqueServices, service)
+	}
 	col := 0
-	for i := 0; i < len(services); i++ {
-		matrix[i%pad] = append(matrix[i%pad], toPoint(services[i]))
+	for i := 0; i < len(uniqueServices); i++ {
+		matrix[i%pad] = append(matrix[i%pad], toPoint(uniqueServices[i]))
 		col = max(col, len(matrix[i%pad]))
 	}
 	// padding
-	ls := len(services)
+	ls := len(uniqueServices)
 	for ; ls%pad != 0; ls++ {
 		matrix[ls%pad] = append(matrix[ls%pad], nil)
 	}
@@ -232,19 +241,41 @@ func (r *RockSteadierSubset) addService(ids []int) {
 	old := r.matrixServices.Load().([][]*int)
 	matrix := make([][]*int, len(old))
 	copy(matrix, old)
+	cloned := make(map[int]bool, len(ids))
 	defer r.matrixServices.Store(matrix)
 
 	for _, id := range ids {
-		// Copy the affected row before append (which may also realloc).
-		row := make([]*int, len(matrix[r.appendIndex]), len(matrix[r.appendIndex])+1)
-		copy(row, matrix[r.appendIndex])
-		row = append(row, toPoint(id))
-		matrix[r.appendIndex] = row
-		x := r.appendIndex
-		y := len(row) - 1
+		if _, ok := r.hasService[id]; ok {
+			continue
+		}
+		x, y := -1, -1
+		for offset := 0; offset < len(matrix) && x == -1; offset++ {
+			rowIndex := (r.appendIndex + offset) % len(matrix)
+			for column, service := range matrix[rowIndex] {
+				if service == nil {
+					x, y = rowIndex, column
+					break
+				}
+			}
+		}
+		if x == -1 {
+			x = r.appendIndex
+			y = len(matrix[x])
+		}
+		if !cloned[x] {
+			row := make([]*int, len(matrix[x]), len(matrix[x])+1)
+			copy(row, matrix[x])
+			matrix[x] = row
+			cloned[x] = true
+		}
+		if y == len(matrix[x]) {
+			matrix[x] = append(matrix[x], toPoint(id))
+		} else {
+			matrix[x][y] = toPoint(id)
+		}
 		r.hasService[id] = [2]int{x, y}
-		r.col = max(r.col, len(row))
-		r.appendIndex = (r.appendIndex + 1) % len(matrix)
+		r.col = max(r.col, len(matrix[x]))
+		r.appendIndex = (x + 1) % len(matrix)
 	}
 }
 
@@ -300,14 +331,18 @@ func (r *RockSteadierSubset) GetServices(client int) []int {
 		return nil
 	}
 	services := make([]int, 0, Lot)
-	oid := idx
+	seen := make(map[int]struct{}, Lot)
 	matrix := r.matrixServices.Load().([][]*int)
 loop:
-	for (idx+1)%len(r.clients) != oid && len(services) != Lot {
+	for scanned := 0; scanned < len(r.clients) && len(services) != Lot; scanned++ {
 		for _, v := range matrix[idx] {
 			if v == nil {
 				continue
 			}
+			if _, ok := seen[*v]; ok {
+				continue
+			}
+			seen[*v] = struct{}{}
 			services = append(services, *v)
 			if len(services) == Lot {
 				break loop

--- a/registry/subset.go
+++ b/registry/subset.go
@@ -10,6 +10,9 @@ import (
 // instances 实例列表
 // size 选取的子集长度
 func Subset(instances []interface{}, clientID int, size int) []interface{} {
+	if size <= 0 {
+		return nil
+	}
 	if len(instances) <= size {
 		return instances
 	}

--- a/specs/83/PRODUCT.md
+++ b/specs/83/PRODUCT.md
@@ -1,0 +1,24 @@
+# Issue 83：网络、子集与 BBR 边界正确性
+
+## Summary
+
+修复 TCP 部分读写、registry 子集生命周期、IPv6/ARP 网络识别和 BBR 长窗口统计，使断连、分段、churn 与业务错误都不会造成 panic、重复字节、幽灵实例、永久阻塞或容量估计归零。
+
+## Behavior
+
+1. `RecvLine` 在对端于换行前关闭时返回已读部分和 EOF 类错误；空 EOF 不索引空 slice、不 panic。
+2. `Send` 跟踪每次实际写入的字节，重试只发送剩余部分；任何最终写错误（包括 `io.EOF`）返回给调用方，不报告虚假成功。
+3. `Recv(length>0)` 在提前 EOF 时返回部分数据与 `io.ErrUnexpectedEOF`/EOF；`Recv(-1)` 聚合跨多个 TCP segment 的数据直到 EOF 或短暂 idle timeout，并在返回前恢复调用前的 read deadline，后续读不被内部探测 deadline 污染。
+4. RockSteadier `GetServices` 至少扫描每一行一次，单 client 和最后一行都不遗漏，在 `Lot` 内返回稳定且去重的服务。
+5. `Subset` 对 `size<=0` 返回空结果，不 panic；正 size 行为保持不变。
+6. RockSteadier 重复 `AddService` 幂等；删除会清除唯一位置并把槽位加入可复用空间，长期 add/remove 不无限增长，也不返回幽灵服务。
+7. `HasLocalIPAddr` 将 IPv6 loopback、ULA/private 与 link-local 单播/组播视为本地地址，`ClientPublicIP` 不把它们当公网来源。
+8. ARP router discovery 使用有限 capture read timeout；静默接口在总 deadline 内返回，而不是永久阻塞。
+9. BBR 在 bucket duration 大于一秒时仍使用至少 1 的 bucket-per-second 因子，`maxFlight` 不因整数截断固定为 0。
+10. BBR middleware 将已经执行完成的 handler（即使返回业务 error）计入 Success 容量/RT 统计；fail-fast、panic 或显式 `Drop` 路径仍不进入成功统计。
+
+## Non-goals
+
+- 不承诺当 `services > clients * Lot` 时所有服务同时获得连接槽；容量本身不足。保持稳定 subsetting/低 churn，不引入每次调用轮换。该上限必须在文档/规格中明确。
+- 不删除 BBR 核心对显式 `Drop` 的 Success gate；只修 middleware 对“已完成业务错误”的错误分类。
+- 不改变 TCP 导出方法签名或 retry option 结构。

--- a/specs/83/TECH.md
+++ b/specs/83/TECH.md
@@ -1,0 +1,44 @@
+# Issue 83：技术方案
+
+## Proposed changes
+
+### TCP（Behavior 1–3）
+
+- Send 维护 offset，按 retry 策略重试 `data[offset:]`，零进展/最终错误带上下文返回。
+- 固定长度读使用 exact-read 语义；流式读在收到首段后用临时 idle deadline 继续 drain，defer 恢复原 deadline。RecvLine 对空返回先判断 error/length。
+- 用 net.Pipe/fake net.Conn 确定性测试 partial write、segmented read、early EOF 与 stale deadline。
+
+### Registry（Behavior 4–6）
+
+- GetServices 用显式 scanned-row 计数实现 do-while 行覆盖。
+- Subset 入口处理非正 size。
+- AddService 先查重；每行维护/扫描 nil 槽优先复用，remove 清除该服务的唯一位置并更新索引。
+
+### IP/ARP（Behavior 7–8）
+
+- IPv6 使用标准库 `IsPrivate`、`IsLinkLocalUnicast`、`IsLinkLocalMulticast` 与 loopback 判定。
+- pcap OpenLive 使用有限 read timeout；NextErrorTimeoutExpired 回到总 deadline 循环。
+
+### BBR（Behavior 9–10）
+
+- `winBucketPerSec` 下限钳为 1。
+- middleware 在 handler 正常返回后统一调用 Success 完成函数，业务 error 原样返回；只有 limiter 拒绝和非正常路径维持 Drop 语义，核心 Op gate 不改。
+
+## Tests
+
+1–3. fake conn/net.Pipe 覆盖 RecvLine EOF、partial Send、exact early EOF、two-segment stream 与 internal deadline restoration；逐项 mutation 必须失败。
+4. 1-client/3-service 与 3-client/3-service 均覆盖所有行。
+5. size 0/negative 空结果和正数 control。
+6. 重复 add/remove churn 后矩阵长度有界、无幽灵、hole 被复用。
+7. `fc00::1`、`fd*`、`fe80::1`、link-local multicast 与 global IPv6 matrix。
+8. ARP read timeout 逻辑抽成可注入/纯循环测试；真实 pcap 只作环境允许时的集成证据。
+9. 5m window/100 buckets 的 maxFlight 正数。
+10. middleware 业务 error 更新 pass/rt；显式 Drop control 仍不更新。
+
+## Verification
+
+```bash
+GOTOOLCHAIN=go1.20.14 go test -race -count=1 ./net/tcp ./registry ./net/ip ./net/arp ./overload/bbr
+GOTOOLCHAIN=go1.20.14 go vet ./net/tcp ./registry ./net/ip ./net/arp ./overload/bbr
+git diff --check
+```


### PR DESCRIPTION
## What

- 修复 TCP 部分读写、提前 EOF、分段流读取和 read deadline 恢复。
- 修复 RockSteadier 全行扫描、非正 subset、重复服务、幽灵槽位和长期 churn 增长。
- 识别本地 IPv6，给 ARP capture 增加有限读取期限。
- 防止 BBR 长 bucket 容量归零；已完成业务 error 计 Success，panic/fail-fast/显式 Drop 保持排除。
- 增加 PRODUCT/TECH 规格与确定性回归。

## Why

原实现会在断连时 panic、部分写重发整包、流式读取截断并污染后续 deadline；registry 会漏行、除零和留下幽灵服务；BBR 在长窗口或高业务错误率下会错误收缩容量。

## How

- Send 按 offset 写剩余字节并返回最终错误；Recv 区分 exact 与 stream 语义。
- registry 使用完整行计数、稳定去重和 copy-on-write hole reuse。
- ARP 使用 50ms capture timeout 配合总 deadline。
- middleware 用 completed 标志区分正常完成，不依赖 Go 1.20 无法判别 panic(nil) 的 recover 值。

## Tests

- Go 1.20.14 focused race count 20
- 五个相关包完整 race 与 vet
- TCP partial write/EOF/segmented/deadline；registry 100 轮 churn；IPv6/ARP/BBR 矩阵
- 独立 reviewer 的 14 项行为 mutation，以及 panic(nil) Drop/传播 follow-up mutation 均被测试捕获
- git diff --check 与 gofmt 校验

## Non-goal

当 services > clients * Lot 时连接槽总容量不足，不能承诺所有服务同时入选；本次保持稳定 subsetting，不引入每次调用轮换。

Fixes #83