### PR TITLE
fix(backend_db): enforce unique group IDs

### DIFF
--- a/distributed/backend/backend.go
+++ b/distributed/backend/backend.go
@@ -1,6 +1,14 @@
 package backend
 
-import "github.com/songzhibin97/gkit/distributed/task"
+import (
+	"errors"
+
+	"github.com/songzhibin97/gkit/distributed/task"
+)
+
+// ErrGroupAlreadyExists is returned when a group identifier has already been
+// taken over.
+var ErrGroupAlreadyExists = errors.New("group already exists")
 
 type Backend interface {
 	// GroupTakeOver 组接管任务详情

--- a/distributed/backend/backend_db/db.go
+++ b/distributed/backend/backend_db/db.go
@@ -214,6 +214,9 @@ func (b *BackendSQLDB) ResetGroup(groupIDs ...string) error {
 // fails loudly when historical duplicates exist; this package intentionally
 // does not choose and delete a surviving task or group automatically. Operators
 // must reconcile duplicates before retrying migration.
+// Both indexed identifiers are bounded to 191 characters so MySQL can create
+// their indexes under utf8mb4; without a size GORM maps strings to LONGTEXT,
+// which MySQL rejects as an index key without an explicit prefix length.
 func (b *BackendSQLDB) autoMigrate() error {
 	return b.gClient.AutoMigrate(
 		task.GroupMeta{},

--- a/distributed/backend/backend_db/db.go
+++ b/distributed/backend/backend_db/db.go
@@ -2,6 +2,7 @@ package backend_db
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -34,7 +35,22 @@ func (b *BackendSQLDB) SetResultExpire(expire int64) {
 
 func (b *BackendSQLDB) GroupTakeOver(groupID string, name string, taskIDs ...string) error {
 	group := task.InitGroupMeta(groupID, name, b.resultExpire, taskIDs...)
-	return b.gClient.Create(group).Error
+	err := b.gClient.Create(group).Error
+	if err == nil {
+		return nil
+	}
+	if isDuplicatedKeyError(b.gClient, err) {
+		return fmt.Errorf("take over group %q: %w", groupID, backend.ErrGroupAlreadyExists)
+	}
+	return err
+}
+
+func isDuplicatedKeyError(db *gorm.DB, err error) bool {
+	if errors.Is(err, gorm.ErrDuplicatedKey) {
+		return true
+	}
+	translator, ok := db.Dialector.(gorm.ErrorTranslator)
+	return ok && errors.Is(translator.Translate(err), gorm.ErrDuplicatedKey)
 }
 
 func (b *BackendSQLDB) GroupCompleted(groupID string) (bool, error) {
@@ -192,13 +208,12 @@ func (b *BackendSQLDB) ResetGroup(groupIDs ...string) error {
 
 // autoMigrate creates/updates the schema.
 //
-// NOTE: GORM's AutoMigrate will not convert a pre-existing non-unique index on
-// Status.TaskID into a unique one (it only creates the index when absent). The
-// unique index is therefore given a distinct name so AutoMigrate creates it on
-// older schemas — but that CREATE fails loudly if the `id` column already holds
-// duplicate task IDs. Deployments upgrading from a schema that allowed
-// duplicate task IDs must de-duplicate first; otherwise the upsert
-// (ON CONFLICT id) cannot dedupe.
+// NOTE: GORM's AutoMigrate will not convert pre-existing non-unique indexes on
+// Status.TaskID or GroupMeta.GroupID into unique ones. Their unique indexes use
+// distinct names so AutoMigrate creates them on older schemas. Index creation
+// fails loudly when historical duplicates exist; this package intentionally
+// does not choose and delete a surviving task or group automatically. Operators
+// must reconcile duplicates before retrying migration.
 func (b *BackendSQLDB) autoMigrate() error {
 	return b.gClient.AutoMigrate(
 		task.GroupMeta{},

--- a/distributed/backend/backend_db/mysql_test.go
+++ b/distributed/backend/backend_db/mysql_test.go
@@ -1,0 +1,129 @@
+package backend_db
+
+import (
+	"database/sql"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/songzhibin97/gkit/distributed/backend"
+	"github.com/songzhibin97/gkit/distributed/task"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+)
+
+const mysqlTestDSNEnv = "GKIT_TEST_MYSQL_DSN"
+
+func openMySQLTestDB(t *testing.T, translateError bool) *gorm.DB {
+	t.Helper()
+	dsn := os.Getenv(mysqlTestDSNEnv)
+	if dsn == "" {
+		t.Skipf("set %s to run MySQL migration tests", mysqlTestDSNEnv)
+	}
+
+	sqlDB, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("open MySQL: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	if err := sqlDB.Ping(); err != nil {
+		t.Fatalf("ping MySQL: %v", err)
+	}
+
+	gdb, err := gorm.Open(mysql.New(mysql.Config{Conn: sqlDB}), &gorm.Config{TranslateError: translateError})
+	if err != nil {
+		t.Fatalf("open GORM MySQL: %v", err)
+	}
+	var database string
+	if err := gdb.Raw("SELECT DATABASE()").Scan(&database).Error; err != nil {
+		t.Fatalf("read MySQL database name: %v", err)
+	}
+	if !strings.HasSuffix(strings.ToLower(database), "_test") {
+		t.Fatalf("%s must select an isolated database whose name ends in _test, got %q", mysqlTestDSNEnv, database)
+	}
+	return gdb
+}
+
+func resetMySQLTables(t *testing.T, gdb *gorm.DB) {
+	t.Helper()
+	if err := gdb.Migrator().DropTable(&task.Status{}, &task.GroupMeta{}); err != nil {
+		t.Fatalf("drop MySQL test tables: %v", err)
+	}
+	t.Cleanup(func() { _ = gdb.Migrator().DropTable(&task.Status{}, &task.GroupMeta{}) })
+}
+
+func TestMySQLUniqueIdentifierMigrationAndConflicts(t *testing.T) {
+	for _, translateError := range []bool{false, true} {
+		name := "translate_error_off"
+		if translateError {
+			name = "translate_error_on"
+		}
+		t.Run(name, func(t *testing.T) {
+			gdb := openMySQLTestDB(t, translateError)
+			resetMySQLTables(t, gdb)
+			b := &BackendSQLDB{gClient: gdb}
+			if err := b.autoMigrate(); err != nil {
+				t.Fatalf("auto migrate: %v", err)
+			}
+
+			groupID := strings.Repeat("g", 191)
+			if err := b.GroupTakeOver(groupID, "first", "task-1"); err != nil {
+				t.Fatalf("first GroupTakeOver: %v", err)
+			}
+			err := b.GroupTakeOver(groupID, "second", "task-2")
+			if !errors.Is(err, backend.ErrGroupAlreadyExists) {
+				t.Fatalf("second GroupTakeOver error = %v, want ErrGroupAlreadyExists", err)
+			}
+
+			taskID := strings.Repeat("t", 191)
+			signature := &task.Signature{ID: taskID, GroupID: groupID, Name: "task"}
+			if err := b.SetStatePending(signature); err != nil {
+				t.Fatalf("SetStatePending: %v", err)
+			}
+			if err := b.SetStateStarted(signature); err != nil {
+				t.Fatalf("SetStateStarted: %v", err)
+			}
+			var count int64
+			if err := gdb.Model(&task.Status{}).Where("id = ?", taskID).Count(&count).Error; err != nil {
+				t.Fatalf("count status rows: %v", err)
+			}
+			if count != 1 {
+				t.Fatalf("rows for task ID = %d, want 1", count)
+			}
+			status, err := b.GetStatus(taskID)
+			if err != nil {
+				t.Fatalf("GetStatus: %v", err)
+			}
+			if status.Status != task.StateStarted {
+				t.Fatalf("status = %v, want StateStarted", status.Status)
+			}
+		})
+	}
+}
+
+func TestMySQLAutoMigrateRejectsHistoricalDuplicateGroupsWithoutDeleting(t *testing.T) {
+	gdb := openMySQLTestDB(t, false)
+	resetMySQLTables(t, gdb)
+	if err := gdb.AutoMigrate(&legacyGroupMeta{}); err != nil {
+		t.Fatalf("create legacy schema: %v", err)
+	}
+	for index := 0; index < 2; index++ {
+		if err := gdb.Create(&legacyGroupMeta{GroupID: "duplicate-group"}).Error; err != nil {
+			t.Fatalf("insert legacy duplicate %d: %v", index, err)
+		}
+	}
+
+	b := &BackendSQLDB{gClient: gdb}
+	if err := b.autoMigrate(); err == nil {
+		t.Fatal("autoMigrate succeeded with historical duplicate group IDs")
+	}
+
+	var count int64
+	if err := gdb.Table("group_meta").Where("id = ?", "duplicate-group").Count(&count).Error; err != nil {
+		t.Fatalf("count historical groups: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("historical duplicate rows after failed migration = %d, want 2", count)
+	}
+}

--- a/distributed/backend/backend_db/upsert_test.go
+++ b/distributed/backend/backend_db/upsert_test.go
@@ -27,7 +27,7 @@ func newSQLiteBackend(t *testing.T) *BackendSQLDB {
 
 type legacyGroupMeta struct {
 	ID      uint   `gorm:"column:_id;primarykey"`
-	GroupID string `gorm:"column:id;index"`
+	GroupID string `gorm:"column:id;size:191;index"`
 }
 
 func (legacyGroupMeta) TableName() string {

--- a/distributed/backend/backend_db/upsert_test.go
+++ b/distributed/backend/backend_db/upsert_test.go
@@ -1,9 +1,12 @@
 package backend_db
 
 import (
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/glebarez/sqlite"
+	"github.com/songzhibin97/gkit/distributed/backend"
 	"gorm.io/gorm"
 
 	"github.com/songzhibin97/gkit/distributed/task"
@@ -20,6 +23,15 @@ func newSQLiteBackend(t *testing.T) *BackendSQLDB {
 		t.Fatalf("auto migrate: %v", err)
 	}
 	return b
+}
+
+type legacyGroupMeta struct {
+	ID      uint   `gorm:"column:_id;primarykey"`
+	GroupID string `gorm:"column:id;index"`
+}
+
+func (legacyGroupMeta) TableName() string {
+	return "group_meta"
 }
 
 // TestUpsertStatus_DedupsByTaskID is the regression guard for the broken
@@ -101,6 +113,70 @@ func TestResetTask_AllowsReuse(t *testing.T) {
 	}
 	if st.Status != task.StatePending {
 		t.Fatalf("status = %v, want StatePending after reuse", st.Status)
+	}
+}
+
+func TestGroupTakeOverRejectsDuplicateGroupID(t *testing.T) {
+	b := newSQLiteBackend(t)
+	const groupID = "duplicate-group"
+
+	if err := b.GroupTakeOver(groupID, "first", "task-1"); err != nil {
+		t.Fatalf("first GroupTakeOver: %v", err)
+	}
+	triggered, err := b.TriggerCompleted(groupID)
+	if err != nil || !triggered {
+		t.Fatalf("first TriggerCompleted = (%v, %v), want (true, nil)", triggered, err)
+	}
+
+	err = b.GroupTakeOver(groupID, "second", "task-2")
+	if !errors.Is(err, backend.ErrGroupAlreadyExists) {
+		t.Errorf("second GroupTakeOver error = %v, want ErrGroupAlreadyExists", err)
+	} else if !strings.Contains(err.Error(), groupID) {
+		t.Errorf("second GroupTakeOver error = %q, want group ID context", err)
+	}
+
+	var count int64
+	if err := b.gClient.Model(&task.GroupMeta{}).Where("id = ?", groupID).Count(&count).Error; err != nil {
+		t.Fatalf("count groups: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("rows for %q = %d, want 1", groupID, count)
+	}
+
+	triggered, err = b.TriggerCompleted(groupID)
+	if err != nil {
+		t.Fatalf("second TriggerCompleted: %v", err)
+	}
+	if triggered {
+		t.Error("second TriggerCompleted succeeded after duplicate takeover")
+	}
+}
+
+func TestAutoMigrateRejectsHistoricalDuplicateGroupIDsWithoutDeleting(t *testing.T) {
+	gdb, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := gdb.AutoMigrate(&legacyGroupMeta{}); err != nil {
+		t.Fatalf("create legacy schema: %v", err)
+	}
+	for index := 0; index < 2; index++ {
+		if err := gdb.Create(&legacyGroupMeta{GroupID: "duplicate-group"}).Error; err != nil {
+			t.Fatalf("insert legacy duplicate %d: %v", index, err)
+		}
+	}
+
+	b := &BackendSQLDB{gClient: gdb}
+	if err := b.autoMigrate(); err == nil {
+		t.Fatal("autoMigrate succeeded with historical duplicate group IDs")
+	}
+
+	var count int64
+	if err := gdb.Table("group_meta").Where("id = ?", "duplicate-group").Count(&count).Error; err != nil {
+		t.Fatalf("count historical groups: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("historical duplicate rows after failed migration = %d, want 2", count)
 	}
 }
 

--- a/distributed/backend/backend_redis/redis.go
+++ b/distributed/backend/backend_redis/redis.go
@@ -23,10 +23,10 @@ var defaultResultExpire int64 = 3600
 
 var ErrType = errors.New("err type")
 
-// ErrGroupAlreadyExists is returned when a group identifier has already been
-// taken over. Callers can use errors.Is to distinguish this conflict from a
-// Redis transport failure.
-var ErrGroupAlreadyExists = errors.New("group already exists")
+// ErrGroupAlreadyExists is kept as an alias for callers that historically
+// imported the Redis-specific sentinel. New code can use the shared backend
+// contract instead.
+var ErrGroupAlreadyExists = backend.ErrGroupAlreadyExists
 
 type BackendRedis struct {
 	// client redis客户端

--- a/distributed/task/group.go
+++ b/distributed/task/group.go
@@ -31,7 +31,7 @@ func (s StringSlice) Value() (driver.Value, error) {
 type GroupMeta struct {
 	ID uint `json:"-" bson:"-" gorm:"column:_id;primarykey;comment:_id"`
 	// GroupID 组的唯一标识
-	GroupID string `json:"group_id" bson:"_id" gorm:"column:id;uniqueIndex:uq_group_meta_group_id;comment:id"`
+	GroupID string `json:"group_id" bson:"_id" gorm:"column:id;size:191;uniqueIndex:uq_group_meta_group_id;comment:id"`
 	// 组名称
 	Name string `json:"name" bson:"name" gorm:"column:name;comment:组名称"`
 	// TaskIDs 接管的任务id

--- a/distributed/task/group.go
+++ b/distributed/task/group.go
@@ -31,7 +31,7 @@ func (s StringSlice) Value() (driver.Value, error) {
 type GroupMeta struct {
 	ID uint `json:"-" bson:"-" gorm:"column:_id;primarykey;comment:_id"`
 	// GroupID 组的唯一标识
-	GroupID string `json:"group_id" bson:"_id" gorm:"column:id;index;comment:id"`
+	GroupID string `json:"group_id" bson:"_id" gorm:"column:id;uniqueIndex:uq_group_meta_group_id;comment:id"`
 	// 组名称
 	Name string `json:"name" bson:"name" gorm:"column:name;comment:组名称"`
 	// TaskIDs 接管的任务id

--- a/distributed/task/state.go
+++ b/distributed/task/state.go
@@ -132,7 +132,7 @@ func (s Results) Value() (driver.Value, error) {
 // Status 任务状态
 type Status struct {
 	ID        uint           `json:"-" bson:"-" gorm:"column:_id;primarykey;comment:_id"`
-	TaskID    string         `json:"task_id" bson:"_id" gorm:"column:id;uniqueIndex:uq_status_task_id;comment:id"`
+	TaskID    string         `json:"task_id" bson:"_id" gorm:"column:id;size:191;uniqueIndex:uq_status_task_id;comment:id"`
 	GroupID   string         `json:"group_id" bson:"group_id" gorm:"column:group_id;comment:组唯一标识"`
 	Name      string         `json:"name" bson:"name" gorm:"column:name;comment:组名称"`
 	Status    State          `json:"status" bson:"status" gorm:"column:status;comment:任务状态"`


### PR DESCRIPTION
## What

- Enforce a database-level unique constraint for SQL-backed group IDs.
- Return the shared `backend.ErrGroupAlreadyExists` conflict from duplicate SQL takeovers while preserving the Redis sentinel as a compatibility alias.
- Bound both indexed identifiers to 191 characters so MySQL can create utf8mb4 unique indexes.
- Add SQLite regressions and an opt-in MySQL integration harness for migration, conflict translation, and historical duplicate safety.

## Why

The SQL backend previously used a non-unique index for `GroupMeta.GroupID`. Reusing an ID inserted another group row, and if the original group had already triggered completion, the duplicate row allowed `TriggerCompleted` to succeed again.

## How

- Give `GroupMeta.GroupID` a distinctly named unique index so fresh schemas reject duplicate identifiers and existing schemas add the constraint during `AutoMigrate`.
- Set `size:191` on `GroupMeta.GroupID` and the existing unique `Status.TaskID`; without it GORM maps both strings to LONGTEXT and MySQL fails with Error 1170.
- Translate dialect-specific unique-key errors through GORM and wrap the shared group-conflict sentinel with the group ID.
- Do not automatically delete or merge historical duplicates. `AutoMigrate` fails explicitly until operators reconcile them; the migration regression verifies both rows remain untouched.

## Tests

- `GKIT_TEST_MYSQL_DSN='<isolated *_test database>' go test -race ./distributed/backend/backend_db ./distributed/task -count=1`
- `go vet ./distributed/backend/backend_db ./distributed/task`
- `go test ./distributed/backend/backend_redis -run '^TestGroupTakeOverDuplicateReturnsConflictPromptly$' -count=1`
- Regression before the fix: the second takeover returned `nil`, two rows existed, and the second `TriggerCompleted` succeeded.
- MySQL 8.0.46 regression before the follow-up: AutoMigrate failed with Error 1170 first on `group_meta.id`, then on `statuses.id`.
- MySQL verifies the shared conflict sentinel with GORM `TranslateError` both disabled and enabled, plus historical duplicate migration failure without row deletion.
- Mutations: removing either identifier size reproduces Error 1170; removing either unique constraint breaks the group conflict or status upsert assertions.
