### PR TITLE
fix(zset): sum overlapping scores and reject NaN

### DIFF
--- a/structure/zset/score_consistency_test.go
+++ b/structure/zset/score_consistency_test.go
@@ -1,0 +1,124 @@
+package zset
+
+import (
+	"math"
+	"testing"
+)
+
+func TestUnionFloat64SumsOverlappingScores(t *testing.T) {
+	left := NewFloat64()
+	left.Add(1.25, "common")
+	left.Add(10, "left")
+	right := NewFloat64()
+	right.Add(2.75, "common")
+	right.Add(20, "right")
+
+	got := UnionFloat64(left, right)
+	if score, ok := got.Score("common"); !ok || score != 4 {
+		t.Fatalf("union common score = (%v, %v), want (4, true)", score, ok)
+	}
+	if got.Len() != 3 {
+		t.Fatalf("union length = %d, want 3", got.Len())
+	}
+}
+
+func TestInterFloat64SumsOverlappingScores(t *testing.T) {
+	left := NewFloat64()
+	left.Add(1.25, "common")
+	left.Add(10, "left")
+	right := NewFloat64()
+	right.Add(2.75, "common")
+	right.Add(20, "right")
+
+	got := InterFloat64(left, right)
+	if score, ok := got.Score("common"); !ok || score != 4 {
+		t.Fatalf("intersection common score = (%v, %v), want (4, true)", score, ok)
+	}
+	if got.Len() != 1 {
+		t.Fatalf("intersection length = %d, want 1", got.Len())
+	}
+}
+
+func TestFloat64SetRejectsNaNWithoutMutation(t *testing.T) {
+	z := NewFloat64()
+	z.Add(1, "stable")
+
+	if added := z.Add(math.NaN(), "new"); added {
+		t.Fatal("Add(NaN) reported a newly-created member")
+	}
+	if z.Contains("new") {
+		t.Fatal("Add(NaN) inserted a member")
+	}
+	if added := z.Add(math.NaN(), "stable"); added {
+		t.Fatal("Add(NaN) reported an existing member as newly created")
+	}
+	if score, ok := z.Score("stable"); !ok || score != 1 {
+		t.Fatalf("stable score after Add(NaN) = (%v, %v), want (1, true)", score, ok)
+	}
+	assertFloat64SetConsistent(t, z)
+}
+
+func TestFloat64SetIncrByRejectsNaNWithoutMutation(t *testing.T) {
+	z := NewFloat64()
+	z.Add(math.Inf(1), "infinite")
+
+	if score, existed := z.IncrBy(math.NaN(), "new"); existed || score != 0 {
+		t.Fatalf("IncrBy(NaN) for new member = (%v, %v), want (0, false)", score, existed)
+	}
+	if z.Contains("new") {
+		t.Fatal("IncrBy(NaN) inserted a new member")
+	}
+
+	score, existed := z.IncrBy(math.Inf(-1), "infinite")
+	if !existed || !math.IsInf(score, 1) {
+		t.Fatalf("IncrBy(-Inf) after +Inf = (%v, %v), want (+Inf, true)", score, existed)
+	}
+	if stored, ok := z.Score("infinite"); !ok || !math.IsInf(stored, 1) {
+		t.Fatalf("stored score after rejected NaN result = (%v, %v), want (+Inf, true)", stored, ok)
+	}
+	assertFloat64SetConsistent(t, z)
+}
+
+func TestSetOperationsRejectNaNAggregates(t *testing.T) {
+	left := NewFloat64()
+	left.Add(math.Inf(1), "nan-sum")
+	left.Add(1, "left")
+	right := NewFloat64()
+	right.Add(math.Inf(-1), "nan-sum")
+	right.Add(2, "right")
+
+	union := UnionFloat64(left, right)
+	if union.Contains("nan-sum") {
+		t.Fatal("union retained a member whose aggregate score is NaN")
+	}
+	if union.Len() != 2 || !union.Contains("left") || !union.Contains("right") {
+		t.Fatalf("union members = %v, want only left and right", union.Range(0, -1))
+	}
+	assertFloat64SetConsistent(t, union)
+
+	intersection := InterFloat64(left, right)
+	if intersection.Contains("nan-sum") || intersection.Len() != 0 {
+		t.Fatalf("intersection members = %v, want empty after rejecting NaN aggregate", intersection.Range(0, -1))
+	}
+	assertFloat64SetConsistent(t, intersection)
+}
+
+func assertFloat64SetConsistent(t *testing.T, z *Float64Set) {
+	t.Helper()
+	nodes := z.Range(0, -1)
+	if len(z.dict) != z.Len() {
+		t.Fatalf("dict length = %d, Len = %d", len(z.dict), z.Len())
+	}
+	if len(nodes) != z.Len() {
+		t.Fatalf("range length = %d, Len = %d", len(nodes), z.Len())
+	}
+	for _, node := range nodes {
+		if math.IsNaN(node.Score) {
+			t.Fatalf("skiplist contains NaN score for %q", node.Value)
+		}
+		score, ok := z.Score(node.Value)
+		if !ok || score != node.Score {
+			t.Fatalf("dict score for %q = (%v, %v), skiplist score = %v", node.Value, score, ok, node.Score)
+		}
+	}
+}

--- a/structure/zset/zset.go
+++ b/structure/zset/zset.go
@@ -23,6 +23,7 @@
 package zset
 
 import (
+	"math"
 	"sync"
 )
 
@@ -50,20 +51,32 @@ func NewFloat64() *Float64Set {
 
 // UnionFloat64 returns the union of given sorted sets, the resulting score of
 // a value is the sum of its scores in the sorted sets where it exists.
+// Values whose accumulated score is NaN are omitted because this API has no
+// error return and NaN cannot be ordered safely in the backing skiplist.
 //
 // UnionFloat64 is the replacement of UNIONSTORE command of redis.
 func UnionFloat64(zs ...*Float64Set) *Float64Set {
 	dest := NewFloat64()
+	scores := make(map[string]float64)
 	for _, z := range zs {
 		for _, n := range z.Range(0, -1) {
-			dest.Add(n.Score, n.Value)
+			score := n.Score
+			if previous, ok := scores[n.Value]; ok {
+				score += previous
+			}
+			scores[n.Value] = score
 		}
+	}
+	for value, score := range scores {
+		dest.Add(score, value)
 	}
 	return dest
 }
 
 // InterFloat64 returns the intersection of given sorted sets, the resulting
 // score of a value is the sum of its scores in the sorted sets where it exists.
+// Values whose accumulated score is NaN are omitted because this API has no
+// error return and NaN cannot be ordered safely in the backing skiplist.
 //
 // InterFloat64 is the replacement of INTERSTORE command of redis.
 func InterFloat64(zs ...*Float64Set) *Float64Set {
@@ -72,15 +85,18 @@ func InterFloat64(zs ...*Float64Set) *Float64Set {
 		return dest
 	}
 	for _, n := range zs[0].Range(0, -1) {
+		score := n.Score
 		ok := true
 		for _, z := range zs[1:] {
-			if !z.Contains(n.Value) {
+			otherScore, exists := z.Score(n.Value)
+			if !exists {
 				ok = false
 				break
 			}
+			score += otherScore
 		}
 		if ok {
-			dest.Add(n.Score, n.Value)
+			dest.Add(score, n.Value)
 		}
 	}
 	return dest
@@ -98,9 +114,13 @@ func (z *Float64Set) Len() int {
 
 // Add adds a new value or update the score of an existing value.
 // Returns true if the value is newly created.
+// A NaN score is rejected without changing the set and returns false.
 //
 // Add is the replacement of ZADD command of redis.
 func (z *Float64Set) Add(score float64, value string) bool {
+	if math.IsNaN(score) {
+		return false
+	}
 	z.mu.Lock()
 	defer z.mu.Unlock()
 
@@ -141,6 +161,9 @@ func (z *Float64Set) Remove(value string) (float64, bool) {
 // IncrBy increments the score of value in the sorted set by incr.
 // If value does not exist in the sorted set, it is added with incr as its score
 // (as if its previous score was zero).
+// A NaN increment or result is rejected without changing the set. For an
+// existing value the current score and true are returned; otherwise it returns
+// zero and false.
 //
 // IncrBy is the replacement of ZINCRBY command of redis.
 func (z *Float64Set) IncrBy(incr float64, value string) (float64, bool) {
@@ -148,6 +171,12 @@ func (z *Float64Set) IncrBy(incr float64, value string) (float64, bool) {
 	defer z.mu.Unlock()
 
 	oldScore, ok := z.dict[value]
+	if math.IsNaN(incr) {
+		if ok {
+			return oldScore, true
+		}
+		return 0, false
+	}
 	if !ok {
 		// Insert a new element.
 		z.list.Insert(incr, value)
@@ -156,6 +185,9 @@ func (z *Float64Set) IncrBy(incr float64, value string) (float64, bool) {
 	}
 	// Update score.
 	newScore := oldScore + incr
+	if math.IsNaN(newScore) {
+		return oldScore, true
+	}
 	_ = z.list.UpdateScore(oldScore, value, newScore)
 	z.dict[value] = newScore
 	return newScore, true


### PR DESCRIPTION
## What

- 修复 UnionFloat64 和 InterFloat64 对重叠 member 的分数累加语义。
- 拒绝直接或计算生成的 NaN，避免 dict 与 skiplist 状态分叉。
- 增加确定性回归测试，覆盖聚合、拒绝返回值和内部一致性。

## Why

原集合运算会覆盖或忽略重叠 member 的其他分数，与公开注释不符。NaN 无法由 skiplist 的全序比较稳定定位，写入后 Remove/Update 可能只修改 dict 而遗留 skiplist 节点。

## How

- union 先按 member 聚合所有输入分数，intersection 在确认成员存在时同步累加。
- Add 收到 NaN 时返回 false 且不修改集合。
- IncrBy 对 NaN 输入或 NaN 结果保持原集合：已有 member 返回当前分数和 true，不存在时返回 0 和 false。
- union/intersection 的 NaN 聚合 member 通过同一 Add 拒绝门被省略。

## Tests

- go test -race ./structure/zset -count=1
- go vet ./structure/zset
- 旧实现回归：5 组新增测试均失败
- mutation：union 累加、intersection 累加、Add NaN 门、IncrBy 计算 NaN 门均被对应测试捕获
- gofmt 与 git diff --check