### PR TITLE
fix(watching): reject non-positive collect intervals

### DIFF
--- a/watching/collect_interval_test.go
+++ b/watching/collect_interval_test.go
@@ -1,0 +1,66 @@
+package watching
+
+import (
+	"testing"
+	"time"
+)
+
+func TestWithCollectIntervalRejectsInvalidDurations(t *testing.T) {
+	tests := []struct {
+		name     string
+		interval string
+	}{
+		{name: "parse error", interval: "invalid"},
+		{name: "zero", interval: "0s"},
+		{name: "negative", interval: "-1s"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name+" keeps default", func(t *testing.T) {
+			w := NewWatching(WithCollectInterval(tt.interval))
+			if got := w.config.CollectInterval; got != defaultInterval {
+				t.Fatalf("CollectInterval = %v, want default %v", got, defaultInterval)
+			}
+			assertNoIntervalReset(t, w)
+		})
+
+		t.Run(tt.name+" keeps current", func(t *testing.T) {
+			const current = 2 * time.Second
+			w := NewWatching(WithCollectInterval(current.String()))
+			requireIntervalReset(t, w)
+
+			WithCollectInterval(tt.interval)(w)
+			if got := w.config.CollectInterval; got != current {
+				t.Fatalf("CollectInterval = %v, want current %v", got, current)
+			}
+			assertNoIntervalReset(t, w)
+		})
+	}
+}
+
+func TestWithCollectIntervalAcceptsPositiveDuration(t *testing.T) {
+	const interval = 250 * time.Millisecond
+	w := NewWatching(WithCollectInterval(interval.String()))
+	if got := w.config.CollectInterval; got != interval {
+		t.Fatalf("CollectInterval = %v, want %v", got, interval)
+	}
+	requireIntervalReset(t, w)
+}
+
+func requireIntervalReset(t *testing.T, w *Watching) {
+	t.Helper()
+	select {
+	case <-w.config.intervalResetting:
+	default:
+		t.Fatal("positive interval did not request a ticker reset")
+	}
+}
+
+func assertNoIntervalReset(t *testing.T, w *Watching) {
+	t.Helper()
+	select {
+	case <-w.config.intervalResetting:
+		t.Fatal("invalid interval requested a ticker reset")
+	default:
+	}
+}

--- a/watching/option.go
+++ b/watching/option.go
@@ -20,7 +20,7 @@ func WithCollectInterval(interval string) options.Option {
 		// CollectInterval wouldn't be zero value, because it
 		// will be initialized as defaultInterval at newOptions()
 		newInterval, err := time.ParseDuration(interval)
-		if err != nil || opts.config.CollectInterval.Seconds() == newInterval.Seconds() {
+		if err != nil || newInterval <= 0 || opts.config.CollectInterval.Seconds() == newInterval.Seconds() {
 			return
 		}
 		opts.config.CollectInterval = newInterval


### PR DESCRIPTION
## What

- Ignore zero and negative values passed to `WithCollectInterval`, preserving the current or default interval.
- Add regression coverage for parse errors, zero, negative, and positive durations without starting the background dump loop.

## Why

`time.ParseDuration` accepts `0s` and `-1s`, so the previous option stored them as the collect interval. `startDumpLoop` later passed that invalid value to `time.NewTicker`, which panics for non-positive durations in a background goroutine.

## How

Treat `newInterval <= 0` the same as a parse error and return before changing the configuration or requesting a ticker reset. Valid positive durations keep the existing behavior.

## Tests

- `go test -race ./watching`
- `go vet ./watching`
- Mutation check: removing the `newInterval <= 0` guard makes all four zero/negative default/current regression cases fail.
