### PR TITLE
fix(egroup): preserve lifecycle shutdown errors

### DIFF
--- a/egroup/errgroup.go
+++ b/egroup/errgroup.go
@@ -33,7 +33,7 @@ func WithContextGroup(ctx context.Context, group goroutine.GGroup) *Group {
 func WithContext(ctx context.Context, opts ...options.Option) *Group {
 	g := &Group{}
 	g.ctx, g.cancel = context.WithCancel(ctx)
-	g.goroutine = goroutine.NewGoroutine(ctx, opts...)
+	g.goroutine = goroutine.NewGoroutine(g.ctx, opts...)
 	return g
 }
 

--- a/egroup/lifecycle_errors_test.go
+++ b/egroup/lifecycle_errors_test.go
@@ -3,13 +3,19 @@ package egroup
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/songzhibin97/gkit/goroutine"
 )
 
 type lifecycleControlledGroup struct {
 	registered chan struct{}
 	completed  chan struct{}
+	shutdowns  atomic.Int32
+	closed     atomic.Bool
 }
 
 func newLifecycleControlledGroup() *lifecycleControlledGroup {
@@ -26,6 +32,9 @@ func (g *lifecycleControlledGroup) AddTask(f func()) bool {
 }
 
 func (g *lifecycleControlledGroup) AddTaskN(ctx context.Context, f func()) bool {
+	if g.closed.Load() {
+		return false
+	}
 	select {
 	case <-ctx.Done():
 		return false
@@ -39,8 +48,12 @@ func (g *lifecycleControlledGroup) AddTaskN(ctx context.Context, f func()) bool 
 	return true
 }
 
-func (*lifecycleControlledGroup) Shutdown() error { return nil }
-func (*lifecycleControlledGroup) Trick() string   { return "" }
+func (g *lifecycleControlledGroup) Shutdown() error {
+	g.closed.Store(true)
+	g.shutdowns.Add(1)
+	return nil
+}
+func (*lifecycleControlledGroup) Trick() string { return "" }
 
 func TestLifeAdminSetGroupShutdownCancelsSuppliedGroup(t *testing.T) {
 	backend := newLifecycleControlledGroup()
@@ -120,4 +133,156 @@ func TestLifeAdminSignalWatcherDoesNotMaskShutdownError(t *testing.T) {
 	if err := waitIssue80Value(t, startDone, "LifeAdmin.Start completion"); !errors.Is(err, want) {
 		t.Fatalf("LifeAdmin.Start error = %v, want shutdown error %v", err, want)
 	}
+}
+
+func TestLifeAdminStartCancellationDoesNotMaskShutdownError(t *testing.T) {
+	backend := newLifecycleControlledGroup()
+	group := WithContextGroup(context.Background(), backend)
+	admin := NewLifeAdmin(SetGroup(group), SetSignal(nil), SetStopTimeout(time.Second))
+
+	want := errors.New("shutdown failed")
+	shutdownEntered := make(chan struct{})
+	releaseShutdown := make(chan struct{})
+	admin.Add(Member{
+		Start: func(ctx context.Context) error {
+			<-ctx.Done()
+			return nil
+		},
+		Shutdown: func(context.Context) error {
+			close(shutdownEntered)
+			<-releaseShutdown
+			return want
+		},
+	})
+
+	startDone := make(chan error, 1)
+	go func() { startDone <- admin.Start() }()
+	waitIssue80Signal(t, backend.registered, "shutdown task registration")
+	waitIssue80Signal(t, backend.registered, "start task registration")
+
+	admin.Shutdown()
+	waitIssue80Signal(t, shutdownEntered, "member shutdown start")
+	// The shutdown callback is still blocked, so the first completion is the
+	// member Start wrapper reacting to normal group cancellation.
+	waitIssue80Signal(t, backend.completed, "member start wrapper completion")
+	close(releaseShutdown)
+
+	if err := waitIssue80Value(t, startDone, "LifeAdmin.Start completion"); !errors.Is(err, want) {
+		t.Fatalf("LifeAdmin.Start error = %v, want shutdown error %v", err, want)
+	}
+}
+
+func TestLifeAdminPreservesMemberStartError(t *testing.T) {
+	backend := newLifecycleControlledGroup()
+	group := WithContextGroup(context.Background(), backend)
+	admin := NewLifeAdmin(SetGroup(group), SetSignal(nil))
+
+	want := fmt.Errorf("member start failed: %w", context.Canceled)
+	releaseStart := make(chan struct{})
+	admin.Add(Member{
+		Start: func(context.Context) error {
+			<-releaseStart
+			return want
+		},
+		Shutdown: func(context.Context) error { return nil },
+	})
+
+	startDone := make(chan error, 1)
+	go func() { startDone <- admin.Start() }()
+	waitIssue80Signal(t, backend.registered, "shutdown task registration")
+	waitIssue80Signal(t, backend.registered, "start task registration")
+	close(releaseStart)
+
+	if err := waitIssue80Value(t, startDone, "LifeAdmin.Start completion"); !errors.Is(err, want) {
+		t.Fatalf("LifeAdmin.Start error = %v, want member start error %v", err, want)
+	}
+}
+
+func TestLifeAdminSetGroupStopsOwnedPool(t *testing.T) {
+	group := WithContext(
+		context.Background(),
+		goroutine.SetMax(1),
+		goroutine.SetIdle(1),
+	)
+	defer func() { _ = group.goroutine.Shutdown() }()
+	admin := NewLifeAdmin(SetGroup(group), SetSignal(nil))
+
+	memberStarted := make(chan struct{})
+	admin.Add(Member{Start: func(ctx context.Context) error {
+		close(memberStarted)
+		<-ctx.Done()
+		return nil
+	}})
+	startDone := make(chan error, 1)
+	go func() { startDone <- admin.Start() }()
+	waitIssue80Signal(t, memberStarted, "member start")
+	if got := lifeAdminPoolWorkerCount(t, group); got != 1 {
+		t.Fatalf("pool workers before shutdown = %d, want 1", got)
+	}
+
+	admin.Shutdown()
+	if err := waitIssue80Value(t, startDone, "LifeAdmin.Start completion"); err != nil && !errors.Is(err, context.Canceled) {
+		t.Fatalf("LifeAdmin.Start error = %v, want nil or context cancellation", err)
+	}
+	if !waitLifeAdminPoolWorkerCount(t, group, 0) {
+		t.Fatalf("pool workers after LifeAdmin.Shutdown = %d, want 0", lifeAdminPoolWorkerCount(t, group))
+	}
+}
+
+func TestLifeAdminSetGroupDoesNotShutdownExternalPool(t *testing.T) {
+	backend := newLifecycleControlledGroup()
+	group := WithContextGroup(context.Background(), backend)
+	admin := NewLifeAdmin(SetGroup(group), SetSignal(nil))
+
+	memberStarted := make(chan struct{})
+	admin.Add(Member{Start: func(ctx context.Context) error {
+		close(memberStarted)
+		<-ctx.Done()
+		return nil
+	}})
+	startDone := make(chan error, 1)
+	go func() { startDone <- admin.Start() }()
+	waitIssue80Signal(t, backend.registered, "start task registration")
+	waitIssue80Signal(t, memberStarted, "member start")
+
+	admin.Shutdown()
+	if err := waitIssue80Value(t, startDone, "LifeAdmin.Start completion"); err != nil && !errors.Is(err, context.Canceled) {
+		t.Fatalf("LifeAdmin.Start error = %v, want nil or context cancellation", err)
+	}
+	if got := backend.shutdowns.Load(); got != 0 {
+		t.Fatalf("external pool Shutdown calls = %d, want 0", got)
+	}
+	externalTaskRan := make(chan struct{})
+	if ok := backend.AddTask(func() { close(externalTaskRan) }); !ok {
+		t.Fatal("external pool rejected a task after LifeAdmin.Shutdown")
+	}
+	waitIssue80Signal(t, externalTaskRan, "external pool task")
+}
+
+func waitLifeAdminPoolWorkerCount(t *testing.T, group *Group, want int) bool {
+	t.Helper()
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if lifeAdminPoolWorkerCount(t, group) == want {
+			return true
+		}
+		time.Sleep(time.Millisecond)
+	}
+	return lifeAdminPoolWorkerCount(t, group) == want
+}
+
+func lifeAdminPoolWorkerCount(t *testing.T, group *Group) int {
+	t.Helper()
+	var max, idle, workers, taskLen int
+	if _, err := fmt.Sscanf(
+		group.goroutine.Trick(),
+		"max: %d idle: %d now goroutine: %d task len: %d",
+		&max,
+		&idle,
+		&workers,
+		&taskLen,
+	); err != nil {
+		t.Fatalf("parse pool state: %v", err)
+	}
+	return workers
 }

--- a/egroup/lifecycle_errors_test.go
+++ b/egroup/lifecycle_errors_test.go
@@ -1,0 +1,123 @@
+package egroup
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type lifecycleControlledGroup struct {
+	registered chan struct{}
+	completed  chan struct{}
+}
+
+func newLifecycleControlledGroup() *lifecycleControlledGroup {
+	return &lifecycleControlledGroup{
+		registered: make(chan struct{}, 4),
+		completed:  make(chan struct{}, 4),
+	}
+}
+
+func (*lifecycleControlledGroup) ChangeMax(int64) {}
+
+func (g *lifecycleControlledGroup) AddTask(f func()) bool {
+	return g.AddTaskN(context.Background(), f)
+}
+
+func (g *lifecycleControlledGroup) AddTaskN(ctx context.Context, f func()) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	default:
+	}
+	g.registered <- struct{}{}
+	go func() {
+		f()
+		g.completed <- struct{}{}
+	}()
+	return true
+}
+
+func (*lifecycleControlledGroup) Shutdown() error { return nil }
+func (*lifecycleControlledGroup) Trick() string   { return "" }
+
+func TestLifeAdminSetGroupShutdownCancelsSuppliedGroup(t *testing.T) {
+	backend := newLifecycleControlledGroup()
+	group := WithContextGroup(context.Background(), backend)
+	admin := NewLifeAdmin(SetGroup(group), SetSignal(nil))
+
+	memberStarted := make(chan struct{})
+	memberStopped := make(chan struct{})
+	shutdownCalled := make(chan struct{})
+	admin.Add(Member{
+		Start: func(ctx context.Context) error {
+			close(memberStarted)
+			<-ctx.Done()
+			close(memberStopped)
+			return nil
+		},
+		Shutdown: func(context.Context) error {
+			close(shutdownCalled)
+			return nil
+		},
+	})
+
+	startDone := make(chan error, 1)
+	go func() { startDone <- admin.Start() }()
+	waitIssue80Signal(t, backend.registered, "shutdown task registration")
+	waitIssue80Signal(t, backend.registered, "start task registration")
+	waitIssue80Signal(t, memberStarted, "member start")
+
+	admin.Shutdown()
+	stoppedByAdmin := false
+	select {
+	case <-memberStopped:
+		stoppedByAdmin = true
+	case <-time.After(100 * time.Millisecond):
+		// Clean up the old implementation, whose LifeAdmin cancel is unrelated
+		// to the supplied group's context.
+		group.cancel()
+		waitIssue80Signal(t, memberStopped, "member cleanup")
+	}
+
+	err := waitIssue80Value(t, startDone, "LifeAdmin.Start completion")
+	waitIssue80Signal(t, shutdownCalled, "member shutdown")
+	if !stoppedByAdmin {
+		t.Fatal("LifeAdmin.Shutdown did not cancel the group supplied by SetGroup")
+	}
+	if err != nil && !errors.Is(err, context.Canceled) {
+		t.Fatalf("LifeAdmin.Start error = %v, want nil or context cancellation", err)
+	}
+}
+
+func TestLifeAdminSignalWatcherDoesNotMaskShutdownError(t *testing.T) {
+	backend := newLifecycleControlledGroup()
+	group := WithContextGroup(context.Background(), backend)
+	admin := NewLifeAdmin(SetGroup(group), SetStopTimeout(time.Second))
+
+	want := errors.New("shutdown failed")
+	shutdownEntered := make(chan struct{})
+	releaseShutdown := make(chan struct{})
+	admin.Add(Member{Shutdown: func(context.Context) error {
+		close(shutdownEntered)
+		<-releaseShutdown
+		return want
+	}})
+
+	startDone := make(chan error, 1)
+	go func() { startDone <- admin.Start() }()
+	waitIssue80Signal(t, backend.registered, "shutdown task registration")
+	waitIssue80Signal(t, backend.registered, "signal task registration")
+
+	group.cancel()
+	waitIssue80Signal(t, shutdownEntered, "member shutdown start")
+	// The shutdown callback is still blocked, so this completion can only be
+	// the signal watcher. Waiting for it removes scheduler timing from the test.
+	waitIssue80Signal(t, backend.completed, "signal watcher completion")
+	close(releaseShutdown)
+
+	if err := waitIssue80Value(t, startDone, "LifeAdmin.Start completion"); !errors.Is(err, want) {
+		t.Fatalf("LifeAdmin.Start error = %v, want shutdown error %v", err, want)
+	}
+}

--- a/egroup/liftcycle.go
+++ b/egroup/liftcycle.go
@@ -2,6 +2,7 @@ package egroup
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/signal"
 	"syscall"
@@ -21,6 +22,13 @@ type Member struct {
 	Start    func(ctx context.Context) error
 	Shutdown func(ctx context.Context) error
 }
+
+type memberStartError struct {
+	err error
+}
+
+func (e *memberStartError) Error() string { return e.err.Error() }
+func (e *memberStartError) Unwrap() error { return e.err }
 
 // LifeAdmin 生命周期管理
 type LifeAdmin struct {
@@ -57,7 +65,20 @@ func (l *LifeAdmin) Start() error {
 			}
 			if m.Start != nil {
 				l.g.Go(func() error {
-					return goroutine.Delegate(l.g.ctx, l.opts.startTimeout, m.Start)
+					err := goroutine.Delegate(l.g.ctx, l.opts.startTimeout, func(ctx context.Context) error {
+						if err := m.Start(ctx); err != nil {
+							return &memberStartError{err: err}
+						}
+						return nil
+					})
+					var memberErr *memberStartError
+					if errors.As(err, &memberErr) {
+						return memberErr.err
+					}
+					if errors.Is(err, context.Canceled) && l.g.ctx.Err() != nil {
+						return nil
+					}
+					return err
 				})
 			}
 		}(m)

--- a/egroup/liftcycle.go
+++ b/egroup/liftcycle.go
@@ -77,7 +77,7 @@ func (l *LifeAdmin) Start() error {
 		for {
 			select {
 			case <-l.g.ctx.Done():
-				return l.g.ctx.Err()
+				return nil
 			case sig := <-c:
 				l.opts.handler(l, sig)
 			}
@@ -115,13 +115,14 @@ func NewLifeAdmin(opts ...options.Option) *LifeAdmin {
 
 	l := &LifeAdmin{opts: o}
 
-	ctx, cancel := context.WithCancel(context.Background())
-
 	if o.g == nil {
+		ctx, cancel := context.WithCancel(context.Background())
 		o.g = WithContext(ctx)
+		l.shutdown = cancel
+	} else {
+		l.shutdown = o.g.cancel
 	}
 	l.g = o.g
-	l.shutdown = cancel
 
 	return l
 }


### PR DESCRIPTION
## What

- Make `LifeAdmin.Shutdown` cancel the context of a group supplied through `SetGroup`, so registered members can stop.
- Treat the default signal watcher's context cancellation as normal completion, preserving real member shutdown errors.
- Normalize member `Start` wrapper cancellation only when it came from the group lifecycle, without hiding member-returned errors.
- Bind pools created by `WithContext` to the group's own context so idle workers exit; externally supplied pools remain caller-owned and usable.
- Add deterministic lifecycle regression tests with controlled task registration and completion ordering.

## Why

`NewLifeAdmin` previously stored a cancel function for a newly-created context even when `SetGroup` supplied a different group, leaving `Start` and its members blocked after `Shutdown`. Internal signal and member-start wrappers could also record normal `context.Canceled` values before a member returned its actual shutdown failure. Finally, `WithContext` created its pool from the parent context rather than the group's cancellable child, leaving idle workers alive after lifecycle completion.

## How

For a supplied group, bind `LifeAdmin.Shutdown` to that group's cancel function. Signal cancellation returns `nil`; member-start callbacks mark their own errors before delegation so only lifecycle-generated cancellation is normalized. `WithContext` now creates its internal pool from `g.ctx`, while `WithContextGroup` continues to leave injected pools under caller ownership.

## Tests

- `go test -race ./egroup -count=10`
- `go vet ./egroup`
- Mutation check: restoring the unrelated constructor cancel makes `TestLifeAdminSetGroupShutdownCancelsSuppliedGroup` fail.
- Mutation check: restoring `return l.g.ctx.Err()` makes `TestLifeAdminSignalWatcherDoesNotMaskShutdownError` fail with `context canceled` instead of the shutdown sentinel.
- Mutation check: removing member-start cancellation normalization makes `TestLifeAdminStartCancellationDoesNotMaskShutdownError` fail.
- Mutation check: rebinding the owned pool to the parent context makes `TestLifeAdminSetGroupStopsOwnedPool` retain one worker.
