### PR TITLE
fix(page_token): prevent page range overflow

### DIFF
--- a/page_token/token.go
+++ b/page_token/token.go
@@ -123,20 +123,17 @@ func (t *token) ProcessPageTokens(numElements int, pageSize int, pageToken strin
 	if pageSize == 0 {
 		pageSize = numElements
 	}
-	end = min(start+pageSize, numElements)
+	if pageSize > numElements-start {
+		end = numElements
+	} else {
+		end = start + pageSize
+	}
 
 	if end < numElements {
 		nextToken = t.ForIndex(int(end))
 	}
 
 	return start, end, nextToken, nil
-}
-
-func min(a, b int) int {
-	if a > b {
-		return b
-	}
-	return a
 }
 
 // NewTokenGenerate constructs a PageToken using the package's hard-coded

--- a/page_token/token_test.go
+++ b/page_token/token_test.go
@@ -1,6 +1,7 @@
 package page_token
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -91,5 +92,18 @@ func Test_token_ProcessPageTokens(t *testing.T) {
 		s, e, tk, err = n.ProcessPageTokens(10, 3, tk)
 		t.Log(s, e, tk)
 		assert.NoError(t, err)
+	}
+}
+
+func TestProcessPageTokens_LargePageSizeDoesNotOverflow(t *testing.T) {
+	n := NewTokenGenerate("test")
+	token := n.ForIndex(1)
+
+	start, end, nextToken, err := n.ProcessPageTokens(10, math.MaxInt, token)
+	if err != nil {
+		t.Fatalf("ProcessPageTokens() error = %v", err)
+	}
+	if start != 1 || end != 10 || nextToken != "" {
+		t.Fatalf("ProcessPageTokens() = (%d, %d, %q), want (1, 10, %q)", start, end, nextToken, "")
 	}
 }


### PR DESCRIPTION
## What

- Prevent `ProcessPageTokens` from overflowing when a valid non-zero page start is combined with a very large page size.
- Add a regression test covering `numElements=10`, token index `1`, and `pageSize=math.MaxInt`.

## Why

The previous `start + pageSize` calculation could wrap to a negative integer before being clamped. That returned an invalid negative end index and generated a bogus next-page token.

## How

Compare the requested page size with the remaining element count before adding it to the start index. This avoids the overflowing addition while preserving the existing `pageSize=0`, invalid-token, and negative-page-size behavior.

## Tests

- `go test ./page_token -run '^TestProcessPageTokens_LargePageSizeDoesNotOverflow$' -count=1 -v`
- `go test ./page_token -count=1`
- `go test -race ./page_token -count=1`
- `go vet ./page_token`
- Mutation check: restoring `min(start+pageSize, numElements)` makes the regression test fail with end `-9223372036854775808`.

Additional full-repository check: `go test ./... -count=1` reaches and passes `page_token`, but the unrelated `distributed/controller/controller_redis.TestControllerRedis_StartConsuming` fails with `context canceled`; the same failure reproduces on an untouched `origin/master` worktree.
