### PR TITLE
fix(tools): harden time and reflection boundaries

### DIFF
--- a/coding/json/issue84_test.go
+++ b/coding/json/issue84_test.go
@@ -1,0 +1,27 @@
+package json
+
+import "testing"
+
+type issue84Payload struct {
+	Value string `json:"value"`
+}
+
+func TestUnmarshalTypedNilTarget(t *testing.T) {
+	var target *issue84Payload
+	if err := (code{}).Unmarshal([]byte(`{"value":"decoded"}`), target); err == nil {
+		t.Fatal("Unmarshal() error = nil, want non-nil typed target error")
+	}
+	if target != nil {
+		t.Fatalf("Unmarshal() changed typed-nil target to %#v", target)
+	}
+}
+
+func TestUnmarshalAllocatesNestedPointerTarget(t *testing.T) {
+	var target *issue84Payload
+	if err := (code{}).Unmarshal([]byte(`{"value":"decoded"}`), &target); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if target == nil || target.Value != "decoded" {
+		t.Fatalf("Unmarshal() target = %#v, want allocated decoded payload", target)
+	}
+}

--- a/coding/json/json.go
+++ b/coding/json/json.go
@@ -1,6 +1,7 @@
 package json
 
 import (
+	"fmt"
 	"reflect"
 
 	json "github.com/json-iterator/go"
@@ -40,6 +41,9 @@ func (c code) Unmarshal(data []byte, v interface{}) error {
 	rv := reflect.ValueOf(v)
 	for rv.Kind() == reflect.Ptr {
 		if rv.IsNil() {
+			if !rv.CanSet() {
+				return fmt.Errorf("json: unmarshal target is a nil %T", v)
+			}
 			rv.Set(reflect.New(rv.Type().Elem()))
 		}
 		rv = rv.Elem()

--- a/coding/xml/issue84_test.go
+++ b/coding/xml/issue84_test.go
@@ -1,0 +1,27 @@
+package xml
+
+import "testing"
+
+type issue84Payload struct {
+	Value string `xml:"value"`
+}
+
+func TestUnmarshalTypedNilTarget(t *testing.T) {
+	var target *issue84Payload
+	if err := (code{}).Unmarshal([]byte(`<payload><value>decoded</value></payload>`), target); err == nil {
+		t.Fatal("Unmarshal() error = nil, want non-nil typed target error")
+	}
+	if target != nil {
+		t.Fatalf("Unmarshal() changed typed-nil target to %#v", target)
+	}
+}
+
+func TestUnmarshalAllocatesNestedPointerTarget(t *testing.T) {
+	var target *issue84Payload
+	if err := (code{}).Unmarshal([]byte(`<payload><value>decoded</value></payload>`), &target); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if target == nil || target.Value != "decoded" {
+		t.Fatalf("Unmarshal() target = %#v, want allocated decoded payload", target)
+	}
+}

--- a/coding/xml/xml.go
+++ b/coding/xml/xml.go
@@ -2,6 +2,7 @@ package xml
 
 import (
 	"encoding/xml"
+	"fmt"
 	"reflect"
 
 	"github.com/songzhibin97/gkit/coding"
@@ -23,6 +24,9 @@ func (c code) Unmarshal(data []byte, v interface{}) error {
 	rv := reflect.ValueOf(v)
 	for rv.Kind() == reflect.Ptr {
 		if rv.IsNil() {
+			if !rv.CanSet() {
+				return fmt.Errorf("xml: unmarshal target is a nil %T", v)
+			}
 			rv.Set(reflect.New(rv.Type().Elem()))
 		}
 		rv = rv.Elem()

--- a/coding/yaml/issue84_test.go
+++ b/coding/yaml/issue84_test.go
@@ -1,0 +1,27 @@
+package yaml
+
+import "testing"
+
+type issue84Payload struct {
+	Value string `yaml:"value"`
+}
+
+func TestUnmarshalTypedNilTarget(t *testing.T) {
+	var target *issue84Payload
+	if err := (code{}).Unmarshal([]byte("value: decoded\n"), target); err == nil {
+		t.Fatal("Unmarshal() error = nil, want non-nil typed target error")
+	}
+	if target != nil {
+		t.Fatalf("Unmarshal() changed typed-nil target to %#v", target)
+	}
+}
+
+func TestUnmarshalAllocatesNestedPointerTarget(t *testing.T) {
+	var target *issue84Payload
+	if err := (code{}).Unmarshal([]byte("value: decoded\n"), &target); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if target == nil || target.Value != "decoded" {
+		t.Fatalf("Unmarshal() target = %#v, want allocated decoded payload", target)
+	}
+}

--- a/coding/yaml/yaml.go
+++ b/coding/yaml/yaml.go
@@ -1,6 +1,7 @@
 package yaml
 
 import (
+	"fmt"
 	"reflect"
 
 	"github.com/songzhibin97/gkit/coding"
@@ -23,6 +24,9 @@ func (c code) Unmarshal(data []byte, v interface{}) error {
 	rv := reflect.ValueOf(v)
 	for rv.Kind() == reflect.Ptr {
 		if rv.IsNil() {
+			if !rv.CanSet() {
+				return fmt.Errorf("yaml: unmarshal target is a nil %T", v)
+			}
 			rv.Set(reflect.New(rv.Type().Elem()))
 		}
 		rv = rv.Elem()

--- a/specs/84/PRODUCT.md
+++ b/specs/84/PRODUCT.md
@@ -2,14 +2,14 @@
 
 ## Summary
 
-修复 DB 时间类型的驱动契约与往返、通用反射工具的 nil/类型/递归边界，以及 ternary 代码生成的稳定构建，使公开的 error 返回通道真正承载无效输入，而不是静默丢值、清零或 panic。
+修复 DB 时间类型的驱动契约与往返、通用反射工具的 nil/类型/递归边界，以及 ternary 代码生成的稳定构建；对本 issue 明确列出的无效输入，通过公开的 error 返回通道报告错误，并消除这些边界中的静默丢值、清零或 panic。
 
 ## Behavior
 
 1. `timeout.Stamp` 的值和指针形态满足 `driver.Valuer`；`Value` 保持返回对应的 `time.Time`，并增加 nil error。
 2. `Stamp.Scan` 接受驱动常见的 `int64`、`[]byte`、`string` 与 `time.Time`；不支持的类型返回 error，绝不静默保留旧值。
 3. `Date`、`DateTime` 与 `DTime` 是无时区 wall-clock 类型：文本和 DB 值统一按 `time.Local` 解析，因此在非 UTC local zone 中 `Value → Scan` 保持相同 wall-clock 与瞬时时间。
-4. `deepcopy.DeepCopy` 与 `Clone` 保留不可寻址源 struct 的导出及普通未导出状态，深拷贝包括 `math/big.Int` 内部存储在内的未导出引用；`time.Time` 保持完整值语义，`sync`/`sync/atomic` 同步原语重置而不复制使用中状态，且所有可深拷贝引用均不与源别名。
+4. `deepcopy.DeepCopy` 与 `Clone` 保留不可寻址源 struct 的导出及普通未导出状态，深拷贝包括 `math/big.Int` 内部存储在内的未导出引用；`time.Time` 保持完整值语义，`sync`/`sync/atomic` 同步原语重置而不复制使用中状态；本项覆盖的 struct 指针/slice 字段及未导出字段引用不与源别名，不扩展 map key 等未在 issue #84 中列出的既有复制语义。
 5. `VoToDo` 与带 `FieldBind` 的 `VoToDoPlus` 遇到 nil 源指针字段时跳过该字段，不 panic，也不破坏目标字段已有值。
 6. protobuf body binder 对非 `proto.Message` 及 typed-nil message 目标返回明确错误；合法 message 仍正常反序列化。
 7. form/query binder 处理自引用指针类型时只为实际出现输入的路径分配对象；空输入面对 nil 类型环或预先存在的对象指针环都不会无限递归或栈溢出，既有非环链仍正常遍历。

--- a/specs/84/PRODUCT.md
+++ b/specs/84/PRODUCT.md
@@ -1,0 +1,29 @@
+# Issue 84：时间、反射与生成工具正确性
+
+## Summary
+
+修复 DB 时间类型的驱动契约与往返、通用反射工具的 nil/类型/递归边界，以及 ternary 代码生成的稳定构建，使公开的 error 返回通道真正承载无效输入，而不是静默丢值、清零或 panic。
+
+## Behavior
+
+1. `timeout.Stamp` 的值和指针形态满足 `driver.Valuer`；`Value` 保持返回对应的 `time.Time`，并增加 nil error。
+2. `Stamp.Scan` 接受驱动常见的 `int64`、`[]byte`、`string` 与 `time.Time`；不支持的类型返回 error，绝不静默保留旧值。
+3. `Date`、`DateTime` 与 `DTime` 是无时区 wall-clock 类型：文本和 DB 值统一按 `time.Local` 解析，因此在非 UTC local zone 中 `Value → Scan` 保持相同 wall-clock 与瞬时时间。
+4. `deepcopy.DeepCopy` 与 `Clone` 保留不可寻址源 struct 的导出及普通未导出状态，深拷贝包括 `math/big.Int` 内部存储在内的未导出引用；`time.Time` 保持完整值语义，`sync`/`sync/atomic` 同步原语重置而不复制使用中状态，且所有可深拷贝引用均不与源别名。
+5. `VoToDo` 与带 `FieldBind` 的 `VoToDoPlus` 遇到 nil 源指针字段时跳过该字段，不 panic，也不破坏目标字段已有值。
+6. protobuf body binder 对非 `proto.Message` 及 typed-nil message 目标返回明确错误；合法 message 仍正常反序列化。
+7. form/query binder 处理自引用指针类型时只为实际出现输入的路径分配对象；空输入面对 nil 类型环或预先存在的对象指针环都不会无限递归或栈溢出，既有非环链仍正常遍历。
+8. `match.Match` 对 ASCII 与多字节 rune 使用一致的 `?` 语义；源已耗尽时尾随 `?` 不会被错误接受。
+9. `StructToMap` 接收 typed-nil 指针时返回 nil，不 panic；非 nil struct 行为保持不变。
+10. JSON、XML 与 YAML codec 的顶层 typed-nil 解码目标返回 error，不 panic；可寻址的 `**T` 等嵌套指针仍可按既有行为分配并解码。
+11. `ReflectValue` 的 slice 类型分支在输入不是 slice/array 时返回类型转换 error，不 panic；合法 slice/array 转换保持不变。
+12. `DateStruct` 与 `DateTimeStruct` 的值、指针 JSON 表示一致，且两种形态都能按各自格式往返。
+13. ternary 生成器的完整模板输出包含所需 `time` import，生成文件可直接格式化和编译，不依赖手工补 import。
+
+## Non-goals
+
+- 不为 DB wall-clock 类型增加 location 配置项；本次明确沿用进程的 `time.Local`。
+- 不改变 `Stamp` 的秒单位或底层类型。
+- 不扩大 bind 的标签语法或默认值规则。
+- 不改变 deepcopy 对 `gkit:"-"` 字段的跳过契约。
+- 不重写 ternary 模板内容或生成 API。

--- a/specs/84/TECH.md
+++ b/specs/84/TECH.md
@@ -1,0 +1,58 @@
+# Issue 84：技术方案
+
+## Context
+
+行为来源为 [PRODUCT.md](./PRODUCT.md)。修改限定在 `timeout/`、`tools/deepcopy`、`tools/vto`、`tools/bind`、`tools/match`、`tools/stm`、`tools/reflect2value`、`coding/{json,xml,yaml}` 与 `ternary`。
+
+## Proposed changes
+
+### A. Timeout（Behavior 1–3、12）
+
+- 将 `Stamp.Value` 改为标准 `(driver.Value, error)`，增加编译期接口断言；`Scan` 增加 `int64` 和 default error。
+- Date/DateTime/DTime 的文本解析统一用 `time.ParseInLocation(..., time.Local)`；序列化格式不变。
+- DateStruct/DateTimeStruct 的 `MarshalJSON` 改为值接收者，使值与指针都覆盖内嵌 `time.Time` 的 RFC3339 marshal。
+
+### B. Deepcopy 与转换（Behavior 4–5、9、11）
+
+- struct copy 将不可寻址 source 转为临时可寻址值，并通过最小受控的 `reflect.NewAt` + `unsafe` 仅访问同类型的未导出字段，使普通私有值与私有引用也进入 visited graph 深拷贝；`time.Time` 作为稳定值整体保留，`sync`/`sync/atomic` 原语保持零值，`gkit:"-"` 仍保留 destination 原值。
+- vto 在指针解引用后先检查 `IsValid`。
+- stm 在 typed-nil 指针 `Elem` 前返回 nil。
+- reflect2value 的所有 slice 分支在 `.Len()` 前验证 Slice/Array kind，并走现有 type-conversion error。
+
+### C. Binding 与 codecs（Behavior 6–7、10）
+
+- protobuf binder 使用 checked type assertion，并在 unmarshal 前对所有 nilable kind 统一拒绝 typed-nil message。
+- form mapping 沿用“字段是否实际写入”的返回信息：nil pointer 先在临时候选值递归，只有子树命中输入时才写回；递归路径同时跟踪 nil pointer 类型与既有 pointer 的类型/地址，分别截断类型环和对象环。
+- JSON/XML/YAML 在顶层 value 不可设置且为 nil pointer 时直接返回目标错误；仅对可设置的嵌套 pointer 执行分配循环。
+
+### D. Match 与 ternary（Behavior 8、13）
+
+- rune 路径比较 decoded rune `sr` 与 `utf8.RuneError`，不再把字节宽度与 rune 常量比较。
+- ternary generator 在 package 声明后输出 `import "time"`，再执行模板与 `format.Source`。
+
+## Behavior-to-test mapping
+
+1. Stamp Valuer 接口断言与对应 `time.Time` Value。
+2. Stamp 各 Scan 输入及 unsupported error。
+3. 临时设置 `time.Local` 为固定 UTC+8，分别验证三类 `Value → Scan`。
+4. 同时覆盖 `Clone(valueStruct)`、`time.Time`、`math/big.Int` 内部 slice、带锁 struct 的私有标量/引用 alias independence 与锁状态重置。
+5. VoToDo 两条入口的 nil pointer field。
+6. protobuf 非 message、typed-nil message error 与合法 control。
+7. 在子进程/受控测试中绑定 nil 自引用类型及预先存在的对象环并及时返回，同时覆盖实际键能分配一层和既有非环链正常遍历。
+8. ASCII/中文源的相同尾随 `?` 矩阵。
+9. StructToMap typed-nil 与 non-nil control。
+10. 三种 codec 的 typed-nil error 和 `**T` allocation control。
+11. 每个支持的 slice 类型至少用一个 scalar 错误输入，并覆盖合法 slice。
+12. DateStruct/DateTimeStruct 值和指针 JSON 相等且可反序列化。
+13. 在临时 module 中运行生成器输出并 `go test`/`go build`。
+
+## Verification
+
+```bash
+gofmt -w <changed-go-files>
+GOTOOLCHAIN=go1.20.14 go test -race -count=1 ./timeout ./tools/deepcopy ./tools/vto ./tools/bind ./tools/match ./tools/stm ./tools/reflect2value ./coding/json ./coding/xml ./coding/yaml ./ternary
+GOTOOLCHAIN=go1.20.14 go vet ./timeout ./tools/deepcopy ./tools/vto ./tools/bind ./tools/match ./tools/stm ./tools/reflect2value ./coding/json ./coding/xml ./coding/yaml ./ternary
+git diff --check
+```
+
+每项先记录旧实现 red，再做局部修复；对 Stamp、timezone round-trip、deepcopy、self-reference bind、typed-nil codec、slice kind 与 generator import 做恢复式 mutation。自引用旧实现可能触发不可恢复 stack overflow，red 证据必须在隔离子进程完成。

--- a/specs/84/TECH.md
+++ b/specs/84/TECH.md
@@ -14,7 +14,7 @@
 
 ### B. Deepcopy 与转换（Behavior 4–5、9、11）
 
-- struct copy 将不可寻址 source 转为临时可寻址值，并通过最小受控的 `reflect.NewAt` + `unsafe` 仅访问同类型的未导出字段，使普通私有值与私有引用也进入 visited graph 深拷贝；`time.Time` 作为稳定值整体保留，`sync`/`sync/atomic` 原语保持零值，`gkit:"-"` 仍保留 destination 原值。
+- struct copy 将不可寻址 source 转为临时可寻址值，并通过最小受控的 `reflect.NewAt` + `unsafe` 仅访问同类型的未导出字段，使普通私有值与私有引用也进入 visited graph 深拷贝；`time.Time` 作为稳定值整体保留，`sync`/`sync/atomic` 原语保持零值，`gkit:"-"` 仍保留 destination 原值；map key 等未在 Behavior 4 中列出的既有复制语义不变。
 - vto 在指针解引用后先检查 `IsValid`。
 - stm 在 typed-nil 指针 `Elem` 前返回 nil。
 - reflect2value 的所有 slice 分支在 `.Len()` 前验证 Slice/Array kind，并走现有 type-conversion error。
@@ -27,7 +27,7 @@
 
 ### D. Match 与 ternary（Behavior 8、13）
 
-- rune 路径比较 decoded rune `sr` 与 `utf8.RuneError`，不再把字节宽度与 rune 常量比较。
+- rune 路径用 decoded rune 的字节宽度是否为 0 判断输入或模式已经耗尽，不再把字节宽度与 `utf8.RuneError` 常量比较，也不把合法的 U+FFFD 当作耗尽标记。
 - ternary generator 在 package 声明后输出 `import "time"`，再执行模板与 `format.Source`。
 
 ## Behavior-to-test mapping
@@ -35,7 +35,7 @@
 1. Stamp Valuer 接口断言与对应 `time.Time` Value。
 2. Stamp 各 Scan 输入及 unsupported error。
 3. 临时设置 `time.Local` 为固定 UTC+8，分别验证三类 `Value → Scan`。
-4. 同时覆盖 `Clone(valueStruct)`、`time.Time`、`math/big.Int` 内部 slice、带锁 struct 的私有标量/引用 alias independence 与锁状态重置。
+4. 同时覆盖 `Clone(valueStruct)`、`time.Time`、`math/big.Int` 内部 slice、带锁 struct 的私有标量/引用 alias independence 与锁状态重置；不将 map key 纳入本项契约。
 5. VoToDo 两条入口的 nil pointer field。
 6. protobuf 非 message、typed-nil message error 与合法 control。
 7. 在子进程/受控测试中绑定 nil 自引用类型及预先存在的对象环并及时返回，同时覆盖实际键能分配一层和既有非环链正常遍历。
@@ -43,7 +43,7 @@
 9. StructToMap typed-nil 与 non-nil control。
 10. 三种 codec 的 typed-nil error 和 `**T` allocation control。
 11. 每个支持的 slice 类型至少用一个 scalar 错误输入，并覆盖合法 slice。
-12. DateStruct/DateTimeStruct 值和指针 JSON 相等且可反序列化。
+12. DateStruct/DateTimeStruct 值和指针 JSON 相等，并分别反序列化后校验 `Time` 等于原始的格式可表示值。
 13. 在临时 module 中运行生成器输出并 `go test`/`go build`。
 
 ## Verification
@@ -55,4 +55,4 @@ GOTOOLCHAIN=go1.20.14 go vet ./timeout ./tools/deepcopy ./tools/vto ./tools/bind
 git diff --check
 ```
 
-每项先记录旧实现 red，再做局部修复；对 Stamp、timezone round-trip、deepcopy、self-reference bind、typed-nil codec、slice kind 与 generator import 做恢复式 mutation。自引用旧实现可能触发不可恢复 stack overflow，red 证据必须在隔离子进程完成。
+每项先记录旧实现 red，再做局部修复；对 Stamp、timezone round-trip、DateStruct/DateTimeStruct JSON round-trip、deepcopy、self-reference bind、typed-nil codec、slice kind 与 generator import 做恢复式 mutation。自引用旧实现可能触发不可恢复 stack overflow，red 证据必须在隔离子进程完成。

--- a/ternary/issue84_test.go
+++ b/ternary/issue84_test.go
@@ -1,0 +1,39 @@
+package ternary
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestTypeGeneratorProducesBuildableSource(t *testing.T) {
+	dir := t.TempDir()
+	copyFile := func(name string) {
+		t.Helper()
+		data, err := os.ReadFile(name)
+		if err != nil {
+			t.Fatalf("os.ReadFile(%q) error = %v", name, err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, name), data, 0o600); err != nil {
+			t.Fatalf("os.WriteFile(%q) error = %v", name, err)
+		}
+	}
+	copyFile("type_gen.go")
+	copyFile("template.txt")
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/generated-ternary\n\ngo 1.20\n"), 0o600); err != nil {
+		t.Fatalf("os.WriteFile(go.mod) error = %v", err)
+	}
+
+	generate := exec.Command("go", "run", "type_gen.go")
+	generate.Dir = dir
+	if output, err := generate.CombinedOutput(); err != nil {
+		t.Fatalf("go run type_gen.go error = %v\n%s", err, output)
+	}
+
+	build := exec.Command("go", "test", "./...")
+	build.Dir = dir
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("generated source does not build: %v\n%s", err, output)
+	}
+}

--- a/ternary/type_gen.go
+++ b/ternary/type_gen.go
@@ -26,6 +26,7 @@ func main() {
 	w := new(bytes.Buffer)
 	start_pos := strings.Index(string(fileData), packageName)
 	w.WriteString(string(fileData)[start_pos : start_pos+len(packageName)])
+	w.WriteString("\n\nimport \"time\"\n")
 
 	ts := []string{"Bool", "Byte", "Complex64", "Complex128", "Float32", "Float64", "Int", "Int8", "Int16", "Int32", "Int64", "Rune", "String", "Uint", "Uint8", "Uint16", "Uint32", "Uint64", "Uintptr"}
 

--- a/timeout/d_time.go
+++ b/timeout/d_time.go
@@ -20,7 +20,7 @@ func (d DTime) MarshalJSON() ([]byte, error) {
 }
 
 func (d *DTime) UnmarshalText(value string) error {
-	dd, err := time.Parse(DTimeFormat, value)
+	dd, err := time.ParseInLocation(DTimeFormat, value, time.Local)
 	if err != nil {
 		return err
 	}

--- a/timeout/date.go
+++ b/timeout/date.go
@@ -20,7 +20,7 @@ func (d Date) MarshalJSON() ([]byte, error) {
 }
 
 func (d *Date) UnmarshalText(value string) error {
-	dd, err := time.Parse(DateFormat, value)
+	dd, err := time.ParseInLocation(DateFormat, value, time.Local)
 	if err != nil {
 		return err
 	}

--- a/timeout/date_struct.go
+++ b/timeout/date_struct.go
@@ -47,8 +47,8 @@ func (m *DateStruct) UnmarshalJSON(src []byte) error {
 
 // MarshalJSON 序列化
 // Author [SliverHorn](https://github.com/SliverHorn)
-func (m *DateStruct) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + m.String() + `"`), nil
+func (m DateStruct) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + m.Format(DateFormat) + `"`), nil
 }
 
 // String 输出 DateTime 变量为字符串

--- a/timeout/datetime.go
+++ b/timeout/datetime.go
@@ -20,7 +20,7 @@ func (d DateTime) MarshalJSON() ([]byte, error) {
 }
 
 func (d *DateTime) UnmarshalText(value string) error {
-	dd, err := time.Parse(DateTimeFormat, value)
+	dd, err := time.ParseInLocation(DateTimeFormat, value, time.Local)
 	if err != nil {
 		return err
 	}

--- a/timeout/datetime_struct.go
+++ b/timeout/datetime_struct.go
@@ -50,8 +50,8 @@ func (m *DateTimeStruct) UnmarshalJSON(src []byte) error {
 
 // MarshalJSON 序列化
 // Author [SliverHorn](https://github.com/SliverHorn)
-func (m *DateTimeStruct) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + m.String() + `"`), nil
+func (m DateTimeStruct) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + m.Format(DateTimeFormat) + `"`), nil
 }
 
 // String 输出 DateTime 变量为字符串

--- a/timeout/issue84_test.go
+++ b/timeout/issue84_test.go
@@ -100,23 +100,33 @@ func TestWallClockDatabaseTypesRoundTripInLocalLocation(t *testing.T) {
 }
 
 func TestDateStructJSONValueAndPointerAreSymmetric(t *testing.T) {
+	// The JSON formats omit location and sub-second precision, so use UTC
+	// values that are exactly representable by each existing format.
+	date := time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)
+	dateTime := time.Date(2024, 1, 15, 10, 20, 30, 0, time.UTC)
 	tests := []struct {
-		name  string
-		value interface{}
-		ptr   interface{}
-		fresh func() interface{}
+		name        string
+		value       interface{}
+		ptr         interface{}
+		fresh       func() interface{}
+		decodedTime func(interface{}) time.Time
+		want        time.Time
 	}{
 		{
-			name:  "DateStruct",
-			value: DateStruct{Time: time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)},
-			ptr:   &DateStruct{Time: time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)},
-			fresh: func() interface{} { return &DateStruct{} },
+			name:        "DateStruct",
+			value:       DateStruct{Time: date},
+			ptr:         &DateStruct{Time: date},
+			fresh:       func() interface{} { return &DateStruct{} },
+			decodedTime: func(value interface{}) time.Time { return value.(*DateStruct).Time },
+			want:        date,
 		},
 		{
-			name:  "DateTimeStruct",
-			value: DateTimeStruct{Time: time.Date(2024, 1, 15, 10, 20, 30, 0, time.UTC)},
-			ptr:   &DateTimeStruct{Time: time.Date(2024, 1, 15, 10, 20, 30, 0, time.UTC)},
-			fresh: func() interface{} { return &DateTimeStruct{} },
+			name:        "DateTimeStruct",
+			value:       DateTimeStruct{Time: dateTime},
+			ptr:         &DateTimeStruct{Time: dateTime},
+			fresh:       func() interface{} { return &DateTimeStruct{} },
+			decodedTime: func(value interface{}) time.Time { return value.(*DateTimeStruct).Time },
+			want:        dateTime,
 		},
 	}
 	for _, tt := range tests {
@@ -132,10 +142,18 @@ func TestDateStructJSONValueAndPointerAreSymmetric(t *testing.T) {
 			if string(fromValue) != string(fromPointer) {
 				t.Fatalf("value JSON = %s, pointer JSON = %s", fromValue, fromPointer)
 			}
-			decoded := tt.fresh()
-			if err := json.Unmarshal(fromValue, decoded); err != nil {
-				t.Fatalf("value JSON did not round-trip: %v", err)
+			assertRoundTrip := func(source string, encoded []byte) {
+				t.Helper()
+				decoded := tt.fresh()
+				if err := json.Unmarshal(encoded, decoded); err != nil {
+					t.Fatalf("%s JSON did not round-trip: %v", source, err)
+				}
+				if got := tt.decodedTime(decoded); !got.Equal(tt.want) {
+					t.Fatalf("%s JSON round-trip = %v, want %v", source, got, tt.want)
+				}
 			}
+			assertRoundTrip("value", fromValue)
+			assertRoundTrip("pointer", fromPointer)
 		})
 	}
 }

--- a/timeout/issue84_test.go
+++ b/timeout/issue84_test.go
@@ -1,0 +1,141 @@
+package timeout
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestStampImplementsValuerAndScansDriverInt64(t *testing.T) {
+	if _, ok := interface{}(Stamp(123)).(driver.Valuer); !ok {
+		t.Fatal("Stamp does not implement driver.Valuer")
+	}
+	value, err := interface{}(Stamp(123)).(driver.Valuer).Value()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantTime := time.Unix(123, 0)
+	gotTime, ok := value.(time.Time)
+	if !ok || !gotTime.Equal(wantTime) {
+		t.Fatalf("Stamp.Value() = %#v, want %v", value, wantTime)
+	}
+
+	var stamp Stamp
+	if err := stamp.Scan(int64(1700000000)); err != nil {
+		t.Fatal(err)
+	}
+	if stamp != Stamp(1700000000) {
+		t.Fatalf("Stamp.Scan(int64) = %d, want 1700000000", stamp)
+	}
+	stamp = 99
+	if err := stamp.Scan(float64(123)); err == nil {
+		t.Fatal("Stamp.Scan(float64) returned nil error")
+	}
+	if stamp != 99 {
+		t.Fatalf("unsupported Scan mutated Stamp to %d", stamp)
+	}
+}
+
+func TestWallClockDatabaseTypesRoundTripInLocalLocation(t *testing.T) {
+	originalLocal := time.Local
+	time.Local = time.FixedZone("UTC+8", 8*60*60)
+	t.Cleanup(func() { time.Local = originalLocal })
+
+	tests := []struct {
+		name     string
+		original time.Time
+		value    func() (driver.Value, error)
+		scan     func(driver.Value) (time.Time, error)
+	}{
+		{
+			name:     "Date",
+			original: time.Date(2024, 1, 15, 0, 0, 0, 0, time.Local),
+			value:    func() (driver.Value, error) { return Date(time.Date(2024, 1, 15, 0, 0, 0, 0, time.Local)).Value() },
+			scan: func(value driver.Value) (time.Time, error) {
+				var decoded Date
+				err := decoded.Scan(value)
+				return time.Time(decoded), err
+			},
+		},
+		{
+			name:     "DateTime",
+			original: time.Date(2024, 1, 15, 10, 20, 30, 0, time.Local),
+			value: func() (driver.Value, error) {
+				return DateTime(time.Date(2024, 1, 15, 10, 20, 30, 0, time.Local)).Value()
+			},
+			scan: func(value driver.Value) (time.Time, error) {
+				var decoded DateTime
+				err := decoded.Scan(value)
+				return time.Time(decoded), err
+			},
+		},
+		{
+			name:     "DTime",
+			original: time.Date(0, 1, 1, 10, 20, 30, 0, time.Local),
+			value:    func() (driver.Value, error) { return DTime(time.Date(0, 1, 1, 10, 20, 30, 0, time.Local)).Value() },
+			scan: func(value driver.Value) (time.Time, error) {
+				var decoded DTime
+				err := decoded.Scan(value)
+				return time.Time(decoded), err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			encoded, err := tt.value()
+			if err != nil {
+				t.Fatal(err)
+			}
+			decoded, err := tt.scan(encoded)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !decoded.Equal(tt.original) {
+				t.Fatalf("Value -> Scan = %v (%d), want %v (%d)", decoded, decoded.Unix(), tt.original, tt.original.Unix())
+			}
+		})
+	}
+}
+
+func TestDateStructJSONValueAndPointerAreSymmetric(t *testing.T) {
+	tests := []struct {
+		name  string
+		value interface{}
+		ptr   interface{}
+		fresh func() interface{}
+	}{
+		{
+			name:  "DateStruct",
+			value: DateStruct{Time: time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)},
+			ptr:   &DateStruct{Time: time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)},
+			fresh: func() interface{} { return &DateStruct{} },
+		},
+		{
+			name:  "DateTimeStruct",
+			value: DateTimeStruct{Time: time.Date(2024, 1, 15, 10, 20, 30, 0, time.UTC)},
+			ptr:   &DateTimeStruct{Time: time.Date(2024, 1, 15, 10, 20, 30, 0, time.UTC)},
+			fresh: func() interface{} { return &DateTimeStruct{} },
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fromValue, err := json.Marshal(tt.value)
+			if err != nil {
+				t.Fatal(err)
+			}
+			fromPointer, err := json.Marshal(tt.ptr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(fromValue) != string(fromPointer) {
+				t.Fatalf("value JSON = %s, pointer JSON = %s", fromValue, fromPointer)
+			}
+			decoded := tt.fresh()
+			if err := json.Unmarshal(fromValue, decoded); err != nil {
+				t.Fatalf("value JSON did not round-trip: %v", err)
+			}
+		})
+	}
+}

--- a/timeout/stamp.go
+++ b/timeout/stamp.go
@@ -2,6 +2,7 @@ package timeout
 
 import (
 	"database/sql/driver"
+	"fmt"
 	"strconv"
 	"time"
 )
@@ -10,27 +11,37 @@ import (
 // 实现了 sql.Scanner 接口
 type Stamp int64
 
+var _ driver.Valuer = Stamp(0)
+
 // Scan 扫描赋值
 func (jt *Stamp) Scan(src interface{}) (err error) {
 	// 断言,只处理string以及原生的time.Time
 	switch sc := src.(type) {
 	case []byte:
-		var i int64
-		i, err = strconv.ParseInt(string(sc), 10, 64)
-		*jt = Stamp(i)
+		var value int64
+		value, err = strconv.ParseInt(string(sc), 10, 64)
+		if err == nil {
+			*jt = Stamp(value)
+		}
+	case int64:
+		*jt = Stamp(sc)
 	case time.Time:
 		*jt = Stamp(sc.Unix())
 	case string:
-		var i int64
-		i, err = strconv.ParseInt(sc, 10, 64)
-		*jt = Stamp(i)
+		var value int64
+		value, err = strconv.ParseInt(sc, 10, 64)
+		if err == nil {
+			*jt = Stamp(value)
+		}
+	default:
+		err = fmt.Errorf("timeout.Stamp: cannot scan value of type %T", src)
 	}
 	return
 }
 
 // Value 获取driver.Value
-func (jt Stamp) Value() driver.Value {
-	return time.Unix(int64(jt), 0)
+func (jt Stamp) Value() (driver.Value, error) {
+	return time.Unix(int64(jt), 0), nil
 }
 
 // Time 转化time.Time

--- a/tools/bind/form_mapping.go
+++ b/tools/bind/form_mapping.go
@@ -62,11 +62,28 @@ func (form formSource) TrySet(value reflect.Value, field reflect.StructField, ta
 
 func mappingByPtr(ptr interface{}, setter setter, tag string) error {
 	// emptyField 空的结构体字段
-	_, err := mapping(reflect.ValueOf(ptr), emptyField, setter, tag)
+	_, err := mapping(reflect.ValueOf(ptr), emptyField, setter, tag, newMappingState())
 	return err
 }
 
-func mapping(value reflect.Value, field reflect.StructField, setter setter, tag string) (bool, error) {
+type mappingPointer struct {
+	typ reflect.Type
+	ptr uintptr
+}
+
+type mappingState struct {
+	visitingPointers       map[mappingPointer]struct{}
+	visitingNilPointerType map[reflect.Type]struct{}
+}
+
+func newMappingState() *mappingState {
+	return &mappingState{
+		visitingPointers:       make(map[mappingPointer]struct{}),
+		visitingNilPointerType: make(map[reflect.Type]struct{}),
+	}
+}
+
+func mapping(value reflect.Value, field reflect.StructField, setter setter, tag string, state *mappingState) (bool, error) {
 	// 获取 tag, 如果是 "-" 忽略此字段
 	if field.Tag.Get(tag) == "-" {
 		return false, nil
@@ -79,12 +96,27 @@ func mapping(value reflect.Value, field reflect.StructField, setter setter, tag 
 		var isNew bool
 		vPtr := value
 		if value.IsNil() {
+			pointerType := value.Type()
+			// 自引用类型的临时候选值不能继续展开同一 nil pointer 类型。
+			if _, visiting := state.visitingNilPointerType[pointerType]; visiting {
+				return false, nil
+			}
+			state.visitingNilPointerType[pointerType] = struct{}{}
+			defer delete(state.visitingNilPointerType, pointerType)
+
 			// 如果是空指针
 			// 重新赋值 reflect.New(value.Type().Elem())
 			isNew = true
 			vPtr = reflect.New(value.Type().Elem())
+		} else {
+			pointer := mappingPointer{typ: value.Type(), ptr: value.Pointer()}
+			if _, visiting := state.visitingPointers[pointer]; visiting {
+				return false, nil
+			}
+			state.visitingPointers[pointer] = struct{}{}
+			defer delete(state.visitingPointers, pointer)
 		}
-		isSetted, err := mapping(vPtr.Elem(), field, setter, tag)
+		isSetted, err := mapping(vPtr.Elem(), field, setter, tag, state)
 		if err != nil {
 			return false, err
 		}
@@ -121,7 +153,7 @@ func mapping(value reflect.Value, field reflect.StructField, setter setter, tag 
 				continue
 			}
 			// 递归子字段
-			ok, err := mapping(value.Field(i), tValue.Field(i), setter, tag)
+			ok, err := mapping(value.Field(i), tValue.Field(i), setter, tag, state)
 			if err != nil {
 				return false, err
 			}

--- a/tools/bind/issue84_test.go
+++ b/tools/bind/issue84_test.go
@@ -1,0 +1,202 @@
+package bind
+
+import (
+	"context"
+	"io"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+type issue84NilMapMessage map[string]string
+
+func (issue84NilMapMessage) ProtoReflect() protoreflect.Message {
+	panic("typed-nil protobuf target must be rejected before ProtoReflect")
+}
+
+func TestProtobufBindingRejectsNonMessage(t *testing.T) {
+	var target struct {
+		Value string
+	}
+	err := ProtoBuf.BindBody(nil, &target)
+	if err == nil {
+		t.Fatal("BindBody() error = nil, want a protobuf target type error")
+	}
+	if !strings.Contains(err.Error(), "does not implement proto.Message") {
+		t.Fatalf("BindBody() error = %q, want explicit protobuf target type error", err)
+	}
+}
+
+func TestProtobufBindingDecodesMessage(t *testing.T) {
+	want := wrapperspb.String("decoded")
+	body, err := proto.Marshal(want)
+	if err != nil {
+		t.Fatalf("proto.Marshal() error = %v", err)
+	}
+
+	got := new(wrapperspb.StringValue)
+	if err := ProtoBuf.BindBody(body, got); err != nil {
+		t.Fatalf("BindBody() error = %v", err)
+	}
+	if !proto.Equal(got, want) {
+		t.Fatalf("BindBody() = %v, want %v", got, want)
+	}
+}
+
+func TestProtobufBindingRejectsTypedNilMessage(t *testing.T) {
+	tests := []struct {
+		name    string
+		message proto.Message
+	}{
+		{name: "pointer", message: (*wrapperspb.StringValue)(nil)},
+		{name: "map", message: issue84NilMapMessage(nil)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ProtoBuf.BindBody(nil, tt.message)
+			if err == nil {
+				t.Fatal("BindBody() error = nil, want a typed-nil target error")
+			}
+			if !strings.Contains(err.Error(), "nil proto.Message") {
+				t.Fatalf("BindBody() error = %q, want explicit typed-nil target error", err)
+			}
+		})
+	}
+}
+
+type issue84RecursiveForm struct {
+	Value string                `json:"value" form:"value"`
+	Next  *issue84RecursiveForm `form:"next"`
+}
+
+func TestFormBindingEmptySelfReferenceReturns(t *testing.T) {
+	const helperEnv = "GKIT_ISSUE84_BIND_SELF_REFERENCE_HELPER"
+	if os.Getenv(helperEnv) == "1" {
+		queryRequest := httptest.NewRequest("GET", "/", nil)
+		var queryTarget issue84RecursiveForm
+		if err := Query.Bind(queryRequest, &queryTarget); err != nil {
+			t.Fatalf("Query.Bind() error = %v", err)
+		}
+		if queryTarget.Next != nil {
+			t.Fatalf("Query.Bind() allocated Next without input: %#v", queryTarget.Next)
+		}
+
+		formRequest := httptest.NewRequest("POST", "/", strings.NewReader(""))
+		formRequest.Header.Set("Content-Type", MIMEPOSTForm)
+		var formTarget issue84RecursiveForm
+		if err := Form.Bind(formRequest, &formTarget); err != nil {
+			t.Fatalf("Form.Bind() error = %v", err)
+		}
+		if formTarget.Next != nil {
+			t.Fatalf("Form.Bind() allocated Next without input: %#v", formTarget.Next)
+		}
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestFormBindingEmptySelfReferenceReturns$", "-test.count=1")
+	cmd.Env = append(os.Environ(), helperEnv+"=1")
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() != nil {
+			t.Fatalf("self-referential form binding did not return: %v", ctx.Err())
+		}
+		t.Fatalf("self-referential form binding subprocess failed: %v", err)
+	}
+}
+
+func TestFormBindingExistingSelfReferenceReturns(t *testing.T) {
+	const helperEnv = "GKIT_ISSUE84_BIND_EXISTING_SELF_REFERENCE_HELPER"
+	if os.Getenv(helperEnv) == "1" {
+		queryRequest := httptest.NewRequest("GET", "/", nil)
+		var queryTarget issue84RecursiveForm
+		queryTarget.Next = &queryTarget
+		if err := Query.Bind(queryRequest, &queryTarget); err != nil {
+			t.Fatalf("Query.Bind() error = %v", err)
+		}
+		if queryTarget.Next != &queryTarget {
+			t.Fatalf("Query.Bind() changed the existing cycle: %#v", queryTarget.Next)
+		}
+
+		formRequest := httptest.NewRequest("POST", "/", strings.NewReader(""))
+		formRequest.Header.Set("Content-Type", MIMEPOSTForm)
+		var formTarget issue84RecursiveForm
+		formTarget.Next = &formTarget
+		if err := Form.Bind(formRequest, &formTarget); err != nil {
+			t.Fatalf("Form.Bind() error = %v", err)
+		}
+		if formTarget.Next != &formTarget {
+			t.Fatalf("Form.Bind() changed the existing cycle: %#v", formTarget.Next)
+		}
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestFormBindingExistingSelfReferenceReturns$", "-test.count=1")
+	cmd.Env = append(os.Environ(), helperEnv+"=1")
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() != nil {
+			t.Fatalf("existing self-referential form binding did not return: %v", ctx.Err())
+		}
+		t.Fatalf("existing self-referential form binding subprocess failed: %v", err)
+	}
+}
+
+func TestFormBindingSelfReferenceAllocatesForInput(t *testing.T) {
+	values := make(url.Values)
+	values.Set("next", `{"value":"child"}`)
+	queryRequest := httptest.NewRequest("GET", "/?"+values.Encode(), nil)
+	var queryTarget issue84RecursiveForm
+	if err := Query.Bind(queryRequest, &queryTarget); err != nil {
+		t.Fatalf("Query.Bind() error = %v", err)
+	}
+	assertOneChild := func(name string, got issue84RecursiveForm) {
+		t.Helper()
+		if got.Next == nil || got.Next.Value != "child" {
+			t.Fatalf("%s Next = %#v, want one allocated child", name, got.Next)
+		}
+		if got.Next.Next != nil {
+			t.Fatalf("%s allocated an unrequested grandchild: %#v", name, got.Next.Next)
+		}
+	}
+	assertOneChild("Query.Bind()", queryTarget)
+
+	formRequest := httptest.NewRequest("POST", "/", strings.NewReader(values.Encode()))
+	formRequest.Header.Set("Content-Type", MIMEPOSTForm)
+	var formTarget issue84RecursiveForm
+	if err := Form.Bind(formRequest, &formTarget); err != nil {
+		t.Fatalf("Form.Bind() error = %v", err)
+	}
+	assertOneChild("Form.Bind()", formTarget)
+}
+
+func TestFormBindingTraversesExistingAcyclicChain(t *testing.T) {
+	child := &issue84RecursiveForm{Value: "before"}
+	target := issue84RecursiveForm{Value: "before", Next: child}
+	values := make(url.Values)
+	values.Set("next", `{"value":"after"}`)
+	request := httptest.NewRequest("GET", "/?"+values.Encode(), nil)
+
+	if err := Query.Bind(request, &target); err != nil {
+		t.Fatalf("Query.Bind() error = %v", err)
+	}
+	if target.Value != "before" || target.Next != child || child.Value != "after" {
+		t.Fatalf("Query.Bind() target = %#v child = %#v, want existing chain updated in place", target, child)
+	}
+	if child.Next != nil {
+		t.Fatalf("Query.Bind() allocated an unrequested grandchild: %#v", child.Next)
+	}
+}

--- a/tools/bind/protobuf.go
+++ b/tools/bind/protobuf.go
@@ -1,8 +1,10 @@
 package bind
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net/http"
+	"reflect"
 
 	"google.golang.org/protobuf/proto"
 )
@@ -22,11 +24,28 @@ func (b protobufBinding) Bind(req *http.Request, obj interface{}) error {
 }
 
 func (protobufBinding) BindBody(body []byte, obj interface{}) error {
-	if err := proto.Unmarshal(body, obj.(proto.Message)); err != nil {
+	message, ok := obj.(proto.Message)
+	if !ok {
+		return fmt.Errorf("protobuf: target %T does not implement proto.Message", obj)
+	}
+	messageValue := reflect.ValueOf(message)
+	if !messageValue.IsValid() || isNilProtobufMessage(messageValue) {
+		return fmt.Errorf("protobuf: target %T is a nil proto.Message", obj)
+	}
+	if err := proto.Unmarshal(body, message); err != nil {
 		return err
 	}
 	// Here it's same to return validate(obj), but util now we can't add
 	// `binding:""` to the struct which automatically generate by gen-proto
 	return nil
 	// return validate(obj)
+}
+
+func isNilProtobufMessage(value reflect.Value) bool {
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
 }

--- a/tools/deepcopy/deepcopy.go
+++ b/tools/deepcopy/deepcopy.go
@@ -2,6 +2,8 @@ package deepcopy
 
 import (
 	"reflect"
+	"time"
+	"unsafe"
 
 	"github.com/songzhibin97/gkit/tools"
 )
@@ -18,6 +20,22 @@ type visitKey struct {
 	ptr uintptr
 	len int
 	cap int
+}
+
+var timeType = reflect.TypeOf(time.Time{})
+
+func isSynchronizationPrimitive(t reflect.Type) bool {
+	return t.Kind() == reflect.Struct && (t.PkgPath() == "sync" || t.PkgPath() == "sync/atomic")
+}
+
+// accessibleField returns a settable view of an unexported field. The unsafe
+// operation is deliberately constrained to addressable fields of the same
+// source/destination type: it neither retains the raw pointer nor exposes it
+// outside this recursive copy. This is required to deep-copy private reference
+// state such as math/big.Int's internal word slice instead of shallow-copying
+// it with the enclosing struct.
+func accessibleField(value reflect.Value) reflect.Value {
+	return reflect.NewAt(value.Type(), unsafe.Pointer(value.UnsafeAddr())).Elem()
 }
 
 // deepCopy recursively copies src into dst. The visited map tracks
@@ -84,14 +102,45 @@ func deepCopy(dst, src reflect.Value, visited map[visitKey]reflect.Value) {
 		for i := 0; i < src.Len(); i++ {
 			deepCopy(dst.Index(i), src.Index(i), visited)
 		}
+	case reflect.Array:
+		for i := 0; i < src.Len(); i++ {
+			deepCopy(dst.Index(i), src.Index(i), visited)
+		}
 	case reflect.Struct:
 		typeSrc := src.Type()
+		if typeSrc == timeType {
+			dst.Set(src)
+			return
+		}
+		if isSynchronizationPrimitive(typeSrc) {
+			// Synchronization state must never be copied after first use. A
+			// containing struct is still traversed so its unrelated private
+			// fields are preserved, while the primitive itself stays reset.
+			dst.Set(reflect.Zero(typeSrc))
+			return
+		}
+
+		// reflect.ValueOf(valueStruct) is not addressable. Materialize an
+		// addressable read-only copy so its unexported fields can be traversed
+		// with the narrowly-scoped accessibleField helper below.
+		addressableSrc := src
+		if !addressableSrc.CanAddr() {
+			addressableSrc = reflect.New(typeSrc).Elem()
+			addressableSrc.Set(src)
+		}
 		for i := 0; i < src.NumField(); i++ {
-			value := src.Field(i)
-			tag := typeSrc.Field(i).Tag
-			if value.CanSet() && tag.Get("gkit") != "-" {
-				deepCopy(dst.Field(i), value, visited)
+			field := typeSrc.Field(i)
+			if field.Tag.Get("gkit") == "-" {
+				continue
 			}
+
+			srcField := addressableSrc.Field(i)
+			dstField := dst.Field(i)
+			if !field.IsExported() {
+				srcField = accessibleField(srcField)
+				dstField = accessibleField(dstField)
+			}
+			deepCopy(dstField, srcField, visited)
 		}
 	default:
 		dst.Set(src)
@@ -102,6 +151,9 @@ func DeepCopy(dst, src interface{}) error {
 	dstT, srcT := reflect.TypeOf(dst), reflect.TypeOf(src)
 	if dstT != srcT {
 		return tools.ErrorNoEquals
+	}
+	if srcT == nil {
+		return tools.ErrorInvalidValue
 	}
 	if srcT.Kind() != reflect.Ptr {
 		return tools.ErrorMustPtr
@@ -116,6 +168,9 @@ func DeepCopy(dst, src interface{}) error {
 
 func Clone(v interface{}) interface{} {
 	rv := reflect.ValueOf(v)
+	if !rv.IsValid() {
+		return nil
+	}
 	visited := map[visitKey]reflect.Value{}
 	if rv.Kind() == reflect.Ptr && !rv.IsNil() {
 		// Allocate a new *T, register it in the visited map BEFORE

--- a/tools/deepcopy/issue84_test.go
+++ b/tools/deepcopy/issue84_test.go
@@ -1,0 +1,185 @@
+package deepcopy
+
+import (
+	"math/big"
+	"sync"
+	"testing"
+	"time"
+)
+
+type issue84Value struct {
+	private int
+	When    time.Time
+	Pointer *int
+	Slice   []string
+	Skip    *int `gkit:"-"`
+}
+
+func TestClonePreservesValueStructAndDeepCopiesExportedReferences(t *testing.T) {
+	pointer, skipped := 7, 11
+	wantTime := time.Date(2024, time.March, 4, 5, 6, 7, 8, time.FixedZone("issue84", 8*60*60))
+	src := issue84Value{
+		private: 19,
+		When:    wantTime,
+		Pointer: &pointer,
+		Slice:   []string{"before"},
+		Skip:    &skipped,
+	}
+
+	got, ok := Clone(src).(issue84Value)
+	if !ok {
+		t.Fatalf("Clone returned %T, want issue84Value", Clone(src))
+	}
+	if got.private != src.private {
+		t.Fatalf("private state = %d, want %d", got.private, src.private)
+	}
+	if !got.When.Equal(src.When) || got.When.Location() != src.When.Location() {
+		t.Fatalf("time = %v (%p), want %v (%p)", got.When, got.When.Location(), src.When, src.When.Location())
+	}
+	if got.Pointer == nil || *got.Pointer != pointer {
+		t.Fatalf("Pointer = %v, want pointer to %d", got.Pointer, pointer)
+	}
+	if got.Pointer == src.Pointer {
+		t.Fatal("Pointer aliases the source")
+	}
+	if len(got.Slice) != 1 || got.Slice[0] != "before" {
+		t.Fatalf("Slice = %v, want [before]", got.Slice)
+	}
+	if &got.Slice[0] == &src.Slice[0] {
+		t.Fatal("Slice aliases the source")
+	}
+	if got.Skip != nil {
+		t.Fatalf("gkit:- field = %v, want zero value", got.Skip)
+	}
+
+	*got.Pointer = 23
+	got.Slice[0] = "after"
+	if pointer != 7 || src.Slice[0] != "before" {
+		t.Fatalf("mutating clone changed source: pointer=%d slice=%v", pointer, src.Slice)
+	}
+}
+
+func TestDeepCopyPreservesTimeAndDestinationSkippedField(t *testing.T) {
+	pointer, sourceSkipped, destinationSkipped := 7, 11, 13
+	src := &issue84Value{
+		private: 19,
+		When:    time.Date(2024, time.March, 4, 5, 6, 7, 8, time.Local),
+		Pointer: &pointer,
+		Slice:   []string{"before"},
+		Skip:    &sourceSkipped,
+	}
+	dst := issue84Value{Skip: &destinationSkipped}
+
+	if err := DeepCopy(&dst, src); err != nil {
+		t.Fatalf("DeepCopy: %v", err)
+	}
+	if dst.private != src.private || !dst.When.Equal(src.When) {
+		t.Fatalf("value state not preserved: got private=%d time=%v, want private=%d time=%v", dst.private, dst.When, src.private, src.When)
+	}
+	if dst.Pointer == nil || dst.Pointer == src.Pointer || *dst.Pointer != pointer {
+		t.Fatalf("Pointer = %v, source=%v", dst.Pointer, src.Pointer)
+	}
+	if len(dst.Slice) != 1 || &dst.Slice[0] == &src.Slice[0] {
+		t.Fatalf("Slice = %v, source=%v", dst.Slice, src.Slice)
+	}
+	if dst.Skip != &destinationSkipped {
+		t.Fatalf("gkit:- field was overwritten: got %v, want destination value", dst.Skip)
+	}
+}
+
+func TestDeepCopyKeepsUnexportedSkippedField(t *testing.T) {
+	type value struct {
+		privateSkip int `gkit:"-"`
+		Copied      int
+	}
+	src := &value{privateSkip: 7, Copied: 11}
+	dst := value{privateSkip: 13}
+
+	if err := DeepCopy(&dst, src); err != nil {
+		t.Fatalf("DeepCopy: %v", err)
+	}
+	if dst.privateSkip != 13 || dst.Copied != 11 {
+		t.Fatalf("DeepCopy = %+v, want privateSkip=13 Copied=11", dst)
+	}
+}
+
+type issue84LockedValue struct {
+	mu    sync.Mutex
+	Value int
+}
+
+func TestCloneDoesNotCopyLockedMutexState(t *testing.T) {
+	src := &issue84LockedValue{Value: 7}
+	src.mu.Lock()
+	defer src.mu.Unlock()
+
+	got, ok := Clone(src).(*issue84LockedValue)
+	if !ok {
+		t.Fatalf("Clone returned %T, want *issue84LockedValue", Clone(src))
+	}
+	if got.Value != src.Value {
+		t.Fatalf("Value = %d, want %d", got.Value, src.Value)
+	}
+	if !got.mu.TryLock() {
+		t.Fatal("clone inherited the source mutex's locked state")
+	}
+	got.mu.Unlock()
+}
+
+func TestCloneDeepCopiesUnexportedBigIntStorage(t *testing.T) {
+	src := new(big.Int).Lsh(big.NewInt(1), 256)
+	want := new(big.Int).Set(src)
+
+	got, ok := Clone(src).(*big.Int)
+	if !ok {
+		t.Fatalf("Clone returned %T, want *big.Int", Clone(src))
+	}
+	got.SetBit(got, 0, 1)
+
+	if src.Cmp(want) != 0 {
+		t.Fatalf("mutating clone changed source: got %v, want %v", src, want)
+	}
+	if got.Bit(0) != 1 {
+		t.Fatalf("clone bit 0 = %d, want 1", got.Bit(0))
+	}
+}
+
+type issue84LockedPrivateValue struct {
+	mu         sync.Mutex
+	private    int
+	privateRef []int
+}
+
+func TestCloneResetsMutexAndPreservesPrivateState(t *testing.T) {
+	src := &issue84LockedPrivateValue{private: 19, privateRef: []int{7}}
+	src.mu.Lock()
+	defer src.mu.Unlock()
+
+	got, ok := Clone(src).(*issue84LockedPrivateValue)
+	if !ok {
+		t.Fatalf("Clone returned %T, want *issue84LockedPrivateValue", Clone(src))
+	}
+	if !got.mu.TryLock() {
+		t.Fatal("clone inherited the source mutex's locked state")
+	}
+	got.mu.Unlock()
+	if got.private != src.private {
+		t.Fatalf("private = %d, want %d", got.private, src.private)
+	}
+	if len(got.privateRef) != 1 || got.privateRef[0] != 7 {
+		t.Fatalf("privateRef = %v, want [7]", got.privateRef)
+	}
+	if &got.privateRef[0] == &src.privateRef[0] {
+		t.Fatal("privateRef aliases the source")
+	}
+	got.privateRef[0] = 23
+	if src.privateRef[0] != 7 {
+		t.Fatalf("mutating clone changed source privateRef: %v", src.privateRef)
+	}
+}
+
+func TestCloneNilReturnsNil(t *testing.T) {
+	if got := Clone(nil); got != nil {
+		t.Fatalf("Clone(nil) = %#v, want nil", got)
+	}
+}

--- a/tools/match/issue84_test.go
+++ b/tools/match/issue84_test.go
@@ -1,0 +1,28 @@
+package match
+
+import "testing"
+
+func TestQuestionWildcardRequiresOneRune(t *testing.T) {
+	tests := []struct {
+		name    string
+		str     string
+		pattern string
+		want    bool
+	}{
+		{name: "ASCII exhausted", str: "ab", pattern: "ab?", want: false},
+		{name: "multibyte exhausted", str: "\u4e2d", pattern: "\u4e2d?", want: false},
+		{name: "ASCII present", str: "abc", pattern: "ab?", want: true},
+		{name: "multibyte present", str: "\u4e2d\u6587", pattern: "\u4e2d?", want: true},
+		{name: "wildcard consumes multibyte", str: "\u4e2d", pattern: "?", want: true},
+		{name: "wildcard consumes replacement rune", str: "\ufffd", pattern: "?", want: true},
+		{name: "literal replacement rune", str: "\ufffd", pattern: "\ufffd", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Match(tt.str, tt.pattern); got != tt.want {
+				t.Fatalf("Match(%q, %q) = %v, want %v", tt.str, tt.pattern, got, tt.want)
+			}
+		})
+	}
+}

--- a/tools/match/match.go
+++ b/tools/match/match.go
@@ -28,15 +28,14 @@ func deepMatch(str, pattern string) bool {
 			// 如果大于 0x7f 使用 utf-8 rune解析
 			return deepMatchRune(str, pattern)
 		}
+		if len(str) > 0 && str[0] > 0x7f {
+			return deepMatchRune(str, pattern)
+		}
 		switch pattern[0] {
 		default:
 			// 如果 待匹配 str 为空 匹配失败
 			if len(str) == 0 {
 				return false
-			}
-			// 如果非ASCII进行rune解析
-			if str[0] > 0x7f {
-				return deepMatchRune(str, pattern)
 			}
 			// 判断str[0] 与 pattern[0] 是否相同
 			if str[0] != pattern[0] {
@@ -94,11 +93,11 @@ func deepMatchRune(str, pattern string) bool {
 		pr, prsz = utf8.RuneError, 0
 	}
 	// done reading
-	for pr != utf8.RuneError {
+	for prsz > 0 {
 		switch pr {
 		default:
 			// 如果另外一个已经读空了 直接返回
-			if srsz == utf8.RuneError {
+			if srsz == 0 {
 				return false
 			}
 			// 判断两个字节是否相同
@@ -107,7 +106,7 @@ func deepMatchRune(str, pattern string) bool {
 			}
 		case '?':
 			// ? 如果另外一个已经读空了 直接返回
-			if srsz == utf8.RuneError {
+			if srsz == 0 {
 				return false
 			}
 		case '*':

--- a/tools/reflect2value/issue84_test.go
+++ b/tools/reflect2value/issue84_test.go
@@ -1,0 +1,59 @@
+package reflect2value
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestReflectValueSliceTypesRejectScalarAndAcceptSliceOrArray(t *testing.T) {
+	tests := []struct {
+		valueType string
+		slice     interface{}
+		array     interface{}
+		want      interface{}
+	}{
+		{valueType: "[]bool", slice: []bool{true, false}, array: [2]bool{true, false}, want: []bool{true, false}},
+		{valueType: "[]int", slice: []int64{1, 2}, array: [2]int64{1, 2}, want: []int{1, 2}},
+		{valueType: "[]int8", slice: []int64{1, 2}, array: [2]int64{1, 2}, want: []int8{1, 2}},
+		{valueType: "[]int16", slice: []int64{1, 2}, array: [2]int64{1, 2}, want: []int16{1, 2}},
+		{valueType: "[]int32", slice: []int64{1, 2}, array: [2]int64{1, 2}, want: []int32{1, 2}},
+		{valueType: "[]int64", slice: []int64{1, 2}, array: [2]int64{1, 2}, want: []int64{1, 2}},
+		{valueType: "[]uint", slice: []uint64{1, 2}, array: [2]uint64{1, 2}, want: []uint{1, 2}},
+		{valueType: "[]uint8", slice: []uint64{1, 2}, array: [2]uint64{1, 2}, want: []uint8{1, 2}},
+		{valueType: "[]uint16", slice: []uint64{1, 2}, array: [2]uint64{1, 2}, want: []uint16{1, 2}},
+		{valueType: "[]uint32", slice: []uint64{1, 2}, array: [2]uint64{1, 2}, want: []uint32{1, 2}},
+		{valueType: "[]uint64", slice: []uint64{1, 2}, array: [2]uint64{1, 2}, want: []uint64{1, 2}},
+		{valueType: "[]float32", slice: []float64{1.25, 2.5}, array: [2]float64{1.25, 2.5}, want: []float32{1.25, 2.5}},
+		{valueType: "[]float64", slice: []float64{1.25, 2.5}, array: [2]float64{1.25, 2.5}, want: []float64{1.25, 2.5}},
+		{valueType: "[]string", slice: []string{"one", "two"}, array: [2]string{"one", "two"}, want: []string{"one", "two"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.valueType, func(t *testing.T) {
+			if _, err := ReflectValue(tt.valueType, int64(1)); err == nil {
+				t.Fatal("scalar input returned nil error")
+			}
+			for name, input := range map[string]interface{}{"slice": tt.slice, "array": tt.array} {
+				t.Run(name, func(t *testing.T) {
+					got, err := ReflectValue(tt.valueType, input)
+					if err != nil {
+						t.Fatalf("ReflectValue: %v", err)
+					}
+					if !reflect.DeepEqual(got.Interface(), tt.want) {
+						t.Fatalf("ReflectValue = %#v, want %#v", got.Interface(), tt.want)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestReflectValueUintSliceKeepsBase64Input(t *testing.T) {
+	got, err := ReflectValue("[]uint8", "AQI=")
+	if err != nil {
+		t.Fatalf("ReflectValue: %v", err)
+	}
+	if !reflect.DeepEqual(got.Interface(), []uint8{1, 2}) {
+		t.Fatalf("ReflectValue = %#v, want []uint8{1, 2}", got.Interface())
+	}
+}

--- a/tools/reflect2value/reflect.go
+++ b/tools/reflect2value/reflect.go
@@ -171,15 +171,28 @@ func reflectValues(valueType string, value interface{}) (reflect.Value, error) {
 		return reflect.MakeSlice(theType, 0, 0), nil
 	}
 
+	values := reflect.ValueOf(value)
+	if (strings.HasPrefix(theType.String(), "[]uint") || theType.String() == "[]byte") && values.Type().String() == "string" {
+		// Decode the base64 string if the value type is []uint8 or its
+		// alias []byte. This is the existing JSON compatibility path.
+		output, err := base64.StdEncoding.DecodeString(value.(string))
+		if err != nil {
+			return reflect.Value{}, err
+		}
+		value = output
+		values = reflect.ValueOf(value)
+	}
+	if values.Kind() != reflect.Slice && values.Kind() != reflect.Array {
+		return reflect.Value{}, typeConversionError(value, theType.String())
+	}
+
 	var theValue reflect.Value
 
 	// Booleans
 	if theType.String() == "[]bool" {
-		bools := reflect.ValueOf(value)
-
-		theValue = reflect.MakeSlice(theType, bools.Len(), bools.Len())
-		for i := 0; i < bools.Len(); i++ {
-			boolValue, err := getBoolValue(strings.Split(theType.String(), "[]")[1], bools.Index(i).Interface())
+		theValue = reflect.MakeSlice(theType, values.Len(), values.Len())
+		for i := 0; i < values.Len(); i++ {
+			boolValue, err := getBoolValue(strings.Split(theType.String(), "[]")[1], values.Index(i).Interface())
 			if err != nil {
 				return reflect.Value{}, err
 			}
@@ -192,11 +205,9 @@ func reflectValues(valueType string, value interface{}) (reflect.Value, error) {
 
 	// Integers
 	if strings.HasPrefix(theType.String(), "[]int") {
-		ints := reflect.ValueOf(value)
-
-		theValue = reflect.MakeSlice(theType, ints.Len(), ints.Len())
-		for i := 0; i < ints.Len(); i++ {
-			intValue, err := getIntValue(strings.Split(theType.String(), "[]")[1], ints.Index(i).Interface())
+		theValue = reflect.MakeSlice(theType, values.Len(), values.Len())
+		for i := 0; i < values.Len(); i++ {
+			intValue, err := getIntValue(strings.Split(theType.String(), "[]")[1], values.Index(i).Interface())
 			if err != nil {
 				return reflect.Value{}, err
 			}
@@ -211,23 +222,9 @@ func reflectValues(valueType string, value interface{}) (reflect.Value, error) {
 
 	// Unsigned integers
 	if strings.HasPrefix(theType.String(), "[]uint") || theType.String() == "[]byte" {
-
-		// Decode the base64 string if the value type is []uint8 or it's alias []byte
-		// See: https://golang.org/pkg/encoding/json/#Marshal
-		// > Array and slice values encode as JSON arrays, except that []byte encodes as a base64-encoded string
-		if reflect.TypeOf(value).String() == "string" {
-			output, err := base64.StdEncoding.DecodeString(value.(string))
-			if err != nil {
-				return reflect.Value{}, err
-			}
-			value = output
-		}
-
-		uints := reflect.ValueOf(value)
-
-		theValue = reflect.MakeSlice(theType, uints.Len(), uints.Len())
-		for i := 0; i < uints.Len(); i++ {
-			uintValue, err := getUintValue(strings.Split(theType.String(), "[]")[1], uints.Index(i).Interface())
+		theValue = reflect.MakeSlice(theType, values.Len(), values.Len())
+		for i := 0; i < values.Len(); i++ {
+			uintValue, err := getUintValue(strings.Split(theType.String(), "[]")[1], values.Index(i).Interface())
 			if err != nil {
 				return reflect.Value{}, err
 			}
@@ -242,11 +239,9 @@ func reflectValues(valueType string, value interface{}) (reflect.Value, error) {
 
 	// Floating point numbers
 	if strings.HasPrefix(theType.String(), "[]float") {
-		floats := reflect.ValueOf(value)
-
-		theValue = reflect.MakeSlice(theType, floats.Len(), floats.Len())
-		for i := 0; i < floats.Len(); i++ {
-			floatValue, err := getFloatValue(strings.Split(theType.String(), "[]")[1], floats.Index(i).Interface())
+		theValue = reflect.MakeSlice(theType, values.Len(), values.Len())
+		for i := 0; i < values.Len(); i++ {
+			floatValue, err := getFloatValue(strings.Split(theType.String(), "[]")[1], values.Index(i).Interface())
 			if err != nil {
 				return reflect.Value{}, err
 			}
@@ -261,11 +256,9 @@ func reflectValues(valueType string, value interface{}) (reflect.Value, error) {
 
 	// Strings
 	if theType.String() == "[]string" {
-		strs := reflect.ValueOf(value)
-
-		theValue = reflect.MakeSlice(theType, strs.Len(), strs.Len())
-		for i := 0; i < strs.Len(); i++ {
-			strValue, err := getStringValue(strings.Split(theType.String(), "[]")[1], strs.Index(i).Interface())
+		theValue = reflect.MakeSlice(theType, values.Len(), values.Len())
+		for i := 0; i < values.Len(); i++ {
+			strValue, err := getStringValue(strings.Split(theType.String(), "[]")[1], values.Index(i).Interface())
 			if err != nil {
 				return reflect.Value{}, err
 			}

--- a/tools/stm/issue84_test.go
+++ b/tools/stm/issue84_test.go
@@ -1,0 +1,24 @@
+package stm
+
+import "testing"
+
+type issue84Struct struct {
+	Name string `json:"name"`
+}
+
+func TestStructToMapTypedNilPointerReturnsNil(t *testing.T) {
+	var src *issue84Struct
+	if got := StructToMap(src, "json"); got != nil {
+		t.Fatalf("StructToMap = %#v, want nil", got)
+	}
+	if got := StructToMapExtraExport(src, "json"); got != nil {
+		t.Fatalf("StructToMapExtraExport = %#v, want nil", got)
+	}
+}
+
+func TestStructToMapNonNilControl(t *testing.T) {
+	got := StructToMap(&issue84Struct{Name: "gkit"}, "json")
+	if got == nil || got["name"] != "gkit" {
+		t.Fatalf("StructToMap = %#v, want map[name:gkit]", got)
+	}
+}

--- a/tools/stm/stm.go
+++ b/tools/stm/stm.go
@@ -17,7 +17,13 @@ func StructToMapExtraExport(val interface{}, tag string) map[string]interface{} 
 
 func structToMap(val interface{}, tag string, extraExport bool) map[string]interface{} {
 	t, v := reflect.TypeOf(val), reflect.ValueOf(val)
+	if !v.IsValid() {
+		return nil
+	}
 	if v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return nil
+		}
 		return structToMap(v.Elem().Interface(), tag, extraExport)
 	}
 	if v.Kind() != reflect.Struct {

--- a/tools/vto/issue84_test.go
+++ b/tools/vto/issue84_test.go
@@ -1,0 +1,50 @@
+package vto
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/songzhibin97/gkit/tools"
+)
+
+type issue84Destination struct {
+	Count int
+}
+
+type issue84Source struct {
+	Count *int
+}
+
+func TestVoToDoSkipsNilSourcePointerField(t *testing.T) {
+	dst := issue84Destination{Count: 42}
+	src := issue84Source{}
+
+	if err := VoToDo(&dst, &src); err != nil {
+		t.Fatalf("VoToDo: %v", err)
+	}
+	if dst.Count != 42 {
+		t.Fatalf("Count = %d, want existing value 42", dst.Count)
+	}
+}
+
+func TestVoToDoPlusFieldBindSkipsNilSourcePointerField(t *testing.T) {
+	dst := issue84Destination{Count: 42}
+	src := issue84Source{}
+
+	if err := VoToDoPlus(&dst, &src, ModelParameters{Model: FieldBind}); err != nil {
+		t.Fatalf("VoToDoPlus: %v", err)
+	}
+	if dst.Count != 42 {
+		t.Fatalf("Count = %d, want existing value 42", dst.Count)
+	}
+}
+
+func TestVoToDoNilTopLevelPointerReturnsExistingError(t *testing.T) {
+	var dst *issue84Destination
+	src := issue84Source{}
+
+	err := VoToDo(dst, &src)
+	if !errors.Is(err, tools.ErrorInvalidValue) {
+		t.Fatalf("VoToDo error = %v, want %v", err, tools.ErrorInvalidValue)
+	}
+}

--- a/tools/vto/votodo.go
+++ b/tools/vto/votodo.go
@@ -31,6 +31,9 @@ type ModelParameters struct {
 // 支持简单的 default模式 在基础类型增加default可以指定默认值
 func VoToDo(dst interface{}, src interface{}) error {
 	dstT, srcT := reflect.TypeOf(dst), reflect.TypeOf(src)
+	if dstT == nil || srcT == nil {
+		return tools.ErrorInvalidValue
+	}
 	if dstT.Kind() != srcT.Kind() {
 		return tools.ErrorNoEquals
 	}
@@ -41,7 +44,11 @@ func VoToDo(dst interface{}, src interface{}) error {
 	if dstT.Kind() != reflect.Struct || srcT.Kind() != reflect.Struct {
 		return tools.ErrorMustStructPtr
 	}
-	dstV, srcV := reflect.ValueOf(dst).Elem(), reflect.ValueOf(src).Elem()
+	dstPtr, srcPtr := reflect.ValueOf(dst), reflect.ValueOf(src)
+	if dstPtr.IsNil() || srcPtr.IsNil() {
+		return tools.ErrorInvalidValue
+	}
+	dstV, srcV := dstPtr.Elem(), srcPtr.Elem()
 	for i := 0; i < dstT.NumField(); i++ {
 		field := dstT.Field(i)
 		if !field.IsExported() {
@@ -55,6 +62,9 @@ func VoToDo(dst interface{}, src interface{}) error {
 		s := srcV.FieldByName(field.Name)
 		for s.Kind() == reflect.Ptr && d.Kind() != s.Kind() {
 			s = s.Elem()
+		}
+		if !s.IsValid() {
+			continue
 		}
 
 		if d.Kind() != s.Kind() && !d.CanConvert(s.Type()) {
@@ -103,6 +113,9 @@ func VoToDo(dst interface{}, src interface{}) error {
 // ModelParameters: 模式匹配
 func VoToDoPlus(dst interface{}, src interface{}, model ModelParameters) error {
 	dstT, srcT := reflect.TypeOf(dst), reflect.TypeOf(src)
+	if dstT == nil || srcT == nil {
+		return tools.ErrorInvalidValue
+	}
 	if dstT.Kind() != srcT.Kind() {
 		return tools.ErrorNoEquals
 	}
@@ -113,7 +126,11 @@ func VoToDoPlus(dst interface{}, src interface{}, model ModelParameters) error {
 	if dstT.Kind() != reflect.Struct || srcT.Kind() != reflect.Struct {
 		return tools.ErrorMustStructPtr
 	}
-	dstV, srcV := reflect.ValueOf(dst).Elem(), reflect.ValueOf(src).Elem()
+	dstPtr, srcPtr := reflect.ValueOf(dst), reflect.ValueOf(src)
+	if dstPtr.IsNil() || srcPtr.IsNil() {
+		return tools.ErrorInvalidValue
+	}
+	dstV, srcV := dstPtr.Elem(), srcPtr.Elem()
 
 	if model.Model&TagBind == TagBind && len(model.Tag) == 0 {
 		model.Tag = "json"
@@ -143,6 +160,9 @@ func VoToDoPlus(dst interface{}, src interface{}, model ModelParameters) error {
 			s := srcV.FieldByName(field.Name)
 			for s.Kind() == reflect.Ptr && d.Kind() != s.Kind() {
 				s = s.Elem()
+			}
+			if !s.IsValid() {
+				continue
 			}
 			if d.Kind() != s.Kind() && !d.CanConvert(s.Type()) {
 				continue
@@ -213,6 +233,9 @@ func VoToDoPlus(dst interface{}, src interface{}, model ModelParameters) error {
 				ss := srcV.FieldByName(srcField.Name)
 				for ss.Kind() == reflect.Ptr && d.Kind() != ss.Kind() {
 					ss = ss.Elem()
+				}
+				if !ss.IsValid() {
+					continue
 				}
 				if d.Kind() != ss.Kind() {
 					continue


### PR DESCRIPTION
## What

- 修复 timeout Stamp 的 database/sql 契约、BIGINT 扫描、本地时区往返和 JSON 值/指针对称性。
- 修复 deepcopy 私有状态/引用、bind 自引用、protobuf typed nil、vto/stm/reflect2value 的反射边界。
- 修复 match 的多字节与 U+FFFD 语义、三种 codec typed nil，以及 ternary 生成器缺失 time import。
- 增加 PRODUCT/TECH 规格和 13 项行为回归。

## Why

原实现会静默清零或别名共享私有状态，遇到 nil/错误 Kind 时 panic，自引用绑定无法终止；数据库时间类型与生成代码也不满足各自运行时契约。

## How

- Stamp 实现 driver.Valuer，并统一本地 wall-clock 解析。
- deepcopy 以受控 reflect.NewAt 访问同类型未导出字段，深拷引用，重置 sync 原语并保留 time.Time 值语义。
- bind 同时跟踪 nil 类型递归与既有 pointer identity；protobuf 拒绝所有 nilable kind 的 typed nil。
- match 用 decoded rune size 判断输入/模式是否耗尽。

## Tests

- Go 1.20.14 focused race count 20
- 12 个相关包完整 race 与 vet
- big.Int 私有存储隔离、sync/private state、nil/既有 pointer 环、typed-nil protobuf map、U+FFFD 等边界
- 独立 reviewer 16/16 项关键 mutation 均被测试捕获
- git diff --check 与 gofmt 校验

Fixes #84