### PR TITLE
fix(task): validate slice argument shapes

### DIFF
--- a/distributed/task/reflect.go
+++ b/distributed/task/reflect.go
@@ -184,11 +184,29 @@ func reflectValues(valueType string, value interface{}) (reflect.Value, error) {
 		return reflect.MakeSlice(theType, 0, 0), nil
 	}
 
+	// Decode base64 strings before validating the container shape. JSON encodes
+	// byte slices as base64 strings, and this preserves the existing conversion
+	// behavior for unsigned integer slices.
+	if strings.HasPrefix(theType.String(), "[]uint") || theType.String() == "[]byte" {
+		if encoded, ok := value.(string); ok {
+			output, err := base64.StdEncoding.DecodeString(encoded)
+			if err != nil {
+				return reflect.Value{}, err
+			}
+			value = output
+		}
+	}
+
+	values := reflect.ValueOf(value)
+	if values.Kind() != reflect.Slice && values.Kind() != reflect.Array {
+		return reflect.Value{}, typeConversionError(value, theType.String())
+	}
+
 	var theValue reflect.Value
 
 	// Booleans
 	if theType.String() == "[]bool" {
-		bools := reflect.ValueOf(value)
+		bools := values
 
 		theValue = reflect.MakeSlice(theType, bools.Len(), bools.Len())
 		for i := 0; i < bools.Len(); i++ {
@@ -205,7 +223,7 @@ func reflectValues(valueType string, value interface{}) (reflect.Value, error) {
 
 	// Integers
 	if strings.HasPrefix(theType.String(), "[]int") {
-		ints := reflect.ValueOf(value)
+		ints := values
 
 		theValue = reflect.MakeSlice(theType, ints.Len(), ints.Len())
 		for i := 0; i < ints.Len(); i++ {
@@ -222,19 +240,7 @@ func reflectValues(valueType string, value interface{}) (reflect.Value, error) {
 
 	// Unsigned integers
 	if strings.HasPrefix(theType.String(), "[]uint") || theType.String() == "[]byte" {
-
-		// Decode the base64 string if the value type is []uint8 or it's alias []byte
-		// See: https://golang.org/pkg/encoding/json/#Marshal
-		// > Array and slice values encode as JSON arrays, except that []byte encodes as a base64-encoded string
-		if reflect.TypeOf(value).String() == "string" {
-			output, err := base64.StdEncoding.DecodeString(value.(string))
-			if err != nil {
-				return reflect.Value{}, err
-			}
-			value = output
-		}
-
-		uints := reflect.ValueOf(value)
+		uints := values
 
 		theValue = reflect.MakeSlice(theType, uints.Len(), uints.Len())
 		for i := 0; i < uints.Len(); i++ {
@@ -251,7 +257,7 @@ func reflectValues(valueType string, value interface{}) (reflect.Value, error) {
 
 	// Floating point numbers
 	if strings.HasPrefix(theType.String(), "[]float") {
-		floats := reflect.ValueOf(value)
+		floats := values
 
 		theValue = reflect.MakeSlice(theType, floats.Len(), floats.Len())
 		for i := 0; i < floats.Len(); i++ {
@@ -268,7 +274,7 @@ func reflectValues(valueType string, value interface{}) (reflect.Value, error) {
 
 	// Strings
 	if theType.String() == "[]string" {
-		strs := reflect.ValueOf(value)
+		strs := values
 
 		theValue = reflect.MakeSlice(theType, strs.Len(), strs.Len())
 		for i := 0; i < strs.Len(); i++ {

--- a/distributed/task/reflect_test.go
+++ b/distributed/task/reflect_test.go
@@ -1,6 +1,7 @@
 package task
 
 import (
+	stdjson "encoding/json"
 	"reflect"
 	"testing"
 
@@ -236,5 +237,71 @@ func TestReflectValue(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestNewTaskWithSignatureRejectsNonSliceArgument(t *testing.T) {
+	testCases := []struct {
+		name      string
+		value     interface{}
+		wantError string
+	}{
+		{name: "int", value: 1, wantError: "1 is not []int"},
+		{name: "bool", value: true, wantError: "true is not []int"},
+		{name: "map", value: map[string]int{"value": 1}, wantError: "map[value:1] is not []int"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					t.Fatalf("NewTaskWithSignature panicked for %T input: %v", tc.value, recovered)
+				}
+			}()
+
+			signature := &Signature{Args: []Arg{{Type: "[]int", Value: tc.value}}}
+			_, err := NewTaskWithSignature(func([]int) error { return nil }, signature)
+			if err == nil {
+				t.Fatal("NewTaskWithSignature returned nil error for non-slice argument")
+			}
+			if err.Error() != tc.wantError {
+				t.Fatalf("NewTaskWithSignature error = %q, want %q", err, tc.wantError)
+			}
+		})
+	}
+}
+
+func TestReflectValueAcceptsSliceAndArrayInput(t *testing.T) {
+	testCases := []struct {
+		name  string
+		value interface{}
+	}{
+		{name: "slice", value: []interface{}{json.Number("1"), json.Number("2")}},
+		{name: "array", value: [2]interface{}{json.Number("1"), json.Number("2")}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			value, err := ReflectValue("[]int", tc.value)
+			if err != nil {
+				t.Fatalf("ReflectValue returned error: %v", err)
+			}
+			if got, want := value.Interface(), []int{1, 2}; !reflect.DeepEqual(got, want) {
+				t.Fatalf("ReflectValue value = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestReflectValuePreservesJSONNumberError(t *testing.T) {
+	number := stdjson.Number("not-a-number")
+	_, wantErr := number.Int64()
+
+	_, err := ReflectValue("[]int", []interface{}{number})
+	if err == nil {
+		t.Fatal("ReflectValue returned nil error for invalid json.Number")
+	}
+	if err.Error() != wantErr.Error() {
+		t.Fatalf("ReflectValue error = %q, want %q", err, wantErr)
 	}
 }


### PR DESCRIPTION
## What

- Validate reflected slice arguments before calling `Len` or `Index`.
- Return the existing conversion error for scalar and map inputs instead of panicking.
- Preserve valid slice, array, base64 unsigned-slice, and numeric element conversion behavior.

## Why

Task arguments are converted in `NewTaskWithSignature`, before `Task.Call` installs its panic recovery. A malformed queued argument such as `{ "type": "[]int", "value": 1 }` could therefore panic the worker process instead of being handled as a task conversion failure.

## How

- Decode the existing base64 unsigned-slice representation first.
- Require the resulting reflected value to be a slice or array before any `Len` or `Index` call.
- Add regression coverage for integer, boolean, and map argument shapes, plus valid slices/arrays and invalid `encoding/json.Number` errors.

## Tests

- `go test -race ./distributed/task ./distributed`
- `go vet ./distributed/task ./distributed`
- Mutation check: removing the kind guard makes `TestNewTaskWithSignatureRejectsNonSliceArgument` fail with the original reflection panics.
