### PR TITLE
fix(controller): preserve shared Redis client lifecycle

### DIFF
--- a/distributed/controller/controller_redis/client_lifecycle_test.go
+++ b/distributed/controller/controller_redis/client_lifecycle_test.go
@@ -1,0 +1,52 @@
+package controller_redis
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/go-redis/redis/v8"
+
+	"github.com/songzhibin97/gkit/distributed/backend/backend_redis"
+	"github.com/songzhibin97/gkit/distributed/broker"
+	"github.com/songzhibin97/gkit/distributed/locker/lock_redis"
+	"github.com/songzhibin97/gkit/distributed/task"
+)
+
+func TestStopConsumingKeepsSharedRedisClientUsable(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewUniversalClient(&redis.UniversalOptions{Addrs: []string{mr.Addr()}})
+	t.Cleanup(func() { _ = client.Close() })
+
+	backend := backend_redis.NewBackendRedis(client, -1)
+	locker := lock_redis.NewRedisLock(client)
+	controller := NewControllerRedis(
+		broker.NewBroker(broker.NewRegisteredTask(), context.Background()),
+		client,
+		"tasks",
+		"delayed",
+	)
+	controller.StopConsuming()
+
+	t.Run("client", func(t *testing.T) {
+		assertSharedRedisOperation(t, "ping", client.Ping(context.Background()).Err())
+	})
+	t.Run("backend", func(t *testing.T) {
+		signature := task.NewSignature("shared-client-task", "task")
+		assertSharedRedisOperation(t, "set pending state", backend.SetStatePending(signature))
+	})
+	t.Run("locker", func(t *testing.T) {
+		assertSharedRedisOperation(t, "lock", locker.Lock("shared-client-lock", 1000, "owner"))
+	})
+}
+
+func assertSharedRedisOperation(t *testing.T, operation string, err error) {
+	t.Helper()
+	if errors.Is(err, redis.ErrClosed) {
+		t.Fatalf("%s failed because StopConsuming closed the shared Redis client: %v", operation, err)
+	}
+	if err != nil {
+		t.Fatalf("%s failed: %v", operation, err)
+	}
+}

--- a/distributed/controller/controller_redis/consumer_lifecycle_regression_test.go
+++ b/distributed/controller/controller_redis/consumer_lifecycle_regression_test.go
@@ -51,6 +51,34 @@ type issue79BlockingRPushHook struct {
 	once    sync.Once
 }
 
+type issue79BlockingClaimHook struct {
+	hash    string
+	started chan struct{}
+	release <-chan struct{}
+	once    sync.Once
+}
+
+func (h *issue79BlockingClaimHook) BeforeProcess(ctx context.Context, cmd redis.Cmder) (context.Context, error) {
+	if strings.EqualFold(cmd.Name(), "evalsha") {
+		args := cmd.Args()
+		if len(args) >= 2 && fmt.Sprint(args[1]) == h.hash {
+			h.once.Do(func() { close(h.started) })
+			<-h.release
+		}
+	}
+	return ctx, nil
+}
+
+func (*issue79BlockingClaimHook) AfterProcess(context.Context, redis.Cmder) error { return nil }
+
+func (*issue79BlockingClaimHook) BeforeProcessPipeline(ctx context.Context, _ []redis.Cmder) (context.Context, error) {
+	return ctx, nil
+}
+
+func (*issue79BlockingClaimHook) AfterProcessPipeline(context.Context, []redis.Cmder) error {
+	return nil
+}
+
 type issue79TrackingRedisClient struct {
 	redis.UniversalClient
 	active         atomic.Int32
@@ -181,7 +209,7 @@ func TestQueueProducerRestoresPoppedTaskWhenHandoffIsCancelled(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	handoff := make(chan []byte)
+	handoff := make(chan *reliableDelivery)
 	processorSlots := make(chan struct{}, 1)
 	failures := make(chan error, 1)
 	done := make(chan struct{})
@@ -253,7 +281,7 @@ func TestQueueProducerSurfacesRestoreFailureWithoutClientDetails(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	handoff := make(chan []byte)
+	handoff := make(chan *reliableDelivery)
 	processorSlots := make(chan struct{}, 1)
 	failures := make(chan error, 1)
 	done := make(chan struct{})
@@ -285,7 +313,7 @@ func TestQueueProducerSurfacesRestoreFailureWithoutClientDetails(t *testing.T) {
 	}
 	select {
 	case err := <-failures:
-		if got := err.Error(); got != "restore queued task: redis command failed" {
+		if got := err.Error(); got != "release queued task: redis command failed" {
 			t.Fatalf("restore error = %q, want operation context without client detail", got)
 		}
 		if !errors.Is(err, redis.ErrClosed) {
@@ -361,13 +389,8 @@ func TestStartConsumingCancelsAndJoinsAttemptBeforeReturn(t *testing.T) {
 }
 
 func TestRetryAttemptsDoNotAccumulateQueueProducers(t *testing.T) {
-	c, _, baseClient := newMiniController(t)
+	c, _, client := newMiniController(t)
 	c.Broker.SetRetry(true)
-	trackingClient := &issue79TrackingRedisClient{
-		UniversalClient: baseClient,
-		popCalls:        make(chan int32, 8),
-	}
-	c.client = trackingClient
 	defer c.StopConsuming()
 	c.RegisterTask("task")
 
@@ -376,17 +399,14 @@ func TestRetryAttemptsDoNotAccumulateQueueProducers(t *testing.T) {
 		if err != nil {
 			t.Fatalf("marshal attempt %d: %v", attempt, err)
 		}
-		if err := trackingClient.RPush(context.Background(), "test_task", body).Err(); err != nil {
+		if err := client.RPush(context.Background(), "test_task", body).Err(); err != nil {
 			t.Fatalf("enqueue attempt %d: %v", attempt, err)
 		}
 
 		failErr := fmt.Errorf("attempt %d failed", attempt)
-		abort := make(chan struct{})
-		processor := &issue79WaitForPopProcessor{
-			popCalls: trackingClient.popCalls,
-			wantCall: attempt * 2,
-			failErr:  failErr,
-			abort:    abort,
+		processor := &reliableTestProcessor{
+			started: make(chan struct{}),
+			err:     failErr,
 		}
 		result := make(chan issue79ConsumeResult, 1)
 		go func() {
@@ -403,78 +423,63 @@ func TestRetryAttemptsDoNotAccumulateQueueProducers(t *testing.T) {
 				t.Fatalf("attempt %d error = %v, want processor failure", attempt, outcome.err)
 			}
 		case <-time.After(3 * time.Second):
-			close(abort)
 			t.Fatalf("attempt %d did not return", attempt)
 		}
-		close(abort)
-		if active := trackingClient.active.Load(); active != 0 {
-			t.Fatalf("active queue producers after attempt %d = %d, want 0", attempt, active)
+		probe := fmt.Sprintf(`{"id":"probe-%d","name":"task"}`, attempt)
+		if err := client.RPush(context.Background(), "test_task", probe).Err(); err != nil {
+			t.Fatalf("enqueue probe %d: %v", attempt, err)
+		}
+		time.Sleep(100 * time.Millisecond)
+		if got := client.LIndex(context.Background(), "test_task", 0).Val(); got != probe {
+			t.Fatalf("queue producer survived attempt %d and claimed probe", attempt)
+		}
+		if err := client.LPop(context.Background(), "test_task").Err(); err != nil {
+			t.Fatalf("remove probe %d: %v", attempt, err)
 		}
 	}
 }
 
 func TestStartConsumingJoinsQueueProducerBeforeReturn(t *testing.T) {
-	c, _, baseClient := newMiniController(t)
-	releasePop := make(chan struct{})
-	trackingClient := &issue79TrackingRedisClient{
-		UniversalClient: baseClient,
-		popCalls:        make(chan int32, 4),
-		blockAfterCall:  2,
-		popUnblocked:    make(chan struct{}),
-		releasePop:      releasePop,
-	}
-	c.client = trackingClient
+	c, _, client := newMiniController(t)
 	defer c.StopConsuming()
 	c.RegisterTask("task")
-
-	body, err := json.Marshal(task.NewSignature("producer-join", "task"))
-	if err != nil {
-		t.Fatalf("marshal task: %v", err)
+	if err := reliableClaimScript.Load(context.Background(), client).Err(); err != nil {
+		t.Fatalf("preload claim script: %v", err)
 	}
-	if err := trackingClient.RPush(context.Background(), "test_task", body).Err(); err != nil {
-		t.Fatalf("enqueue task: %v", err)
+	releaseClaim := make(chan struct{})
+	hook := &issue79BlockingClaimHook{
+		hash:    reliableClaimScript.Hash(),
+		started: make(chan struct{}),
+		release: releaseClaim,
 	}
-	failErr := errors.New("stop attempt")
-	abort := make(chan struct{})
-	processor := &issue79WaitForPopProcessor{
-		popCalls: trackingClient.popCalls,
-		wantCall: 2,
-		failErr:  failErr,
-		abort:    abort,
-	}
+	client.AddHook(hook)
 	result := make(chan issue79ConsumeResult, 1)
 	go func() {
-		retry, err := c.StartConsuming(2, processor)
+		retry, err := c.StartConsuming(2, issue79Processor{})
 		result <- issue79ConsumeResult{retry: retry, err: err}
 	}()
 
 	select {
-	case <-trackingClient.popUnblocked:
+	case <-hook.started:
 	case <-time.After(3 * time.Second):
-		close(abort)
-		close(releasePop)
+		close(releaseClaim)
 		t.Fatal("queue producer did not reach its cancellation gate")
 	}
+	c.Broker.StopConsuming()
 	select {
 	case early := <-result:
-		close(abort)
-		close(releasePop)
+		close(releaseClaim)
 		t.Fatalf("StartConsuming returned before queue producer joined: retry=%v err=%v", early.retry, early.err)
 	case <-time.After(100 * time.Millisecond):
 	}
-	close(releasePop)
+	close(releaseClaim)
 	select {
 	case outcome := <-result:
-		if !errors.Is(outcome.err, failErr) {
-			t.Fatalf("StartConsuming error = %v, want processor failure", outcome.err)
+		if !errors.Is(outcome.err, context.Canceled) {
+			t.Fatalf("StartConsuming error = %v, want context.Canceled", outcome.err)
 		}
 	case <-time.After(3 * time.Second):
-		close(abort)
 		t.Fatal("StartConsuming did not return after queue producer joined")
-	}
-	close(abort)
-	if active := trackingClient.active.Load(); active != 0 {
-		t.Fatalf("active queue producers = %d, want 0", active)
 	}
 }
 

--- a/distributed/controller/controller_redis/redis.go
+++ b/distributed/controller/controller_redis/redis.go
@@ -40,6 +40,13 @@ type ControllerRedis struct {
 	consumingQueue string
 	// delayedQueue  延迟队列名称
 	delayedQueue string
+
+	deliveryMu            sync.Mutex
+	stopping              bool
+	deliveryLease         time.Duration
+	finalizationTimeout   time.Duration
+	ackConfirmationWindow time.Duration
+	tokenSource           *deliveryTokenGenerator
 }
 
 const consumerRestoreTimeout = 5 * time.Second
@@ -136,7 +143,8 @@ func (c *ControllerRedis) StartConsuming(concurrency int, handler task.Processor
 	defer cancelAttempt()
 
 	c.helper.Info("[*] Waiting for messages. To exit press CTRL+C")
-	handoff := make(chan []byte)
+	reliableQueue := newReliableQueue(c.client, c.consumingQueue, c.deliveryLease, c.tokenSource)
+	handoff := make(chan *reliableDelivery)
 	processorSlots := make(chan struct{}, concurrency)
 	failures := &consumerAttemptErrors{}
 	reportFailure := func(err error) {
@@ -161,22 +169,22 @@ func (c *ControllerRedis) StartConsuming(concurrency int, handler task.Processor
 	var processorWg sync.WaitGroup
 	for {
 		select {
-		case taskBody := <-handoff:
+		case delivery := <-handoff:
 			if attemptCtx.Err() != nil {
 				<-processorSlots
-				if restoreErr := c.restorePendingTask(c.consumingQueue, taskBody); restoreErr != nil {
-					reportFailure(restoreErr)
+				if releaseErr := c.releaseReliableDelivery(reliableQueue, delivery); releaseErr != nil {
+					reportFailure(releaseErr)
 				}
 				continue
 			}
 			processorWg.Add(1)
-			go func(body []byte) {
+			go func(claimed *reliableDelivery) {
 				defer processorWg.Done()
 				defer func() { <-processorSlots }()
-				if processErr := c.consumeOne(body, c.consumingQueue, handler); processErr != nil {
+				if processErr := c.consumeReliableDelivery(attemptCtx, reliableQueue, claimed, handler); processErr != nil {
 					reportFailure(processErr)
 				}
-			}(taskBody)
+			}(delivery)
 		case <-attemptCtx.Done():
 			cancelAttempt()
 			producerWg.Wait()
@@ -286,10 +294,13 @@ func (c *ControllerRedis) popDelayedTaskWithContext(ctx context.Context, queue s
 func (c *ControllerRedis) produceQueuedTasks(
 	ctx context.Context,
 	queue string,
-	handoff chan<- []byte,
+	handoff chan<- *reliableDelivery,
 	processorSlots chan struct{},
 	reportFailure func(error),
 ) {
+	reliableQueue := newReliableQueue(c.client, queue, c.deliveryLease, c.tokenSource)
+	idleInterval := 25 * time.Millisecond
+	emptyCount := uint64(0)
 	for {
 		select {
 		case processorSlots <- struct{}{}:
@@ -297,30 +308,40 @@ func (c *ControllerRedis) produceQueuedTasks(
 			return
 		}
 
-		taskBody, err := c.popTaskWithContext(ctx, queue, 0)
+		delivery, err := reliableQueue.claim(ctx)
 		if err != nil {
 			<-processorSlots
 			switch {
-			case errors.Is(err, redis.Nil):
-				continue
 			case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
 				return
 			default:
-				reportFailure(wrapRedisOperation("pop queued task", err))
+				reportFailure(err)
 				return
 			}
 		}
-		if len(taskBody) == 0 {
+		if delivery == nil {
 			<-processorSlots
+			emptyCount++
+			if !waitReliablePoll(ctx, reliableIdleDelay(idleInterval, queue, emptyCount)) {
+				return
+			}
+			if idleInterval < time.Second {
+				idleInterval *= 2
+				if idleInterval > time.Second {
+					idleInterval = time.Second
+				}
+			}
 			continue
 		}
+		emptyCount = 0
+		idleInterval = 25 * time.Millisecond
 
 		select {
-		case handoff <- taskBody:
+		case handoff <- delivery:
 		case <-ctx.Done():
 			<-processorSlots
-			if restoreErr := c.restorePendingTask(queue, taskBody); restoreErr != nil {
-				reportFailure(restoreErr)
+			if releaseErr := c.releaseReliableDelivery(reliableQueue, delivery); releaseErr != nil {
+				reportFailure(releaseErr)
 			}
 			return
 		}
@@ -416,6 +437,9 @@ func (c *ControllerRedis) restoreDelayedTask(queue string, taskBody []byte, scor
 }
 
 func (c *ControllerRedis) StopConsuming() {
+	c.deliveryMu.Lock()
+	c.stopping = true
+	c.deliveryMu.Unlock()
 	c.Broker.StopConsuming()
 	c.consumingWg.Wait()
 }
@@ -473,11 +497,15 @@ func (c *ControllerRedis) GetDelayedTasks() ([]*task.Signature, error) {
 // closing it after every component sharing the client has stopped using it.
 func NewControllerRedis(broker *broker.Broker, client redis.UniversalClient, consumingQueue, delayedQueue string) controller.Controller {
 	return &ControllerRedis{
-		Broker:         broker,
-		client:         client,
-		lock:           redsync.New(goredis.NewPool(client)),
-		helper:         log.NewHelper(log.DefaultLogger),
-		consumingQueue: consumingQueue,
-		delayedQueue:   delayedQueue,
+		Broker:                broker,
+		client:                client,
+		lock:                  redsync.New(goredis.NewPool(client)),
+		helper:                log.NewHelper(log.DefaultLogger),
+		consumingQueue:        consumingQueue,
+		delayedQueue:          delayedQueue,
+		deliveryLease:         defaultDeliveryLease,
+		finalizationTimeout:   consumerRestoreTimeout,
+		ackConfirmationWindow: consumerRestoreTimeout,
+		tokenSource:           newDeliveryTokenGenerator(nil),
 	}
 }

--- a/distributed/controller/controller_redis/redis.go
+++ b/distributed/controller/controller_redis/redis.go
@@ -418,7 +418,6 @@ func (c *ControllerRedis) restoreDelayedTask(queue string, taskBody []byte, scor
 func (c *ControllerRedis) StopConsuming() {
 	c.Broker.StopConsuming()
 	c.consumingWg.Wait()
-	c.client.Close()
 }
 
 func (c *ControllerRedis) Publish(ctx context.Context, t *task.Signature) error {
@@ -470,6 +469,8 @@ func (c *ControllerRedis) GetDelayedTasks() ([]*task.Signature, error) {
 	return taskSlice, nil
 }
 
+// NewControllerRedis borrows client. The caller remains responsible for
+// closing it after every component sharing the client has stopped using it.
 func NewControllerRedis(broker *broker.Broker, client redis.UniversalClient, consumingQueue, delayedQueue string) controller.Controller {
 	return &ControllerRedis{
 		Broker:         broker,

--- a/distributed/controller/controller_redis/redis_test.go
+++ b/distributed/controller/controller_redis/redis_test.go
@@ -33,6 +33,7 @@ func initLiveController(t *testing.T) controller.Controller {
 	}
 	queue := fmt.Sprintf("gkit:test:controller:%d", time.Now().UnixNano())
 	delayedQueue := queue + ":delayed"
+	reliableKeys := deriveReliableQueueKeys(queue)
 	producerCtx, cancelProducer := context.WithCancel(context.Background())
 	producerDone := make(chan struct{})
 	t.Cleanup(func() {
@@ -41,7 +42,8 @@ func initLiveController(t *testing.T) controller.Controller {
 
 		cleanupCtx, cancelCleanup := context.WithTimeout(context.Background(), time.Second)
 		defer cancelCleanup()
-		if err := client.Del(cleanupCtx, queue, delayedQueue).Err(); err != nil {
+		if err := client.Del(cleanupCtx, queue, delayedQueue, reliableKeys.inflight,
+			reliableKeys.visibility, reliableKeys.outcomes, reliableKeys.repairCursor, reliableKeys.repairBacklog).Err(); err != nil {
 			t.Errorf("clean live Redis queues: %v", err)
 		}
 		if err := client.Close(); err != nil {

--- a/distributed/controller/controller_redis/redis_test.go
+++ b/distributed/controller/controller_redis/redis_test.go
@@ -2,6 +2,7 @@ package controller_redis
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -13,7 +14,9 @@ import (
 	"github.com/songzhibin97/gkit/distributed/controller"
 )
 
-func InitController() controller.Controller {
+func initLiveController(t *testing.T) controller.Controller {
+	t.Helper()
+
 	opt := redis.UniversalOptions{
 		Addrs: []string{"127.0.0.1:6379"},
 	}
@@ -28,28 +31,59 @@ func InitController() controller.Controller {
 		_ = client.Close()
 		return nil
 	}
+	queue := fmt.Sprintf("gkit:test:controller:%d", time.Now().UnixNano())
+	delayedQueue := queue + ":delayed"
+	producerCtx, cancelProducer := context.WithCancel(context.Background())
+	producerDone := make(chan struct{})
+	t.Cleanup(func() {
+		cancelProducer()
+		<-producerDone
+
+		cleanupCtx, cancelCleanup := context.WithTimeout(context.Background(), time.Second)
+		defer cancelCleanup()
+		if err := client.Del(cleanupCtx, queue, delayedQueue).Err(); err != nil {
+			t.Errorf("clean live Redis queues: %v", err)
+		}
+		if err := client.Close(); err != nil {
+			t.Errorf("close live Redis client: %v", err)
+		}
+	})
+
 	bk := broker.NewBroker(broker.NewRegisteredTask(), context.Background())
 	go func() {
+		defer close(producerDone)
+		ticker := time.NewTicker(10 * time.Millisecond)
+		defer ticker.Stop()
+
 		n := 0
 		for {
-			time.Sleep(time.Second)
-			if err := client.LPush(context.Background(), "test_task",
-				fmt.Sprintf(`{
-    "id":"%d",
-    "name":"test_task"
-}`, n)).Err(); err != nil {
-				fmt.Println("err:", err)
+			select {
+			case <-producerCtx.Done():
+				return
+			case <-ticker.C:
+			}
+			if err := client.LPush(producerCtx, queue, fmt.Sprintf(`{"id":"%d","name":"test_task"}`, n)).Err(); err != nil {
+				if producerCtx.Err() != nil {
+					return
+				}
+				t.Errorf("produce live Redis task: %v", err)
+				return
 			}
 			n++
 		}
 	}()
-	return NewControllerRedis(bk, client, "test_task", "delayed")
+	return NewControllerRedis(bk, client, queue, delayedQueue)
 }
 
-type processor struct{}
+type processor struct {
+	processed chan<- struct{}
+}
 
 func (p processor) Process(t *task.Signature) error {
-	fmt.Println("消费", t.ID, t.Name)
+	select {
+	case p.processed <- struct{}{}:
+	default:
+	}
 	return nil
 }
 
@@ -62,19 +96,33 @@ func (p processor) PreConsumeHandler() bool {
 }
 
 func TestControllerRedis_StartConsuming(t *testing.T) {
-	ct := InitController()
+	ct := initLiveController(t)
 	if ct == nil {
 		t.Skip("no live Redis at 127.0.0.1:6379")
 	}
+	t.Cleanup(ct.StopConsuming)
 	ct.RegisterTask("test_task")
-	go func() {
-		time.Sleep(10 * time.Second)
-		ct.StopConsuming()
-	}()
-	b, err := ct.StartConsuming(1, processor{})
-	if err != nil {
-		t.Error(err)
-		return
+	processed := make(chan struct{}, 1)
+	type consumeResult struct {
+		retry bool
+		err   error
 	}
-	t.Log(b)
+	result := make(chan consumeResult, 1)
+	go func() {
+		retry, err := ct.StartConsuming(1, processor{processed: processed})
+		result <- consumeResult{retry: retry, err: err}
+	}()
+	select {
+	case <-processed:
+	case <-time.After(3 * time.Second):
+		t.Fatal("live Redis task was not consumed")
+	}
+	ct.StopConsuming()
+	outcome := <-result
+	if !errors.Is(outcome.err, context.Canceled) {
+		t.Fatalf("StartConsuming error = %v, want context.Canceled after StopConsuming", outcome.err)
+	}
+	if outcome.retry {
+		t.Fatal("StartConsuming retry = true after an intentional stop, want false")
+	}
 }

--- a/distributed/controller/controller_redis/reliable_consumer.go
+++ b/distributed/controller/controller_redis/reliable_consumer.go
@@ -1,0 +1,217 @@
+package controller_redis
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"time"
+
+	json "github.com/json-iterator/go"
+
+	"github.com/songzhibin97/gkit/distributed/task"
+)
+
+func (c *ControllerRedis) consumeReliableDelivery(
+	attemptCtx context.Context,
+	queue *reliableQueue,
+	delivery *reliableDelivery,
+	handler task.Processor,
+) error {
+	var signature task.Signature
+	decoder := json.NewDecoder(bytes.NewReader(delivery.payload))
+	decoder.UseNumber()
+	if err := decoder.Decode(&signature); err != nil {
+		decodeErr := fmt.Errorf("decode queued task: %w", err)
+		if c.deliveryMustRelease(attemptCtx) {
+			return errors.Join(decodeErr, c.releaseReliableDelivery(queue, delivery))
+		}
+		return errors.Join(decodeErr, c.deferReliableDelivery(queue, delivery))
+	}
+
+	if !c.IsRegisterTask(signature.Name) {
+		if c.deliveryMustRelease(attemptCtx) {
+			return errors.Join(attemptCtx.Err(), c.releaseReliableDelivery(queue, delivery))
+		}
+		if signature.IgnoreNotRegisteredTask {
+			return c.acknowledgeReliableDelivery(queue, delivery)
+		}
+		notRegisteredErr := fmt.Errorf("task %q is not registered", signature.Name)
+		return errors.Join(notRegisteredErr, c.deferReliableDelivery(queue, delivery))
+	}
+
+	if !c.tryStartReliableProcessing(attemptCtx) {
+		return errors.Join(attemptCtx.Err(), c.releaseReliableDelivery(queue, delivery))
+	}
+
+	renewCtx, cancelRenew := context.WithCancel(context.Background())
+	renewDone := make(chan error, 1)
+	go func() {
+		renewDone <- c.maintainReliableDelivery(renewCtx, queue, delivery)
+	}()
+	processErr := handler.Process(&signature)
+	cancelRenew()
+	renewErr := <-renewDone
+
+	if processErr != nil {
+		finalizeErr := c.deferReliableDelivery(queue, delivery)
+		return errors.Join(fmt.Errorf("process task %q: %w", signature.ID, processErr), renewErr, finalizeErr)
+	}
+	ackErr := c.acknowledgeReliableDelivery(queue, delivery)
+	return errors.Join(renewErr, ackErr)
+}
+
+func (c *ControllerRedis) deliveryMustRelease(ctx context.Context) bool {
+	c.deliveryMu.Lock()
+	defer c.deliveryMu.Unlock()
+	return c.stopping || ctx.Err() != nil
+}
+
+func (c *ControllerRedis) tryStartReliableProcessing(ctx context.Context) bool {
+	c.deliveryMu.Lock()
+	defer c.deliveryMu.Unlock()
+	return !c.stopping && ctx.Err() == nil
+}
+
+func (c *ControllerRedis) releaseReliableDelivery(queue *reliableQueue, delivery *reliableDelivery) error {
+	ctx, cancel := context.WithTimeout(context.Background(), c.reliableFinalizationTimeout())
+	defer cancel()
+	return queue.release(ctx, delivery)
+}
+
+func (c *ControllerRedis) deferReliableDelivery(queue *reliableQueue, delivery *reliableDelivery) error {
+	ctx, cancel := context.WithTimeout(context.Background(), c.reliableFinalizationTimeout())
+	defer cancel()
+	_, err := queue.deferRetry(ctx, delivery)
+	return err
+}
+
+func (c *ControllerRedis) acknowledgeReliableDelivery(queue *reliableQueue, delivery *reliableDelivery) error {
+	window := c.ackConfirmationWindow
+	if window <= 0 {
+		window = consumerRestoreTimeout
+	}
+	confirmationDeadline := time.Now().Add(window)
+	var lastErr error
+	for {
+		remaining := time.Until(confirmationDeadline)
+		if remaining <= 0 {
+			if lastErr != nil {
+				return lastErr
+			}
+			return context.DeadlineExceeded
+		}
+		operationTimeout := c.reliableFinalizationTimeout()
+		if remaining < operationTimeout {
+			operationTimeout = remaining
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), operationTimeout)
+		err := queue.acknowledge(ctx, delivery)
+		cancel()
+		if err == nil || errors.Is(err, ErrDeliveryLeaseLost) {
+			return err
+		}
+		lastErr = err
+		remaining = time.Until(confirmationDeadline)
+		if remaining <= 0 {
+			return lastErr
+		}
+		wait := 25 * time.Millisecond
+		if remaining < wait {
+			wait = remaining
+		}
+		time.Sleep(wait)
+	}
+}
+
+func (c *ControllerRedis) maintainReliableDelivery(ctx context.Context, queue *reliableQueue, delivery *reliableDelivery) error {
+	var lastRenewErr error
+	var renewFailures uint64
+	for {
+		remaining := time.Until(delivery.confirmedUntil)
+		if remaining <= 0 {
+			if lastRenewErr != nil {
+				return errors.Join(ErrDeliveryLeaseLost, lastRenewErr)
+			}
+			return ErrDeliveryLeaseLost
+		}
+
+		wait := remaining / 2
+		if lastRenewErr != nil {
+			wait = reliableIdleDelay(25*time.Millisecond, delivery.token, renewFailures)
+			if wait > remaining {
+				wait = remaining
+			}
+		}
+		if !waitReliablePoll(ctx, wait) {
+			return nil
+		}
+
+		remaining = time.Until(delivery.confirmedUntil)
+		if remaining <= 0 {
+			continue
+		}
+		operationTimeout := remaining / 2
+		if operationTimeout > 5*time.Second {
+			operationTimeout = 5 * time.Second
+		}
+		if operationTimeout <= 0 {
+			continue
+		}
+		renewCtx, cancel := context.WithTimeout(ctx, operationTimeout)
+		err := queue.renew(renewCtx, delivery)
+		cancel()
+		if err == nil {
+			lastRenewErr = nil
+			renewFailures = 0
+			continue
+		}
+		if ctx.Err() != nil {
+			return nil
+		}
+		if errors.Is(err, ErrDeliveryLeaseLost) {
+			return err
+		}
+		lastRenewErr = err
+		renewFailures++
+	}
+}
+
+func (c *ControllerRedis) reliableFinalizationTimeout() time.Duration {
+	if c.finalizationTimeout <= 0 {
+		return consumerRestoreTimeout
+	}
+	return c.finalizationTimeout
+}
+
+func waitReliablePoll(ctx context.Context, duration time.Duration) bool {
+	if duration <= 0 {
+		return ctx.Err() == nil
+	}
+	timer := time.NewTimer(duration)
+	defer func() {
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+	}()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
+func reliableIdleDelay(base time.Duration, queue string, emptyCount uint64) time.Duration {
+	seed := make([]byte, len(queue)+8)
+	copy(seed, queue)
+	binary.BigEndian.PutUint64(seed[len(queue):], emptyCount)
+	digest := sha256.Sum256(seed)
+	basisPoints := 8000 + int(binary.BigEndian.Uint16(digest[:2]))%4001
+	return time.Duration(int64(base) * int64(basisPoints) / 10000)
+}

--- a/distributed/controller/controller_redis/reliable_consumer_test.go
+++ b/distributed/controller/controller_redis/reliable_consumer_test.go
@@ -1,0 +1,488 @@
+package controller_redis
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/go-redis/redis/v8"
+	json "github.com/json-iterator/go"
+
+	"github.com/songzhibin97/gkit/distributed/broker"
+	"github.com/songzhibin97/gkit/distributed/task"
+)
+
+type reliableTestProcessor struct {
+	started  chan struct{}
+	release  chan struct{}
+	returned chan struct{}
+	err      error
+	once     sync.Once
+}
+
+func (p *reliableTestProcessor) Process(*task.Signature) error {
+	p.once.Do(func() { close(p.started) })
+	if p.release != nil {
+		<-p.release
+	}
+	if p.returned != nil {
+		close(p.returned)
+	}
+	return p.err
+}
+
+func (*reliableTestProcessor) ConsumeQueue() string    { return "task" }
+func (*reliableTestProcessor) PreConsumeHandler() bool { return true }
+
+type reliableConsumeResult struct {
+	retry bool
+	err   error
+}
+
+type claimTimingHook struct {
+	hash  string
+	times chan time.Time
+}
+
+func (h *claimTimingHook) BeforeProcess(ctx context.Context, _ redis.Cmder) (context.Context, error) {
+	return ctx, nil
+}
+
+func (h *claimTimingHook) AfterProcess(_ context.Context, cmd redis.Cmder) error {
+	if !strings.EqualFold(cmd.Name(), "evalsha") {
+		return nil
+	}
+	args := cmd.Args()
+	if len(args) >= 2 && fmt.Sprint(args[1]) == h.hash {
+		select {
+		case h.times <- time.Now():
+		default:
+		}
+	}
+	return nil
+}
+
+func (*claimTimingHook) BeforeProcessPipeline(ctx context.Context, _ []redis.Cmder) (context.Context, error) {
+	return ctx, nil
+}
+
+func (*claimTimingHook) AfterProcessPipeline(context.Context, []redis.Cmder) error { return nil }
+
+func newReliableTestController(t *testing.T, queue string) (*ControllerRedis, redis.UniversalClient) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redis.NewUniversalClient(&redis.UniversalOptions{Addrs: []string{mr.Addr()}})
+	t.Cleanup(func() { _ = client.Close() })
+	b := broker.NewBroker(broker.NewRegisteredTask(), context.Background())
+	c := NewControllerRedis(b, client, queue, queue+":delayed").(*ControllerRedis)
+	c.RegisterTask("task")
+	return c, client
+}
+
+func reliableTaggedPrefix(queue, tag string) string {
+	digest := sha256.Sum256([]byte(queue))
+	return fmt.Sprintf("{%s}:gkit:%x", tag, digest)
+}
+
+func reliableTaskBody(t *testing.T, id string) []byte {
+	t.Helper()
+	signature := task.NewSignature(id, "task")
+	signature.Router = "queue:{reliable}"
+	body, err := json.Marshal(signature)
+	if err != nil {
+		t.Fatalf("marshal task: %v", err)
+	}
+	return body
+}
+
+func TestClaimPersistsUntilSuccessfulAck(t *testing.T) {
+	const queue = "queue:{reliable}"
+	c, client := newReliableTestController(t, queue)
+	body := reliableTaskBody(t, "persistent-claim")
+	if err := client.RPush(context.Background(), queue, body).Err(); err != nil {
+		t.Fatalf("enqueue task: %v", err)
+	}
+	processor := &reliableTestProcessor{started: make(chan struct{}), release: make(chan struct{})}
+	result := make(chan reliableConsumeResult, 1)
+	go func() {
+		retry, err := c.StartConsuming(1, processor)
+		result <- reliableConsumeResult{retry: retry, err: err}
+	}()
+	select {
+	case <-processor.started:
+	case <-time.After(3 * time.Second):
+		c.StopConsuming()
+		t.Fatal("processor did not start")
+	}
+
+	prefix := reliableTaggedPrefix(queue, "reliable")
+	if got := client.HLen(context.Background(), prefix+":inflight").Val(); got != 1 {
+		close(processor.release)
+		c.StopConsuming()
+		t.Fatalf("inflight reservations while processing = %d, want 1", got)
+	}
+	if got := client.ZCard(context.Background(), prefix+":ack-outcomes").Val(); got != 0 {
+		close(processor.release)
+		c.StopConsuming()
+		t.Fatalf("ack outcomes before processor success = %d, want 0", got)
+	}
+	close(processor.release)
+	deadline := time.Now().Add(3 * time.Second)
+	for client.ZCard(context.Background(), prefix+":ack-outcomes").Val() != 1 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := client.ZCard(context.Background(), prefix+":ack-outcomes").Val(); got != 1 {
+		c.StopConsuming()
+		t.Fatalf("ack outcomes after processor success = %d, want 1", got)
+	}
+	c.StopConsuming()
+	select {
+	case <-result:
+	case <-time.After(3 * time.Second):
+		t.Fatal("consumer did not stop")
+	}
+}
+
+func TestAckOccursOnlyAfterProcessorSuccess(t *testing.T) {
+	t.Run("ignored unregistered task is acknowledged", func(t *testing.T) {
+		const queue = "queue:{ignore-unregistered}"
+		c, client := newReliableTestController(t, queue)
+		signature := task.NewSignature("ignored", "missing")
+		signature.Router = queue
+		signature.IgnoreNotRegisteredTask = true
+		body, err := json.Marshal(signature)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if err := client.RPush(context.Background(), queue, body).Err(); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		processor := &reliableTestProcessor{started: make(chan struct{})}
+		result := make(chan reliableConsumeResult, 1)
+		go func() {
+			retry, err := c.StartConsuming(1, processor)
+			result <- reliableConsumeResult{retry: retry, err: err}
+		}()
+		keys := deriveReliableQueueKeys(queue)
+		deadline := time.Now().Add(3 * time.Second)
+		for client.ZCard(context.Background(), keys.outcomes).Val() != 1 && time.Now().Before(deadline) {
+			time.Sleep(time.Millisecond)
+		}
+		if got := client.ZCard(context.Background(), keys.outcomes).Val(); got != 1 {
+			c.StopConsuming()
+			t.Fatalf("ack outcomes = %d, want 1", got)
+		}
+		select {
+		case <-processor.started:
+			c.StopConsuming()
+			t.Fatal("processor ran for ignored unregistered task")
+		default:
+		}
+		c.StopConsuming()
+		<-result
+	})
+
+	t.Run("non-ignored unregistered task is deferred", func(t *testing.T) {
+		const queue = "queue:{defer-unregistered}"
+		c, client := newReliableTestController(t, queue)
+		signature := task.NewSignature("not-ignored", "missing")
+		signature.Router = queue
+		body, err := json.Marshal(signature)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if err := client.RPush(context.Background(), queue, body).Err(); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		processor := &reliableTestProcessor{started: make(chan struct{})}
+		_, err = c.StartConsuming(1, processor)
+		if err == nil || !strings.Contains(err.Error(), "not registered") {
+			t.Fatalf("StartConsuming error = %v, want not-registered failure", err)
+		}
+		keys := deriveReliableQueueKeys(queue)
+		if got := client.HLen(context.Background(), keys.inflight).Val(); got != 1 {
+			t.Fatalf("deferred inflight = %d, want 1", got)
+		}
+		if got := client.ZCard(context.Background(), keys.outcomes).Val(); got != 0 {
+			t.Fatalf("ack outcomes = %d, want 0", got)
+		}
+	})
+}
+
+func TestActiveProcessorRenewsWithinConfirmedDeadline(t *testing.T) {
+	const queue = "queue:{renew-active}"
+	c, client := newReliableTestController(t, queue)
+	c.deliveryLease = 80 * time.Millisecond
+	if err := reliableRenewScript.Load(context.Background(), client).Err(); err != nil {
+		t.Fatalf("preload renew script: %v", err)
+	}
+	lostRenew := &loseScriptResponseHook{hash: reliableRenewScript.Hash(), err: errors.New("renew response lost")}
+	client.AddHook(lostRenew)
+	lostRenew.armed.Store(true)
+	body := reliableTaskBody(t, "long-running")
+	if err := client.RPush(context.Background(), queue, body).Err(); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	processor := &reliableTestProcessor{started: make(chan struct{}), release: make(chan struct{})}
+	result := make(chan reliableConsumeResult, 1)
+	go func() {
+		retry, err := c.StartConsuming(1, processor)
+		result <- reliableConsumeResult{retry: retry, err: err}
+	}()
+	select {
+	case <-processor.started:
+	case <-time.After(3 * time.Second):
+		c.StopConsuming()
+		t.Fatal("processor did not start")
+	}
+	time.Sleep(250 * time.Millisecond)
+	if lostRenew.armed.Load() {
+		close(processor.release)
+		c.StopConsuming()
+		t.Fatal("renewal transport failure was not injected")
+	}
+	keys := deriveReliableQueueKeys(queue)
+	if got := client.HLen(context.Background(), keys.inflight).Val(); got != 1 {
+		close(processor.release)
+		c.StopConsuming()
+		t.Fatalf("active inflight after initial lease = %d, want 1", got)
+	}
+	probe := newReliableQueue(client, queue, c.deliveryLease, newDeliveryTokenGenerator(nil))
+	if reclaimed, err := probe.claim(context.Background()); err != nil || reclaimed != nil {
+		close(processor.release)
+		c.StopConsuming()
+		t.Fatalf("healthy delivery reclaimed = (%v, %v)", reclaimed, err)
+	}
+	close(processor.release)
+	deadline := time.Now().Add(3 * time.Second)
+	for client.HLen(context.Background(), keys.inflight).Val() != 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	c.StopConsuming()
+	<-result
+}
+
+func TestStopJoinsHeartbeatAndOwnedDeliveries(t *testing.T) {
+	const queue = "queue:{stop-join}"
+	c, client := newReliableTestController(t, queue)
+	c.deliveryLease = 40 * time.Millisecond
+	if err := reliableRenewScript.Load(context.Background(), client).Err(); err != nil {
+		t.Fatalf("preload renew script: %v", err)
+	}
+	if err := reliableAckScript.Load(context.Background(), client).Err(); err != nil {
+		t.Fatalf("preload ack script: %v", err)
+	}
+	renewEntered := make(chan struct{})
+	renewCanceled := make(chan struct{})
+	renewRelease := make(chan struct{})
+	var renewReleaseOnce sync.Once
+	releaseRenew := func() { renewReleaseOnce.Do(func() { close(renewRelease) }) }
+	t.Cleanup(releaseRenew)
+	renewHook := &beforeScriptHook{
+		hash:     reliableRenewScript.Hash(),
+		entered:  renewEntered,
+		canceled: renewCanceled,
+		release:  renewRelease,
+	}
+	renewHook.armed.Store(true)
+	ackEntered := make(chan struct{})
+	ackHook := &beforeScriptHook{hash: reliableAckScript.Hash(), entered: ackEntered}
+	ackHook.armed.Store(true)
+	client.AddHook(renewHook)
+	client.AddHook(ackHook)
+
+	body := reliableTaskBody(t, "stop-active")
+	if err := client.RPush(context.Background(), queue, body).Err(); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	processor := &reliableTestProcessor{
+		started:  make(chan struct{}),
+		release:  make(chan struct{}),
+		returned: make(chan struct{}),
+	}
+	var processorReleaseOnce sync.Once
+	releaseProcessor := func() { processorReleaseOnce.Do(func() { close(processor.release) }) }
+	t.Cleanup(releaseProcessor)
+	consumeDone := make(chan reliableConsumeResult, 1)
+	go func() {
+		retry, err := c.StartConsuming(1, processor)
+		consumeDone <- reliableConsumeResult{retry: retry, err: err}
+	}()
+	select {
+	case <-processor.started:
+	case <-time.After(3 * time.Second):
+		c.StopConsuming()
+		t.Fatal("processor did not start")
+	}
+	select {
+	case <-renewEntered:
+	case <-time.After(3 * time.Second):
+		releaseProcessor()
+		c.StopConsuming()
+		t.Fatal("renew call did not enter blocking hook")
+	}
+
+	stopCtx := c.GetStopCtx()
+	stopDone := make(chan struct{})
+	go func() {
+		c.StopConsuming()
+		close(stopDone)
+	}()
+	select {
+	case <-stopCtx.Done():
+	case <-time.After(3 * time.Second):
+		releaseProcessor()
+		releaseRenew()
+		t.Fatal("StopConsuming did not cancel the consume attempt")
+	}
+	releaseProcessor()
+	select {
+	case <-processor.returned:
+	case <-time.After(3 * time.Second):
+		releaseRenew()
+		t.Fatal("processor did not return")
+	}
+	select {
+	case <-renewCanceled:
+	case <-time.After(3 * time.Second):
+		releaseRenew()
+		t.Fatal("processor return did not cancel the blocked renew operation")
+	}
+	select {
+	case <-ackEntered:
+		releaseRenew()
+		t.Fatal("finalization started before the blocked renew operation was joined")
+	case <-stopDone:
+		releaseRenew()
+		t.Fatal("StopConsuming returned before the blocked renew operation was joined")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	releaseRenew()
+	select {
+	case <-ackEntered:
+	case <-time.After(3 * time.Second):
+		t.Fatal("acknowledgement did not start after renew was released")
+	}
+	select {
+	case <-stopDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("StopConsuming did not finish after processor and renewal returned")
+	}
+	if outcome := <-consumeDone; !errors.Is(outcome.err, ErrDeliveryLeaseLost) {
+		t.Fatalf("StartConsuming error = %v, want ErrDeliveryLeaseLost after blocked renew outlives lease", outcome.err)
+	}
+	if err := client.Ping(context.Background()).Err(); err != nil {
+		t.Fatalf("shared Redis client closed: %v", err)
+	}
+}
+
+func TestIdleClaimRequestsAreBounded(t *testing.T) {
+	const queue = "queue:{idle-bound}"
+	c, client := newReliableTestController(t, queue)
+	if err := reliableClaimScript.Load(context.Background(), client).Err(); err != nil {
+		t.Fatalf("preload claim script: %v", err)
+	}
+	timing := &claimTimingHook{hash: reliableClaimScript.Hash(), times: make(chan time.Time, 32)}
+	client.AddHook(timing)
+	processor := &reliableTestProcessor{started: make(chan struct{}), release: make(chan struct{})}
+	consumeDone := make(chan reliableConsumeResult, 1)
+	go func() {
+		retry, err := c.StartConsuming(1, processor)
+		consumeDone <- reliableConsumeResult{retry: retry, err: err}
+	}()
+
+	var calls []time.Time
+	deadline := time.After(8 * time.Second)
+	for len(calls) < 8 {
+		select {
+		case calledAt := <-timing.times:
+			calls = append(calls, calledAt)
+		case <-deadline:
+			c.StopConsuming()
+			t.Fatalf("claim calls = %d, want 8", len(calls))
+		}
+	}
+	steadyInterval := calls[7].Sub(calls[6])
+	if steadyInterval < 800*time.Millisecond || steadyInterval > 1300*time.Millisecond {
+		c.StopConsuming()
+		t.Fatalf("steady idle claim interval = %v, want [800ms, 1.3s]", steadyInterval)
+	}
+	for count := uint64(1); count <= 64; count++ {
+		delay := reliableIdleDelay(time.Second, queue, count)
+		if delay < 800*time.Millisecond || delay > 1200*time.Millisecond {
+			c.StopConsuming()
+			t.Fatalf("idle jitter delay = %v, want [800ms, 1.2s]", delay)
+		}
+	}
+
+	publishedAt := time.Now()
+	body := reliableTaskBody(t, "idle-discovery")
+	if err := client.RPush(context.Background(), queue, body).Err(); err != nil {
+		c.StopConsuming()
+		t.Fatalf("publish ready task: %v", err)
+	}
+	select {
+	case <-processor.started:
+		if elapsed := time.Since(publishedAt); elapsed > 1200*time.Millisecond {
+			close(processor.release)
+			c.StopConsuming()
+			t.Fatalf("idle task discovery = %v, want <= 1.2s", elapsed)
+		}
+	case <-time.After(1500 * time.Millisecond):
+		close(processor.release)
+		c.StopConsuming()
+		t.Fatal("published task not discovered from steady idle")
+	}
+	close(processor.release)
+	c.StopConsuming()
+	<-consumeDone
+}
+
+func TestProcessorErrorDefersDelivery(t *testing.T) {
+	const queue = "queue:{reliable}"
+	c, client := newReliableTestController(t, queue)
+	body := reliableTaskBody(t, "processor-error")
+	if err := client.RPush(context.Background(), queue, body).Err(); err != nil {
+		t.Fatalf("enqueue task: %v", err)
+	}
+	wantErr := errors.New("processor failed")
+	processor := &reliableTestProcessor{started: make(chan struct{}), err: wantErr}
+	retry, err := c.StartConsuming(1, processor)
+	if retry {
+		t.Fatal("retry = true, want false")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("StartConsuming error = %v, want processor failure", err)
+	}
+	prefix := reliableTaggedPrefix(queue, "reliable")
+	durable := client.LLen(context.Background(), queue).Val() + client.HLen(context.Background(), prefix+":inflight").Val()
+	if durable != 1 {
+		t.Fatalf("durable copies after processor error = %d, want 1", durable)
+	}
+}
+
+func TestMalformedPayloadRemainsRecoverable(t *testing.T) {
+	const queue = "queue:{reliable}"
+	c, client := newReliableTestController(t, queue)
+	body := []byte("{not-json")
+	if err := client.RPush(context.Background(), queue, body).Err(); err != nil {
+		t.Fatalf("enqueue malformed task: %v", err)
+	}
+	processor := &reliableTestProcessor{started: make(chan struct{})}
+	_, err := c.StartConsuming(1, processor)
+	if err == nil {
+		t.Fatal("StartConsuming error = nil, want decode failure")
+	}
+	prefix := reliableTaggedPrefix(queue, "reliable")
+	durable := client.LLen(context.Background(), queue).Val() + client.HLen(context.Background(), prefix+":inflight").Val()
+	if durable != 1 {
+		t.Fatalf("durable copies after decode failure = %d, want 1", durable)
+	}
+}

--- a/distributed/controller/controller_redis/reliable_failpoint_live_test.go
+++ b/distributed/controller/controller_redis/reliable_failpoint_live_test.go
@@ -1,0 +1,273 @@
+package controller_redis
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-redis/redis/v8"
+)
+
+type productionLuaBoundary struct {
+	name       string
+	command    string
+	occurrence int
+}
+
+func injectProductionLuaFailure(t *testing.T, source string, boundary productionLuaBoundary) *redis.Script {
+	t.Helper()
+	if boundary.occurrence < 1 {
+		t.Fatalf("boundary %q occurrence = %d", boundary.name, boundary.occurrence)
+	}
+	searchFrom := 0
+	commandStart := -1
+	for occurrence := 0; occurrence < boundary.occurrence; occurrence++ {
+		relative := strings.Index(source[searchFrom:], boundary.command)
+		if relative < 0 {
+			t.Fatalf("production boundary %q occurrence %d not found", boundary.name, boundary.occurrence)
+		}
+		commandStart = searchFrom + relative
+		searchFrom = commandStart + len(boundary.command)
+	}
+	commandEnd := commandStart + len(boundary.command)
+	injected := source[:commandEnd] +
+		"\nif true then return redis.error_reply('injected production boundary: " + boundary.name + "') end" +
+		source[commandEnd:]
+	return redis.NewScript(injected)
+}
+
+func TestLuaFailureBoundariesRetainRecoverableCopyOrAck(t *testing.T) {
+	client := newLiveReliableClient(t)
+	payload := []byte{0, 1, 2, 255, 't', 'a', 's', 'k'}
+
+	t.Run("claim", func(t *testing.T) {
+		boundaries := []productionLuaBoundary{
+			{name: "repair cursor SET", command: "redis.call('SET', KEYS[5], next_cursor, 'PX', outcome_ttl)", occurrence: 1},
+			{name: "destination HSET", command: "redis.call('HSET', KEYS[2], token, envelope)", occurrence: 1},
+			{name: "destination ZADD", command: "redis.call('ZADD', KEYS[3], deadline, token)", occurrence: 2},
+			{name: "source LPOP", command: "redis.call('LPOP', KEYS[1])", occurrence: 1},
+		}
+		for index, boundary := range boundaries {
+			queue := fmt.Sprintf("gkit:103:production:claim:%d:{live}", index)
+			keys := deriveReliableQueueKeys(queue)
+			cleanupReliableQueue(t, client, queue)
+			if err := client.RPush(context.Background(), queue, payload).Err(); err != nil {
+				t.Fatalf("seed %s: %v", boundary.name, err)
+			}
+			script := injectProductionLuaFailure(t, reliableClaimScriptSource, boundary)
+			_, err := script.Run(context.Background(), client,
+				[]string{queue, keys.inflight, keys.visibility, keys.outcomes, keys.repairCursor, keys.repairBacklog},
+				"claim-token", time.Minute.Milliseconds(), ackOutcomeKeyTTL.Milliseconds()).Result()
+			if err == nil {
+				t.Fatalf("boundary %q returned nil error", boundary.name)
+			}
+			assertRecoverablePayload(t, client, keys, payload)
+			cleanupReliableQueue(t, client, queue)
+		}
+	})
+
+	t.Run("oversized repair page", func(t *testing.T) {
+		boundaries := []productionLuaBoundary{
+			{name: "repair backlog ZADD", command: "redis.call('ZADD', KEYS[6], 'NX', unpack(backlog_add))", occurrence: 1},
+			{name: "repair cursor SET", command: "redis.call('SET', KEYS[5], next_cursor, 'PX', outcome_ttl)", occurrence: 1},
+		}
+		for boundaryIndex, boundary := range boundaries {
+			queue := fmt.Sprintf("gkit:103:production:oversized-repair:%d:{live}", boundaryIndex)
+			keys := deriveReliableQueueKeys(queue)
+			cleanupReliableQueue(t, client, queue)
+			const entries = 400
+			deadline := float64(time.Now().Add(time.Hour).UnixMilli())
+			ctx := context.Background()
+			_, err := client.Pipelined(ctx, func(pipe redis.Pipeliner) error {
+				for index := 0; index < entries; index++ {
+					token := fmt.Sprintf("oversized-token-%03d", index)
+					pipe.HSet(ctx, keys.inflight, token, fmt.Sprintf("0000000000:oversized-payload-%03d", index))
+					pipe.ZAdd(ctx, keys.visibility, &redis.Z{Score: deadline, Member: token})
+				}
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("seed %s: %v", boundary.name, err)
+			}
+			page, next, err := client.HScan(ctx, keys.inflight, 0, "*", 128).Result()
+			if err != nil || next != 0 || len(page)/2 != entries {
+				t.Fatalf("inspect oversized page for %s = %d pairs, cursor %d, %v", boundary.name, len(page)/2, next, err)
+			}
+			orphanToken := page[2*128]
+			wantPayload := page[2*128+1][reliableEnvelopeHeaderSize:]
+			if err := client.ZRem(ctx, keys.visibility, orphanToken).Err(); err != nil {
+				t.Fatalf("make overflow orphan for %s: %v", boundary.name, err)
+			}
+			script := injectProductionLuaFailure(t, reliableClaimScriptSource, boundary)
+			_, err = script.Run(ctx, client,
+				[]string{queue, keys.inflight, keys.visibility, keys.outcomes, keys.repairCursor, keys.repairBacklog},
+				"oversized-claim-token", time.Minute.Milliseconds(), ackOutcomeKeyTTL.Milliseconds()).Result()
+			if err == nil {
+				t.Fatalf("boundary %q returned nil error", boundary.name)
+			}
+			q := newReliableQueue(client, queue, time.Minute, newDeliveryTokenGenerator(nil))
+			var recovered *reliableDelivery
+			for attempt := 0; attempt < 16 && recovered == nil; attempt++ {
+				recovered, err = q.claim(ctx)
+				if err != nil {
+					t.Fatalf("recover after %s attempt %d: %v", boundary.name, attempt, err)
+				}
+			}
+			if recovered == nil || string(recovered.payload) != wantPayload {
+				t.Fatalf("recovered after %s = %v, want %q", boundary.name, recovered, wantPayload)
+			}
+			cleanupReliableQueue(t, client, queue)
+		}
+	})
+
+	t.Run("reclaim", func(t *testing.T) {
+		boundaries := []productionLuaBoundary{
+			{name: "repair cursor SET", command: "redis.call('SET', KEYS[5], next_cursor, 'PX', outcome_ttl)", occurrence: 1},
+			{name: "destination HSET", command: "redis.call('HSET', KEYS[2], token, oldenvelope)", occurrence: 1},
+			{name: "destination ZADD", command: "redis.call('ZADD', KEYS[3], deadline, token)", occurrence: 1},
+			{name: "source ZREM", command: "redis.call('ZREM', KEYS[3], oldtoken)", occurrence: 3},
+			{name: "source HDEL", command: "redis.call('HDEL', KEYS[2], oldtoken)", occurrence: 2},
+		}
+		for index, boundary := range boundaries {
+			queue := fmt.Sprintf("gkit:103:production:reclaim:%d:{live}", index)
+			keys := deriveReliableQueueKeys(queue)
+			cleanupReliableQueue(t, client, queue)
+			seedReservedPayloadAt(t, client, keys, "old-token", payload, 0)
+			script := injectProductionLuaFailure(t, reliableClaimScriptSource, boundary)
+			_, err := script.Run(context.Background(), client,
+				[]string{queue, keys.inflight, keys.visibility, keys.outcomes, keys.repairCursor, keys.repairBacklog},
+				"new-token", time.Minute.Milliseconds(), ackOutcomeKeyTTL.Milliseconds()).Result()
+			if err == nil {
+				t.Fatalf("boundary %q returned nil error", boundary.name)
+			}
+			assertRecoverablePayload(t, client, keys, payload)
+			cleanupReliableQueue(t, client, queue)
+		}
+	})
+
+	t.Run("deferred retry", func(t *testing.T) {
+		boundaries := []productionLuaBoundary{
+			{name: "destination HSET", command: "redis.call('HSET', KEYS[1], newtoken, newenvelope)", occurrence: 1},
+			{name: "destination ZADD", command: "redis.call('ZADD', KEYS[2], deadline, newtoken)", occurrence: 1},
+			{name: "source ZREM", command: "redis.call('ZREM', KEYS[2], oldtoken)", occurrence: 1},
+			{name: "source HDEL", command: "redis.call('HDEL', KEYS[1], oldtoken)", occurrence: 1},
+			{name: "backlog ZREM", command: "redis.call('ZREM', KEYS[4], oldtoken)", occurrence: 1},
+		}
+		for index, boundary := range boundaries {
+			queue := fmt.Sprintf("gkit:103:production:retry:%d:{live}", index)
+			keys := deriveReliableQueueKeys(queue)
+			cleanupReliableQueue(t, client, queue)
+			seedReservedPayloadAt(t, client, keys, "old-token", payload, time.Now().Add(time.Minute).UnixMilli())
+			script := injectProductionLuaFailure(t, reliableDeferScriptSource, boundary)
+			_, err := script.Run(context.Background(), client,
+				[]string{keys.inflight, keys.visibility, keys.outcomes, keys.repairBacklog},
+				"old-token", "new-token", time.Second.Milliseconds()).Result()
+			if err == nil {
+				t.Fatalf("boundary %q returned nil error", boundary.name)
+			}
+			assertRecoverablePayload(t, client, keys, payload)
+			cleanupReliableQueue(t, client, queue)
+		}
+	})
+
+	t.Run("release", func(t *testing.T) {
+		boundaries := []productionLuaBoundary{
+			{name: "destination RPUSH", command: "redis.call('RPUSH', KEYS[1], payload)", occurrence: 1},
+			{name: "source ZREM", command: "redis.call('ZREM', KEYS[3], token)", occurrence: 1},
+			{name: "source HDEL", command: "redis.call('HDEL', KEYS[2], token)", occurrence: 1},
+			{name: "backlog ZREM", command: "redis.call('ZREM', KEYS[4], token)", occurrence: 1},
+		}
+		for index, boundary := range boundaries {
+			queue := fmt.Sprintf("gkit:103:production:release:%d:{live}", index)
+			keys := deriveReliableQueueKeys(queue)
+			cleanupReliableQueue(t, client, queue)
+			seedReservedPayloadAt(t, client, keys, "release-token", payload, time.Now().Add(time.Minute).UnixMilli())
+			script := injectProductionLuaFailure(t, reliableReleaseScriptSource, boundary)
+			_, err := script.Run(context.Background(), client,
+				[]string{queue, keys.inflight, keys.visibility, keys.repairBacklog}, "release-token").Result()
+			if err == nil {
+				t.Fatalf("boundary %q returned nil error", boundary.name)
+			}
+			assertRecoverablePayload(t, client, keys, payload)
+			cleanupReliableQueue(t, client, queue)
+		}
+	})
+
+	t.Run("ack", func(t *testing.T) {
+		boundaries := []productionLuaBoundary{
+			{name: "outcome ZADD", command: "redis.call('ZADD', KEYS[3], outcome, token)", occurrence: 1},
+			{name: "outcome PEXPIRE", command: "redis.call('PEXPIRE', KEYS[3], ttl)", occurrence: 2},
+			{name: "visibility ZREM", command: "redis.call('ZREM', KEYS[2], token)", occurrence: 2},
+			{name: "inflight HDEL", command: "redis.call('HDEL', KEYS[1], token)", occurrence: 2},
+			{name: "backlog ZREM", command: "redis.call('ZREM', KEYS[4], token)", occurrence: 2},
+		}
+		for index, boundary := range boundaries {
+			queue := fmt.Sprintf("gkit:103:production:ack:%d:{live}", index)
+			keys := deriveReliableQueueKeys(queue)
+			cleanupReliableQueue(t, client, queue)
+			seedReservedPayloadAt(t, client, keys, "ack-token", payload, time.Now().Add(time.Minute).UnixMilli())
+			script := injectProductionLuaFailure(t, reliableAckScriptSource, boundary)
+			_, err := script.Run(context.Background(), client,
+				[]string{keys.inflight, keys.visibility, keys.outcomes, keys.repairBacklog}, "ack-token",
+				ackOutcomeRetention.Milliseconds(), ackOutcomeKeyTTL.Milliseconds()).Result()
+			if err == nil {
+				t.Fatalf("boundary %q returned nil error", boundary.name)
+			}
+			if score := client.ZScore(context.Background(), keys.outcomes, "ack-token").Val(); score == 0 {
+				t.Fatalf("boundary %q left no ACK outcome", boundary.name)
+			}
+			q := newReliableQueue(client, queue, time.Minute, newDeliveryTokenGenerator(nil))
+			if err := q.acknowledge(context.Background(), &reliableDelivery{token: "ack-token", payload: payload}); err != nil {
+				t.Fatalf("boundary %q same-token confirmation: %v", boundary.name, err)
+			}
+			cleanupReliableQueue(t, client, queue)
+		}
+	})
+}
+
+func seedReservedPayloadAt(
+	t *testing.T,
+	client redis.UniversalClient,
+	keys reliableQueueKeys,
+	token string,
+	payload []byte,
+	deadlineMillis int64,
+) {
+	t.Helper()
+	envelope := append([]byte("0000000000:"), payload...)
+	if err := client.HSet(context.Background(), keys.inflight, token, envelope).Err(); err != nil {
+		t.Fatalf("seed inflight: %v", err)
+	}
+	if err := client.ZAdd(context.Background(), keys.visibility, &redis.Z{
+		Score:  float64(deadlineMillis),
+		Member: token,
+	}).Err(); err != nil {
+		t.Fatalf("seed visibility: %v", err)
+	}
+}
+
+func assertRecoverablePayload(t *testing.T, client redis.UniversalClient, keys reliableQueueKeys, payload []byte) {
+	t.Helper()
+	ready, err := client.LRange(context.Background(), keys.ready, 0, -1).Result()
+	if err != nil && err != redis.Nil {
+		t.Fatalf("read ready: %v", err)
+	}
+	for _, candidate := range ready {
+		if bytes.Equal([]byte(candidate), payload) {
+			return
+		}
+	}
+	inflight, err := client.HVals(context.Background(), keys.inflight).Result()
+	if err != nil && err != redis.Nil {
+		t.Fatalf("read inflight: %v", err)
+	}
+	for _, envelope := range inflight {
+		if len(envelope) >= reliableEnvelopeHeaderSize && bytes.Equal([]byte(envelope[reliableEnvelopeHeaderSize:]), payload) {
+			return
+		}
+	}
+	t.Fatal("transition failure left no recoverable payload")
+}

--- a/distributed/controller/controller_redis/reliable_keys.go
+++ b/distributed/controller/controller_redis/reliable_keys.go
@@ -1,0 +1,110 @@
+package controller_redis
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"strings"
+	"sync"
+)
+
+type reliableQueueKeys struct {
+	ready         string
+	inflight      string
+	visibility    string
+	outcomes      string
+	repairCursor  string
+	repairBacklog string
+	prefix        string
+}
+
+var reliableSlotTags = struct {
+	sync.RWMutex
+	tags map[int]string
+}{tags: make(map[int]string)}
+
+func deriveReliableQueueKeys(queue string) reliableQueueKeys {
+	tag, ok := redisHashTag(queue)
+	if !ok {
+		tag = reliableTagForSlot(redisClusterSlot(queue))
+	}
+	digest := sha256.Sum256([]byte(queue))
+	prefix := fmt.Sprintf("{%s}:gkit:%x", tag, digest)
+	return reliableQueueKeys{
+		ready:         queue,
+		inflight:      prefix + ":inflight",
+		visibility:    prefix + ":visibility",
+		outcomes:      prefix + ":ack-outcomes",
+		repairCursor:  prefix + ":repair-cursor",
+		repairBacklog: prefix + ":repair-backlog",
+		prefix:        prefix,
+	}
+}
+
+func redisHashTag(key string) (string, bool) {
+	open := strings.IndexByte(key, '{')
+	if open < 0 || open+1 >= len(key) {
+		return "", false
+	}
+	closeOffset := strings.IndexByte(key[open+1:], '}')
+	if closeOffset <= 0 {
+		return "", false
+	}
+	return key[open+1 : open+1+closeOffset], true
+}
+
+func redisClusterSlot(key string) int {
+	if tag, ok := redisHashTag(key); ok {
+		key = tag
+	}
+	return int(redisCRC16([]byte(key)) % 16384)
+}
+
+func reliableTagForSlot(slot int) string {
+	if slot < 0 || slot >= 16384 {
+		panic("controller_redis: invalid Redis Cluster slot")
+	}
+	reliableSlotTags.RLock()
+	tag := reliableSlotTags.tags[slot]
+	reliableSlotTags.RUnlock()
+	if tag != "" {
+		return tag
+	}
+
+	tag = findReliableTagForSlot(slot)
+	reliableSlotTags.Lock()
+	defer reliableSlotTags.Unlock()
+	if cached := reliableSlotTags.tags[slot]; cached != "" {
+		return cached
+	}
+	if len(reliableSlotTags.tags) >= 16384 {
+		panic("controller_redis: reliable queue tag cache exhausted")
+	}
+	reliableSlotTags.tags[slot] = tag
+	return tag
+}
+
+func findReliableTagForSlot(slot int) string {
+	for candidate := 0; candidate <= 131071; candidate++ {
+		tag := fmt.Sprintf("gkit-%x", candidate)
+		if int(redisCRC16([]byte(tag))%16384) == slot {
+			return tag
+		}
+	}
+	panic("controller_redis: reliable queue tag search exhausted")
+}
+
+// redisCRC16 implements the CRC-16/XMODEM variant used by Redis Cluster.
+func redisCRC16(data []byte) uint16 {
+	var crc uint16
+	for _, b := range data {
+		crc ^= uint16(b) << 8
+		for bit := 0; bit < 8; bit++ {
+			if crc&0x8000 != 0 {
+				crc = crc<<1 ^ 0x1021
+			} else {
+				crc <<= 1
+			}
+		}
+	}
+	return crc
+}

--- a/distributed/controller/controller_redis/reliable_live_test.go
+++ b/distributed/controller/controller_redis/reliable_live_test.go
@@ -1,0 +1,596 @@
+package controller_redis
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-redis/redis/v8"
+)
+
+func newLiveReliableClient(t *testing.T) redis.UniversalClient {
+	t.Helper()
+	address := os.Getenv("GKIT_REDIS_TEST_ADDR")
+	if address == "" {
+		t.Skip("GKIT_REDIS_TEST_ADDR is not set")
+	}
+	client := redis.NewUniversalClient(&redis.UniversalOptions{Addrs: []string{address}})
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Ping(ctx).Err(); err != nil {
+		_ = client.Close()
+		t.Fatalf("connect to live Redis: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	return client
+}
+
+func cleanupReliableQueue(t *testing.T, client redis.UniversalClient, queue string) {
+	t.Helper()
+	keys := deriveReliableQueueKeys(queue)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Del(ctx, queue, keys.inflight, keys.visibility, keys.outcomes, keys.repairCursor, keys.repairBacklog).Err(); err != nil {
+		t.Errorf("cleanup reliable queue: %v", err)
+	}
+}
+
+func TestReliableLuaRedis7Transitions(t *testing.T) {
+	client := newLiveReliableClient(t)
+	for index, queue := range []string{
+		fmt.Sprintf("gkit:103:live:%d:{tagged}", time.Now().UnixNano()),
+		fmt.Sprintf("gkit:103:live:untagged:%d", time.Now().UnixNano()),
+		fmt.Sprintf("gkit:103:live:{malformed:%d", time.Now().UnixNano()),
+	} {
+		t.Run(fmt.Sprintf("queue-%d", index), func(t *testing.T) {
+			defer cleanupReliableQueue(t, client, queue)
+			q := newReliableQueue(client, queue, 100*time.Millisecond, newDeliveryTokenGenerator(nil))
+			payload := []byte{0, byte(index), 255, '{', '}'}
+			if err := client.RPush(context.Background(), queue, payload).Err(); err != nil {
+				t.Fatalf("enqueue: %v", err)
+			}
+			delivery, err := q.claim(context.Background())
+			if err != nil || delivery == nil {
+				t.Fatalf("claim = (%v, %v)", delivery, err)
+			}
+			if err := q.renew(context.Background(), delivery); err != nil {
+				t.Fatalf("renew: %v", err)
+			}
+			if err := q.acknowledge(context.Background(), delivery); err != nil {
+				t.Fatalf("ack: %v", err)
+			}
+			time.Sleep(110 * time.Millisecond)
+			if err := q.acknowledge(context.Background(), delivery); err != nil {
+				t.Fatalf("same-token ack confirmation: %v", err)
+			}
+		})
+	}
+}
+
+func TestReliableLuaRedis7AckOutcomeUsesRedisTimeAndBoundedCleanup(t *testing.T) {
+	client := newLiveReliableClient(t)
+	queue := fmt.Sprintf("gkit:103:ack-retention:{live-%d}", time.Now().UnixNano())
+	defer cleanupReliableQueue(t, client, queue)
+	q := newReliableQueue(client, queue, time.Minute, newDeliveryTokenGenerator(nil))
+	ctx := context.Background()
+	if err := client.RPush(ctx, queue, "ack-retention-task").Err(); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	delivery, err := q.claim(ctx)
+	if err != nil || delivery == nil {
+		t.Fatalf("claim = (%v, %v), want delivery", delivery, err)
+	}
+
+	redisNow, err := client.Time(ctx).Result()
+	if err != nil {
+		t.Fatalf("Redis TIME before seeding outcomes: %v", err)
+	}
+	expired := make([]*redis.Z, 200)
+	for index := range expired {
+		expired[index] = &redis.Z{
+			Score:  float64(redisNow.Add(-time.Second).UnixMilli()),
+			Member: fmt.Sprintf("expired-outcome-%03d", index),
+		}
+	}
+	if err := client.ZAdd(ctx, q.keys.outcomes, expired...).Err(); err != nil {
+		t.Fatalf("seed expired outcomes: %v", err)
+	}
+
+	before, err := client.Time(ctx).Result()
+	if err != nil {
+		t.Fatalf("Redis TIME before acknowledgement: %v", err)
+	}
+	if err := q.acknowledge(ctx, delivery); err != nil {
+		t.Fatalf("acknowledge: %v", err)
+	}
+	after, err := client.Time(ctx).Result()
+	if err != nil {
+		t.Fatalf("Redis TIME after acknowledgement: %v", err)
+	}
+	score, err := client.ZScore(ctx, q.keys.outcomes, delivery.token).Result()
+	if err != nil {
+		t.Fatalf("read acknowledgement outcome: %v", err)
+	}
+	lower := before.UnixMilli() + (24 * time.Hour).Milliseconds()
+	upper := after.UnixMilli() + (24 * time.Hour).Milliseconds()
+	if outcomeMillis := int64(score); outcomeMillis < lower || outcomeMillis > upper {
+		t.Fatalf("outcome score = %d, want Redis TIME + 24h in [%d, %d]", outcomeMillis, lower, upper)
+	}
+	if remainingExpired := client.ZCount(ctx, q.keys.outcomes, "-inf", fmt.Sprint(after.UnixMilli())).Val(); remainingExpired != 72 {
+		t.Fatalf("expired outcomes after one ACK cleanup = %d, want 72 (exactly 128 of 200 removed)", remainingExpired)
+	}
+	if total := client.ZCard(ctx, q.keys.outcomes).Val(); total != 73 {
+		t.Fatalf("outcome members after bounded cleanup = %d, want 72 expired + 1 confirmed", total)
+	}
+	if ttl := client.PTTL(ctx, q.keys.outcomes).Val(); ttl <= 24*time.Hour || ttl > 25*time.Hour {
+		t.Fatalf("outcome key TTL = %v, want (24h, 25h]", ttl)
+	}
+}
+
+func TestReliableLuaRedis7PrevalidationDoesNotLoseReadyTask(t *testing.T) {
+	client := newLiveReliableClient(t)
+	queue := fmt.Sprintf("gkit:103:prevalidate:{live-%d}", time.Now().UnixNano())
+	defer cleanupReliableQueue(t, client, queue)
+	q := newReliableQueue(client, queue, time.Second, newDeliveryTokenGenerator(nil))
+	payload := []byte("prevalidate-task")
+	if err := client.RPush(context.Background(), queue, payload).Err(); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	if err := client.Set(context.Background(), q.keys.inflight, "wrong-type", 0).Err(); err != nil {
+		t.Fatalf("seed wrong type: %v", err)
+	}
+	if _, err := q.claim(context.Background()); err == nil {
+		t.Fatal("claim error = nil, want key type failure")
+	}
+	if got := client.LIndex(context.Background(), queue, 0).Val(); got != string(payload) {
+		t.Fatalf("ready task after prevalidation failure = %q, want %q", got, payload)
+	}
+	if err := client.Del(context.Background(), q.keys.inflight).Err(); err != nil {
+		t.Fatalf("remove wrong-type inflight key: %v", err)
+	}
+	if err := client.HSet(context.Background(), q.keys.repairCursor, "wrong", "type").Err(); err != nil {
+		t.Fatalf("seed wrong-type repair cursor: %v", err)
+	}
+	if _, err := q.claim(context.Background()); err == nil {
+		t.Fatal("claim error = nil, want repair-cursor type failure")
+	}
+	if got := client.LIndex(context.Background(), queue, 0).Val(); got != string(payload) {
+		t.Fatalf("ready task after cursor prevalidation failure = %q, want %q", got, payload)
+	}
+	if err := client.Del(context.Background(), q.keys.repairCursor).Err(); err != nil {
+		t.Fatalf("remove wrong-type repair cursor: %v", err)
+	}
+	if err := client.HSet(context.Background(), q.keys.repairBacklog, "wrong", "type").Err(); err != nil {
+		t.Fatalf("seed wrong type repair backlog: %v", err)
+	}
+	if _, err := q.claim(context.Background()); err == nil {
+		t.Fatal("claim error = nil, want repair-backlog type failure")
+	}
+	if got := client.LIndex(context.Background(), queue, 0).Val(); got != string(payload) {
+		t.Fatalf("ready task after backlog prevalidation failure = %q, want %q", got, payload)
+	}
+}
+
+func TestReliableLuaRedis7ListpackTerminalPageContinuation(t *testing.T) {
+	client := newLiveReliableClient(t)
+	queue := fmt.Sprintf("gkit:103:listpack:{live-%d}", time.Now().UnixNano())
+	defer cleanupReliableQueue(t, client, queue)
+	q := newReliableQueue(client, queue, time.Minute, newDeliveryTokenGenerator(nil))
+	const entries = 400
+	deadline := float64(time.Now().Add(time.Hour).UnixMilli())
+	ctx := context.Background()
+	_, err := client.Pipelined(ctx, func(pipe redis.Pipeliner) error {
+		for index := 0; index < entries; index++ {
+			token := fmt.Sprintf("listpack-token-%03d", index)
+			payload := fmt.Sprintf("listpack-payload-%03d", index)
+			pipe.HSet(ctx, q.keys.inflight, token, "0000000000:"+payload)
+			pipe.ZAdd(ctx, q.keys.visibility, &redis.Z{Score: deadline, Member: token})
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("seed listpack inflight hash: %v", err)
+	}
+	if encoding := client.Do(ctx, "OBJECT", "ENCODING", q.keys.inflight).Val(); encoding != "listpack" {
+		t.Fatalf("inflight encoding = %v, want listpack", encoding)
+	}
+	page, next, err := client.HScan(ctx, q.keys.inflight, 0, "*", 128).Result()
+	if err != nil {
+		t.Fatalf("inspect listpack HSCAN page: %v", err)
+	}
+	if next != 0 || len(page)/2 != entries {
+		t.Fatalf("listpack HSCAN = %d pairs, cursor %d; want %d pairs, cursor 0", len(page)/2, next, entries)
+	}
+	orphanToken := page[2*128]
+	wantEnvelope := page[2*128+1]
+	wantPayload := wantEnvelope[reliableEnvelopeHeaderSize:]
+	if err := client.ZRem(ctx, q.keys.visibility, orphanToken).Err(); err != nil {
+		t.Fatalf("make 129th listpack token orphan: %v", err)
+	}
+
+	if delivery, err := q.claim(ctx); err != nil || delivery != nil {
+		t.Fatalf("first listpack claim = (%v, %v), want durable continuation only", delivery, err)
+	}
+	if score, err := client.ZScore(ctx, q.keys.repairBacklog, orphanToken).Result(); err != nil || score != 0 {
+		t.Fatalf("129th orphan backlog score = %v, %v; want persisted score 0", score, err)
+	}
+	if cursor := client.Get(ctx, q.keys.repairCursor).Val(); cursor != "0" {
+		t.Fatalf("terminal listpack cursor = %q, want 0", cursor)
+	}
+	if ttl := client.PTTL(ctx, q.keys.repairBacklog).Val(); ttl <= 0 || ttl > ackOutcomeKeyTTL {
+		t.Fatalf("repair backlog TTL = %v, want (0, %v]", ttl, ackOutcomeKeyTTL)
+	}
+
+	var recovered *reliableDelivery
+	for attempt := 0; attempt < 16 && recovered == nil; attempt++ {
+		recovered, err = q.claim(ctx)
+		if err != nil {
+			t.Fatalf("drain listpack continuation %d: %v", attempt, err)
+		}
+	}
+	if recovered == nil || string(recovered.payload) != wantPayload {
+		t.Fatalf("recovered listpack delivery = %v, want payload %q", recovered, wantPayload)
+	}
+}
+
+func TestReliableLuaRedis7RepairCallIsBounded(t *testing.T) {
+	client := newLiveReliableClient(t)
+	queue := fmt.Sprintf("gkit:103:bounded-repair:{live-%d}", time.Now().UnixNano())
+	defer cleanupReliableQueue(t, client, queue)
+	keys := deriveReliableQueueKeys(queue)
+	const entries = 400
+	ctx := context.Background()
+	_, err := client.Pipelined(ctx, func(pipe redis.Pipeliner) error {
+		for index := 0; index < entries; index++ {
+			token := fmt.Sprintf("bounded-token-%03d", index)
+			pipe.HSet(ctx, keys.inflight, token, fmt.Sprintf("0000000000:bounded-payload-%03d", index))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("seed bounded repair hash: %v", err)
+	}
+	result, err := reliableClaimScript.Run(ctx, client,
+		[]string{queue, keys.inflight, keys.visibility, keys.outcomes, keys.repairCursor, keys.repairBacklog},
+		"bounded-claim-token", time.Minute.Milliseconds(), ackOutcomeKeyTTL.Milliseconds()).Result()
+	if err != nil {
+		t.Fatalf("run one bounded repair call: %v", err)
+	}
+	values, err := reliableScriptValues(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code, err := reliableScriptInt(values[0]); err != nil || code != 3 {
+		t.Fatalf("repair result = %v, %v; want code 3", values, err)
+	}
+	if ready := client.LLen(ctx, queue).Val(); ready != maxClaimReconciliations {
+		t.Fatalf("repaired entries in one script = %d, want %d", ready, maxClaimReconciliations)
+	}
+	if remaining := client.HLen(ctx, keys.inflight).Val(); remaining != entries-maxClaimReconciliations {
+		t.Fatalf("remaining inflight = %d, want %d", remaining, entries-maxClaimReconciliations)
+	}
+	if backlog := client.ZCard(ctx, keys.repairBacklog).Val(); backlog != entries-maxClaimReconciliations {
+		t.Fatalf("durable continuation size = %d, want %d", backlog, entries-maxClaimReconciliations)
+	}
+}
+
+func TestReliableLuaRedis7StaleBacklogAfterFinalization(t *testing.T) {
+	client := newLiveReliableClient(t)
+	ctx := context.Background()
+
+	t.Run("release", func(t *testing.T) {
+		q, delivery := seedListpackBacklogDelivery(t, client, "release")
+		defer cleanupReliableQueue(t, client, q.keys.ready)
+		if err := q.release(ctx, delivery); err != nil {
+			t.Fatalf("production release: %v", err)
+		}
+		assertBacklogTokenRemoved(t, client, q, delivery.token)
+		seedStaleBacklogHint(t, client, q, delivery.token, false)
+		recovered, err := q.claim(ctx)
+		if err != nil || recovered == nil || string(recovered.payload) != string(delivery.payload) {
+			t.Fatalf("claim released payload = (%v, %v), want %q", recovered, err, delivery.payload)
+		}
+		assertBacklogTokenRemoved(t, client, q, delivery.token)
+	})
+
+	t.Run("defer", func(t *testing.T) {
+		q, delivery := seedListpackBacklogDelivery(t, client, "defer")
+		defer cleanupReliableQueue(t, client, q.keys.ready)
+		delivery.failures = 10
+		next, err := q.deferRetry(ctx, delivery)
+		if err != nil {
+			t.Fatalf("production defer: %v", err)
+		}
+		assertBacklogTokenRemoved(t, client, q, delivery.token)
+		if envelope := client.HGet(ctx, q.keys.inflight, next.token).Val(); envelope == "" {
+			t.Fatal("deferred reservation missing new-token envelope")
+		}
+		seedStaleBacklogHint(t, client, q, delivery.token, true)
+		if _, err := q.claim(ctx); err != nil {
+			t.Fatalf("claim after defer stale hint: %v", err)
+		}
+		assertBacklogTokenRemoved(t, client, q, delivery.token)
+		if envelope := client.HGet(ctx, q.keys.inflight, next.token).Val(); envelope == "" {
+			t.Fatal("stale old-token cleanup removed deferred new token")
+		}
+	})
+
+	t.Run("ack", func(t *testing.T) {
+		q, delivery := seedListpackBacklogDelivery(t, client, "ack")
+		defer cleanupReliableQueue(t, client, q.keys.ready)
+		if err := q.acknowledge(ctx, delivery); err != nil {
+			t.Fatalf("production ack: %v", err)
+		}
+		assertBacklogTokenRemoved(t, client, q, delivery.token)
+		if score := client.ZScore(ctx, q.keys.outcomes, delivery.token).Val(); score == 0 {
+			t.Fatal("ack outcome missing")
+		}
+		seedStaleBacklogHint(t, client, q, delivery.token, true)
+		recovered, err := q.claim(ctx)
+		if err != nil || recovered != nil {
+			t.Fatalf("claim after acknowledged stale hint = (%v, %v), want nil", recovered, err)
+		}
+		assertBacklogTokenRemoved(t, client, q, delivery.token)
+		if ready := client.LLen(ctx, q.keys.ready).Val(); ready != 0 {
+			t.Fatalf("acknowledged payload was requeued: ready length %d", ready)
+		}
+	})
+}
+
+func TestReliableLuaRedis7FinalizationBacklogPrevalidation(t *testing.T) {
+	client := newLiveReliableClient(t)
+	ctx := context.Background()
+	for _, name := range []string{"release", "defer", "ack"} {
+		t.Run(name, func(t *testing.T) {
+			queue := fmt.Sprintf("gkit:103:finalize-type:%s:{live-%d}", name, time.Now().UnixNano())
+			defer cleanupReliableQueue(t, client, queue)
+			q := newReliableQueue(client, queue, time.Minute, newDeliveryTokenGenerator(nil))
+			delivery := &reliableDelivery{token: "finalize-token", payload: []byte("finalize-payload"), failures: 10}
+			seedReservedPayloadAt(t, client, q.keys, delivery.token, delivery.payload, time.Now().Add(time.Minute).UnixMilli())
+			if err := client.HSet(ctx, q.keys.repairBacklog, "wrong", "type").Err(); err != nil {
+				t.Fatalf("seed wrong-type backlog: %v", err)
+			}
+			var err error
+			switch name {
+			case "release":
+				err = q.release(ctx, delivery)
+			case "defer":
+				_, err = q.deferRetry(ctx, delivery)
+			case "ack":
+				err = q.acknowledge(ctx, delivery)
+			}
+			if err == nil {
+				t.Fatal("wrong-type repair backlog returned nil error")
+			}
+			if envelope := client.HGet(ctx, q.keys.inflight, delivery.token).Val(); envelope == "" {
+				t.Fatal("prevalidation failure removed inflight payload")
+			}
+			if score := client.ZScore(ctx, q.keys.visibility, delivery.token).Val(); score == 0 {
+				t.Fatal("prevalidation failure removed visibility")
+			}
+		})
+	}
+}
+
+func seedListpackBacklogDelivery(t *testing.T, client redis.UniversalClient, suffix string) (*reliableQueue, *reliableDelivery) {
+	t.Helper()
+	queue := fmt.Sprintf("gkit:103:stale-%s:{live-%d}", suffix, time.Now().UnixNano())
+	q := newReliableQueue(client, queue, time.Minute, newDeliveryTokenGenerator(nil))
+	const entries = 400
+	deadline := float64(time.Now().Add(time.Hour).UnixMilli())
+	ctx := context.Background()
+	_, err := client.Pipelined(ctx, func(pipe redis.Pipeliner) error {
+		for index := 0; index < entries; index++ {
+			token := fmt.Sprintf("stale-token-%03d", index)
+			pipe.HSet(ctx, q.keys.inflight, token, fmt.Sprintf("0000000000:stale-payload-%03d", index))
+			pipe.ZAdd(ctx, q.keys.visibility, &redis.Z{Score: deadline, Member: token})
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("seed stale-token listpack: %v", err)
+	}
+	if encoding := client.Do(ctx, "OBJECT", "ENCODING", q.keys.inflight).Val(); encoding != "listpack" {
+		t.Fatalf("stale-token inflight encoding = %v, want listpack", encoding)
+	}
+	page, next, err := client.HScan(ctx, q.keys.inflight, 0, "*", 128).Result()
+	if err != nil || next != 0 || len(page)/2 != entries {
+		t.Fatalf("inspect stale-token listpack = %d pairs, cursor %d, %v", len(page)/2, next, err)
+	}
+	token := page[2*128]
+	failures, payload, err := decodeReliableEnvelope([]byte(page[2*128+1]))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if delivery, err := q.claim(ctx); err != nil || delivery != nil {
+		t.Fatalf("generate repair backlog = (%v, %v)", delivery, err)
+	}
+	if _, err := client.ZScore(ctx, q.keys.repairBacklog, token).Result(); err != nil {
+		t.Fatalf("overflow token missing from backlog: %v", err)
+	}
+	return q, &reliableDelivery{token: token, payload: payload, failures: failures}
+}
+
+func seedStaleBacklogHint(t *testing.T, client redis.UniversalClient, q *reliableQueue, token string, residualVisibility bool) {
+	t.Helper()
+	ctx := context.Background()
+	if err := client.ZAdd(ctx, q.keys.repairBacklog, &redis.Z{Score: 0, Member: token}).Err(); err != nil {
+		t.Fatalf("restore stale backlog hint: %v", err)
+	}
+	if residualVisibility {
+		if err := client.ZAdd(ctx, q.keys.visibility, &redis.Z{Score: float64(time.Now().Add(time.Hour).UnixMilli()), Member: token}).Err(); err != nil {
+			t.Fatalf("restore stale visibility hint: %v", err)
+		}
+	}
+}
+
+func assertBacklogTokenRemoved(t *testing.T, client redis.UniversalClient, q *reliableQueue, token string) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := client.ZScore(ctx, q.keys.repairBacklog, token).Result(); !errors.Is(err, redis.Nil) {
+		t.Fatalf("backlog token %q still present: %v", token, err)
+	}
+	if _, err := client.ZScore(ctx, q.keys.visibility, token).Result(); !errors.Is(err, redis.Nil) {
+		t.Fatalf("stale visibility token %q still present: %v", token, err)
+	}
+}
+
+func TestReliableLuaRedis7PersistentOrphanTraversal(t *testing.T) {
+	client := newLiveReliableClient(t)
+	queue := fmt.Sprintf("gkit:103:cursor:{live-%d}", time.Now().UnixNano())
+	defer cleanupReliableQueue(t, client, queue)
+	q := newReliableQueue(client, queue, time.Minute, newDeliveryTokenGenerator(nil))
+	const entries = 2300
+	deadline := float64(time.Now().Add(time.Hour).UnixMilli())
+	ctx := context.Background()
+	_, err := client.Pipelined(ctx, func(pipe redis.Pipeliner) error {
+		for index := 0; index < entries; index++ {
+			token := fmt.Sprintf("cursor-token-%04d", index)
+			payload := fmt.Sprintf("cursor-payload-%04d", index)
+			pipe.HSet(ctx, q.keys.inflight, token, "0000000000:"+payload)
+			pipe.ZAdd(ctx, q.keys.visibility, &redis.Z{Score: deadline, Member: token})
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("seed stable inflight hash: %v", err)
+	}
+	firstPage, firstNext, err := client.HScan(ctx, q.keys.inflight, 0, "*", 128).Result()
+	if err != nil {
+		t.Fatalf("inspect first HSCAN page: %v", err)
+	}
+	if firstNext == 0 {
+		t.Fatal("2300-entry hash unexpectedly fit in first HSCAN page")
+	}
+	firstTokens := make(map[string]struct{}, len(firstPage)/2)
+	for index := 0; index < len(firstPage); index += 2 {
+		firstTokens[firstPage[index]] = struct{}{}
+	}
+	var orphanToken string
+	for index := entries - 1; index >= 0; index-- {
+		candidate := fmt.Sprintf("cursor-token-%04d", index)
+		if _, present := firstTokens[candidate]; !present {
+			orphanToken = candidate
+			break
+		}
+	}
+	if orphanToken == "" {
+		t.Fatal("could not choose orphan outside first HSCAN page")
+	}
+	wantPayload := "cursor-payload-" + orphanToken[len("cursor-token-"):]
+	if err := client.ZRem(ctx, q.keys.visibility, orphanToken).Err(); err != nil {
+		t.Fatalf("make later-page orphan: %v", err)
+	}
+
+	if delivery, err := q.claim(ctx); err != nil || delivery != nil {
+		t.Fatalf("first-page claim = (%v, %v), want no recovered orphan", delivery, err)
+	}
+	if cursor := client.Get(ctx, q.keys.repairCursor).Val(); cursor == "" || cursor == "0" {
+		t.Fatalf("persisted repair cursor after first page = %q, want nonzero", cursor)
+	}
+	if ttl := client.PTTL(ctx, q.keys.repairCursor).Val(); ttl <= 0 || ttl > ackOutcomeKeyTTL {
+		t.Fatalf("repair cursor TTL = %v, want (0, %v]", ttl, ackOutcomeKeyTTL)
+	}
+
+	var recovered *reliableDelivery
+	for attempt := 0; attempt < 256 && recovered == nil; attempt++ {
+		recovered, err = q.claim(ctx)
+		if err != nil {
+			t.Fatalf("claim traversal attempt %d: %v", attempt, err)
+		}
+	}
+	if recovered == nil || string(recovered.payload) != wantPayload {
+		t.Fatalf("recovered delivery = %v, want payload %q", recovered, wantPayload)
+	}
+
+	for attempt := 0; attempt < 256 && (client.Get(ctx, q.keys.repairCursor).Val() != "0" || client.ZCard(ctx, q.keys.repairBacklog).Val() != 0); attempt++ {
+		if _, err := q.claim(ctx); err != nil {
+			t.Fatalf("finish stable cursor cycle %d: %v", attempt, err)
+		}
+	}
+	if cursor := client.Get(ctx, q.keys.repairCursor).Val(); cursor != "0" {
+		t.Fatalf("repair cursor did not complete stable cycle: %q", cursor)
+	}
+	if backlog := client.ZCard(ctx, q.keys.repairBacklog).Val(); backlog != 0 {
+		t.Fatalf("repair backlog did not drain: %d", backlog)
+	}
+}
+
+func TestReliableLuaRedis7CommittedAckLostResponse(t *testing.T) {
+	client := newLiveReliableClient(t)
+	queue := fmt.Sprintf("gkit:103:lost-ack:{live-%d}", time.Now().UnixNano())
+	defer cleanupReliableQueue(t, client, queue)
+	q := newReliableQueue(client, queue, time.Second, newDeliveryTokenGenerator(nil))
+	hook := &loseScriptResponseHook{hash: reliableAckScript.Hash(), err: errors.New("lost live ACK response")}
+	client.AddHook(hook)
+	if err := reliableAckScript.Load(context.Background(), client).Err(); err != nil {
+		t.Fatalf("preload ACK script: %v", err)
+	}
+	if err := client.RPush(context.Background(), queue, "lost-response-task").Err(); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	delivery, err := q.claim(context.Background())
+	if err != nil || delivery == nil {
+		t.Fatalf("claim = (%v, %v)", delivery, err)
+	}
+	hook.armed.Store(true)
+	c := &ControllerRedis{finalizationTimeout: 100 * time.Millisecond, ackConfirmationWindow: time.Second}
+	if err := c.acknowledgeReliableDelivery(q, delivery); err != nil {
+		t.Fatalf("confirm lost ACK response: %v", err)
+	}
+	if client.ZScore(context.Background(), q.keys.outcomes, delivery.token).Val() == 0 {
+		t.Fatal("ACK outcome missing after lost response")
+	}
+}
+
+func TestReliableRedisClusterQueueCompatibility(t *testing.T) {
+	address := os.Getenv("GKIT_REDIS_CLUSTER_TEST_ADDR")
+	if address == "" {
+		t.Skip("GKIT_REDIS_CLUSTER_TEST_ADDR is not set")
+	}
+	addresses := strings.Split(address, ",")
+	if len(addresses) != 3 {
+		t.Fatalf("GKIT_REDIS_CLUSTER_TEST_ADDR must list three master addresses, got %d", len(addresses))
+	}
+	client := redis.NewClusterClient(&redis.ClusterOptions{
+		Addrs: addresses,
+		ClusterSlots: func(context.Context) ([]redis.ClusterSlot, error) {
+			return []redis.ClusterSlot{
+				{Start: 0, End: 5460, Nodes: []redis.ClusterNode{{Addr: addresses[0]}}},
+				{Start: 5461, End: 10922, Nodes: []redis.ClusterNode{{Addr: addresses[1]}}},
+				{Start: 10923, End: 16383, Nodes: []redis.ClusterNode{{Addr: addresses[2]}}},
+			}, nil
+		},
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Ping(ctx).Err(); err != nil {
+		_ = client.Close()
+		t.Fatalf("connect to Redis Cluster: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	for index, queue := range []string{
+		fmt.Sprintf("gkit:103:cluster:%d:{tagged}", time.Now().UnixNano()),
+		fmt.Sprintf("gkit:103:cluster:untagged:%d", time.Now().UnixNano()),
+		fmt.Sprintf("gkit:103:cluster:{malformed:%d", time.Now().UnixNano()),
+	} {
+		t.Run(fmt.Sprintf("queue-%d", index), func(t *testing.T) {
+			defer cleanupReliableQueue(t, client, queue)
+			q := newReliableQueue(client, queue, time.Second, newDeliveryTokenGenerator(nil))
+			if err := client.RPush(context.Background(), queue, "cluster-task").Err(); err != nil {
+				t.Fatalf("enqueue: %v", err)
+			}
+			delivery, err := q.claim(context.Background())
+			if err != nil || delivery == nil {
+				t.Fatalf("cluster claim = (%v, %v)", delivery, err)
+			}
+			if err := q.acknowledge(context.Background(), delivery); err != nil {
+				t.Fatalf("cluster ack: %v", err)
+			}
+		})
+	}
+}

--- a/distributed/controller/controller_redis/reliable_queue.go
+++ b/distributed/controller/controller_redis/reliable_queue.go
@@ -1,0 +1,717 @@
+package controller_redis
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/go-redis/redis/v8"
+)
+
+var (
+	ErrDeliveryLeaseLost        = errors.New("redis delivery lease lost")
+	ErrDeliveryTokenUnavailable = errors.New("redis delivery token unavailable")
+	ErrDeliveryTokenCollision   = errors.New("redis delivery token collision limit reached")
+)
+
+const (
+	defaultDeliveryLease       = 30 * time.Second
+	ackOutcomeRetention        = 24 * time.Hour
+	ackOutcomeKeyTTL           = 25 * time.Hour
+	maxDeliveryTokenAttempts   = 4
+	maxClaimReconciliations    = 128
+	reliableEnvelopeHeaderSize = 11
+)
+
+type deliveryTokenGenerator struct {
+	mu     sync.Mutex
+	reader io.Reader
+}
+
+func newDeliveryTokenGenerator(reader io.Reader) *deliveryTokenGenerator {
+	if reader == nil {
+		reader = rand.Reader
+	}
+	return &deliveryTokenGenerator{reader: reader}
+}
+
+func (g *deliveryTokenGenerator) next() (string, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	var token [16]byte
+	if _, err := io.ReadFull(g.reader, token[:]); err != nil {
+		return "", fmt.Errorf("%w: %w", ErrDeliveryTokenUnavailable, err)
+	}
+	return hex.EncodeToString(token[:]), nil
+}
+
+type reliableDelivery struct {
+	token          string
+	payload        []byte
+	failures       uint64
+	serverTime     time.Time
+	deadline       time.Time
+	confirmedUntil time.Time
+}
+
+func (d *reliableDelivery) updateConfirmation(requestStarted time.Time, serverMillis, deadlineMillis int64) {
+	d.serverTime = time.UnixMilli(serverMillis)
+	d.deadline = time.UnixMilli(deadlineMillis)
+	remaining := time.Duration(deadlineMillis-serverMillis) * time.Millisecond
+	if remaining < 0 {
+		remaining = 0
+	}
+	d.confirmedUntil = requestStarted.Add(remaining)
+}
+
+type reliableQueue struct {
+	client      redis.UniversalClient
+	keys        reliableQueueKeys
+	lease       time.Duration
+	tokenSource *deliveryTokenGenerator
+}
+
+func newReliableQueue(client redis.UniversalClient, queue string, lease time.Duration, tokenSource *deliveryTokenGenerator) *reliableQueue {
+	if lease <= 0 {
+		lease = defaultDeliveryLease
+	}
+	if tokenSource == nil {
+		tokenSource = newDeliveryTokenGenerator(nil)
+	}
+	return &reliableQueue{
+		client:      client,
+		keys:        deriveReliableQueueKeys(queue),
+		lease:       lease,
+		tokenSource: tokenSource,
+	}
+}
+
+const reliableClaimScriptSource = `
+local function typename(key)
+  local value = redis.call('TYPE', key)
+  if type(value) == 'table' then return value['ok'] end
+  return value
+end
+local function requiretype(key, expected)
+  local actual = typename(key)
+  return actual == 'none' or actual == expected
+end
+local function nowms()
+  local now = redis.call('TIME')
+  return tonumber(now[1]) * 1000 + math.floor(tonumber(now[2]) / 1000)
+end
+if not requiretype(KEYS[1], 'list') or not requiretype(KEYS[2], 'hash') or
+   not requiretype(KEYS[3], 'zset') or not requiretype(KEYS[4], 'zset') or
+   not requiretype(KEYS[5], 'string') or not requiretype(KEYS[6], 'zset') then
+  return redis.error_reply('reliable claim: invalid key type')
+end
+local token = ARGV[1]
+local lease = tonumber(ARGV[2])
+local outcome_ttl = tonumber(ARGV[3])
+if not token or token == '' or not lease or lease <= 0 or not outcome_ttl or outcome_ttl <= 0 then
+  return redis.error_reply('reliable claim: invalid argument')
+end
+if redis.call('HEXISTS', KEYS[2], token) == 1 or redis.call('ZSCORE', KEYS[3], token) or
+   redis.call('ZSCORE', KEYS[4], token) or redis.call('ZSCORE', KEYS[6], token) then
+  return {2}
+end
+local now = nowms()
+local repair_cursor = redis.call('GET', KEYS[5]) or '0'
+if not string.match(repair_cursor, '^%d+$') then
+  return redis.error_reply('reliable claim: invalid repair cursor')
+end
+local expired = redis.call('ZRANGEBYSCORE', KEYS[4], '-inf', now, 'LIMIT', 0, 128)
+local outcome_count = redis.call('ZCARD', KEYS[4])
+local outcome_ttl_missing = outcome_count > 0 and redis.call('PTTL', KEYS[4]) < 0
+local newest = redis.call('ZREVRANGE', KEYS[4], 0, 0, 'WITHSCORES')
+local backlog_tokens = redis.call('ZRANGE', KEYS[6], 0, 127)
+local draining_backlog = #backlog_tokens > 0
+local next_cursor = repair_cursor
+local overflow_tokens = {}
+local repair = {}
+if draining_backlog then
+  for index = 1, #backlog_tokens do
+    local repair_token = backlog_tokens[index]
+    repair[#repair + 1] = {
+      token = repair_token,
+      envelope = redis.call('HGET', KEYS[2], repair_token),
+      outcome = redis.call('ZSCORE', KEYS[4], repair_token),
+      visibility = redis.call('ZSCORE', KEYS[3], repair_token)
+    }
+  end
+else
+  local scan = redis.call('HSCAN', KEYS[2], repair_cursor, 'COUNT', 128)
+  local entries = scan[2]
+  next_cursor = scan[1]
+  if #entries % 2 ~= 0 then
+    return redis.error_reply('reliable claim: invalid repair scan page')
+  end
+  local entry_limit = math.min(#entries, 256)
+  for index = 1, entry_limit, 2 do
+    local repair_token = entries[index]
+    repair[#repair + 1] = {
+      token = repair_token,
+      envelope = redis.call('HGET', KEYS[2], repair_token),
+      outcome = redis.call('ZSCORE', KEYS[4], repair_token),
+      visibility = redis.call('ZSCORE', KEYS[3], repair_token)
+    }
+  end
+  for index = entry_limit + 1, #entries, 2 do
+    overflow_tokens[#overflow_tokens + 1] = entries[index]
+  end
+end
+for index = 1, #repair do
+  local envelope = repair[index].envelope
+  if envelope and (string.len(envelope) < 11 or string.sub(envelope, 11, 11) ~= ':' or
+     not tonumber(string.sub(envelope, 1, 10))) then
+    return redis.error_reply('reliable claim: invalid orphan envelope')
+  end
+end
+local entry_count = #repair
+local visible = {}
+local visibility_budget = 128 - entry_count
+if visibility_budget > 0 then
+  visible = redis.call('ZRANGE', KEYS[3], 0, visibility_budget - 1)
+end
+local due = redis.call('ZRANGEBYSCORE', KEYS[3], '-inf', now, 'LIMIT', 0, 1)
+local oldtoken = nil
+local oldoutcome = nil
+local oldenvelope = nil
+if #due == 1 then
+  oldtoken = due[1]
+  oldoutcome = redis.call('ZSCORE', KEYS[4], oldtoken)
+  oldenvelope = redis.call('HGET', KEYS[2], oldtoken)
+  if oldenvelope and (string.len(oldenvelope) < 11 or string.sub(oldenvelope, 11, 11) ~= ':' or
+     not tonumber(string.sub(oldenvelope, 1, 10))) then
+    return redis.error_reply('reliable claim: invalid envelope')
+  end
+end
+local payload = redis.call('LINDEX', KEYS[1], 0)
+
+-- Every validation above precedes the first write. Housekeeping is bounded
+-- and returns for a fresh claim if it changed recoverable state.
+local reconciled = false
+if #expired > 0 then
+  redis.call('ZREM', KEYS[4], unpack(expired))
+  reconciled = true
+end
+if outcome_ttl_missing then
+  local repaired_ttl = outcome_ttl
+  if #newest == 2 then repaired_ttl = math.max(1, tonumber(newest[2]) - now + 3600000) end
+  redis.call('PEXPIRE', KEYS[4], repaired_ttl)
+end
+if not draining_backlog then
+  if #overflow_tokens > 0 then
+    local backlog_add = {}
+    for index = 1, #overflow_tokens do
+      backlog_add[#backlog_add + 1] = 0
+      backlog_add[#backlog_add + 1] = overflow_tokens[index]
+    end
+    redis.call('ZADD', KEYS[6], 'NX', unpack(backlog_add))
+  end
+else
+  redis.call('PEXPIRE', KEYS[5], outcome_ttl)
+end
+for index = 1, #repair do
+  local orphan_token = repair[index].token
+  local envelope = repair[index].envelope
+  local outcome = repair[index].outcome
+  local visibility = repair[index].visibility
+  if not envelope then
+    if visibility then
+      redis.call('ZREM', KEYS[3], orphan_token)
+      reconciled = true
+    end
+  elseif outcome and tonumber(outcome) > now then
+    redis.call('ZREM', KEYS[3], orphan_token)
+    redis.call('HDEL', KEYS[2], orphan_token)
+    reconciled = true
+  elseif not visibility then
+    redis.call('RPUSH', KEYS[1], string.sub(envelope, 12))
+    redis.call('HDEL', KEYS[2], orphan_token)
+    reconciled = true
+  end
+end
+if draining_backlog then redis.call('ZREM', KEYS[6], unpack(backlog_tokens)) end
+for index = 1, #visible do
+  local visible_token = visible[index]
+  if redis.call('HEXISTS', KEYS[2], visible_token) == 0 then
+    redis.call('ZREM', KEYS[3], visible_token)
+    reconciled = true
+  end
+end
+if not draining_backlog then redis.call('SET', KEYS[5], next_cursor, 'PX', outcome_ttl) end
+if redis.call('ZCARD', KEYS[6]) > 0 then redis.call('PEXPIRE', KEYS[6], outcome_ttl) end
+if reconciled then return {3} end
+
+if oldtoken then
+  if oldoutcome and tonumber(oldoutcome) > now then
+    redis.call('ZREM', KEYS[3], oldtoken)
+    redis.call('HDEL', KEYS[2], oldtoken)
+    return {3}
+  end
+  if not oldenvelope then
+    redis.call('ZREM', KEYS[3], oldtoken)
+    return {3}
+  end
+  local deadline = now + lease
+  redis.call('HSET', KEYS[2], token, oldenvelope)
+  redis.call('ZADD', KEYS[3], deadline, token)
+  redis.call('ZREM', KEYS[3], oldtoken)
+  redis.call('HDEL', KEYS[2], oldtoken)
+  return {1, token, oldenvelope, tostring(now), tostring(deadline)}
+end
+if not payload then return {0, tostring(now)} end
+local envelope = '0000000000:' .. payload
+local deadline = now + lease
+redis.call('HSET', KEYS[2], token, envelope)
+redis.call('ZADD', KEYS[3], deadline, token)
+local removed = redis.call('LPOP', KEYS[1])
+if not removed or removed ~= payload then
+  return redis.error_reply('reliable claim: ready payload changed')
+end
+return {1, token, envelope, tostring(now), tostring(deadline)}
+`
+
+var reliableClaimScript = redis.NewScript(reliableClaimScriptSource)
+
+const reliableRenewScriptSource = `
+local function typename(key)
+  local value = redis.call('TYPE', key)
+  if type(value) == 'table' then return value['ok'] end
+  return value
+end
+local function nowms()
+  local now = redis.call('TIME')
+  return tonumber(now[1]) * 1000 + math.floor(tonumber(now[2]) / 1000)
+end
+local ht = typename(KEYS[1])
+local zt = typename(KEYS[2])
+if (ht ~= 'none' and ht ~= 'hash') or (zt ~= 'none' and zt ~= 'zset') then
+  return redis.error_reply('reliable renew: invalid key type')
+end
+local token = ARGV[1]
+local lease = tonumber(ARGV[2])
+if not token or token == '' or not lease or lease <= 0 then
+  return redis.error_reply('reliable renew: invalid argument')
+end
+local now = nowms()
+local envelope = redis.call('HGET', KEYS[1], token)
+local score = redis.call('ZSCORE', KEYS[2], token)
+if not envelope or not score or tonumber(score) <= now then return {0, tostring(now)} end
+local deadline = now + lease
+redis.call('ZADD', KEYS[2], deadline, token)
+return {1, tostring(now), tostring(deadline)}
+`
+
+var reliableRenewScript = redis.NewScript(reliableRenewScriptSource)
+
+const reliableAckScriptSource = `
+local function typename(key)
+  local value = redis.call('TYPE', key)
+  if type(value) == 'table' then return value['ok'] end
+  return value
+end
+local function nowms()
+  local now = redis.call('TIME')
+  return tonumber(now[1]) * 1000 + math.floor(tonumber(now[2]) / 1000)
+end
+local ht = typename(KEYS[1])
+local vt = typename(KEYS[2])
+local ot = typename(KEYS[3])
+local bt = typename(KEYS[4])
+if (ht ~= 'none' and ht ~= 'hash') or (vt ~= 'none' and vt ~= 'zset') or
+   (ot ~= 'none' and ot ~= 'zset') or (bt ~= 'none' and bt ~= 'zset') then
+  return redis.error_reply('reliable ack: invalid key type')
+end
+local token = ARGV[1]
+local retention = tonumber(ARGV[2])
+local ttl = tonumber(ARGV[3])
+if not token or token == '' or not retention or retention <= 0 or not ttl or ttl <= retention then
+  return redis.error_reply('reliable ack: invalid argument')
+end
+local now = nowms()
+local prior = redis.call('ZSCORE', KEYS[3], token)
+local expired = redis.call('ZRANGEBYSCORE', KEYS[3], '-inf', now, 'LIMIT', 0, 128)
+local envelope = redis.call('HGET', KEYS[1], token)
+local score = redis.call('ZSCORE', KEYS[2], token)
+if prior and tonumber(prior) > now then
+  redis.call('ZREM', KEYS[2], token)
+  redis.call('HDEL', KEYS[1], token)
+  redis.call('PEXPIRE', KEYS[3], ttl)
+  redis.call('ZREM', KEYS[4], token)
+  return {1, 1, tostring(now), tostring(prior)}
+end
+if not envelope or not score or tonumber(score) <= now then return {0, 0, tostring(now)} end
+if #expired > 0 then redis.call('ZREM', KEYS[3], unpack(expired)) end
+local outcome = now + retention
+redis.call('ZADD', KEYS[3], outcome, token)
+redis.call('PEXPIRE', KEYS[3], ttl)
+redis.call('ZREM', KEYS[2], token)
+redis.call('HDEL', KEYS[1], token)
+redis.call('ZREM', KEYS[4], token)
+return {1, 0, tostring(now), tostring(outcome)}
+`
+
+var reliableAckScript = redis.NewScript(reliableAckScriptSource)
+
+const reliableReleaseScriptSource = `
+local function typename(key)
+  local value = redis.call('TYPE', key)
+  if type(value) == 'table' then return value['ok'] end
+  return value
+end
+local function nowms()
+  local now = redis.call('TIME')
+  return tonumber(now[1]) * 1000 + math.floor(tonumber(now[2]) / 1000)
+end
+local rt = typename(KEYS[1])
+local ht = typename(KEYS[2])
+local vt = typename(KEYS[3])
+local bt = typename(KEYS[4])
+if (rt ~= 'none' and rt ~= 'list') or (ht ~= 'none' and ht ~= 'hash') or
+   (vt ~= 'none' and vt ~= 'zset') or (bt ~= 'none' and bt ~= 'zset') then
+  return redis.error_reply('reliable release: invalid key type')
+end
+local token = ARGV[1]
+if not token or token == '' then return redis.error_reply('reliable release: invalid token') end
+local now = nowms()
+local envelope = redis.call('HGET', KEYS[2], token)
+local score = redis.call('ZSCORE', KEYS[3], token)
+if not envelope or not score or tonumber(score) <= now then return {0, tostring(now)} end
+if string.len(envelope) < 11 or string.sub(envelope, 11, 11) ~= ':' or
+   not tonumber(string.sub(envelope, 1, 10)) then
+  return redis.error_reply('reliable release: invalid envelope')
+end
+local payload = string.sub(envelope, 12)
+redis.call('RPUSH', KEYS[1], payload)
+redis.call('ZREM', KEYS[3], token)
+redis.call('HDEL', KEYS[2], token)
+redis.call('ZREM', KEYS[4], token)
+return {1, tostring(now)}
+`
+
+var reliableReleaseScript = redis.NewScript(reliableReleaseScriptSource)
+
+const reliableDeferScriptSource = `
+local function typename(key)
+  local value = redis.call('TYPE', key)
+  if type(value) == 'table' then return value['ok'] end
+  return value
+end
+local function nowms()
+  local now = redis.call('TIME')
+  return tonumber(now[1]) * 1000 + math.floor(tonumber(now[2]) / 1000)
+end
+local ht = typename(KEYS[1])
+local vt = typename(KEYS[2])
+local ot = typename(KEYS[3])
+local bt = typename(KEYS[4])
+if (ht ~= 'none' and ht ~= 'hash') or (vt ~= 'none' and vt ~= 'zset') or
+   (ot ~= 'none' and ot ~= 'zset') or (bt ~= 'none' and bt ~= 'zset') then
+  return redis.error_reply('reliable retry: invalid key type')
+end
+local oldtoken = ARGV[1]
+local newtoken = ARGV[2]
+local delay = tonumber(ARGV[3])
+if not oldtoken or oldtoken == '' or not newtoken or newtoken == '' or
+   not delay or delay < 0 then return redis.error_reply('reliable retry: invalid argument') end
+if redis.call('HEXISTS', KEYS[1], newtoken) == 1 or redis.call('ZSCORE', KEYS[2], newtoken) or
+   redis.call('ZSCORE', KEYS[3], newtoken) or redis.call('ZSCORE', KEYS[4], newtoken) then return {2} end
+local now = nowms()
+local envelope = redis.call('HGET', KEYS[1], oldtoken)
+local score = redis.call('ZSCORE', KEYS[2], oldtoken)
+if not envelope or not score or tonumber(score) <= now then return {0, tostring(now)} end
+if string.len(envelope) < 11 or string.sub(envelope, 11, 11) ~= ':' then
+  return redis.error_reply('reliable retry: invalid envelope')
+end
+local failure = tonumber(string.sub(envelope, 1, 10))
+if not failure then return redis.error_reply('reliable retry: invalid failure count') end
+if failure < 9999999999 then failure = failure + 1 end
+local payload = string.sub(envelope, 12)
+local newenvelope = string.format('%010d:', failure) .. payload
+local deadline = now + delay
+redis.call('HSET', KEYS[1], newtoken, newenvelope)
+redis.call('ZADD', KEYS[2], deadline, newtoken)
+redis.call('ZREM', KEYS[2], oldtoken)
+redis.call('HDEL', KEYS[1], oldtoken)
+redis.call('ZREM', KEYS[4], oldtoken)
+return {1, newtoken, newenvelope, tostring(now), tostring(deadline)}
+`
+
+var reliableDeferScript = redis.NewScript(reliableDeferScriptSource)
+
+func (q *reliableQueue) claim(ctx context.Context) (*reliableDelivery, error) {
+reconcile:
+	for reconciled := 0; reconciled < maxClaimReconciliations; reconciled++ {
+		for attempt := 0; attempt < maxDeliveryTokenAttempts; attempt++ {
+			token, err := q.tokenSource.next()
+			if err != nil {
+				return nil, err
+			}
+			requestStarted := time.Now()
+			result, err := reliableClaimScript.Run(ctx, q.client,
+				[]string{q.keys.ready, q.keys.inflight, q.keys.visibility, q.keys.outcomes, q.keys.repairCursor, q.keys.repairBacklog},
+				token, q.lease.Milliseconds(), ackOutcomeKeyTTL.Milliseconds()).Result()
+			if err != nil {
+				return nil, wrapRedisOperation("claim queued task", err)
+			}
+			values, err := reliableScriptValues(result)
+			if err != nil {
+				return nil, err
+			}
+			code, err := reliableScriptInt(values[0])
+			if err != nil {
+				return nil, err
+			}
+			switch code {
+			case 0:
+				return nil, nil
+			case 1:
+				if len(values) != 5 {
+					return nil, fmt.Errorf("claim queued task: invalid script response")
+				}
+				envelope, err := reliableScriptBytes(values[2])
+				if err != nil {
+					return nil, err
+				}
+				failures, payload, err := decodeReliableEnvelope(envelope)
+				if err != nil {
+					return nil, err
+				}
+				serverMillis, err := reliableScriptInt(values[3])
+				if err != nil {
+					return nil, err
+				}
+				deadlineMillis, err := reliableScriptInt(values[4])
+				if err != nil {
+					return nil, err
+				}
+				delivery := &reliableDelivery{token: token, payload: payload, failures: failures}
+				delivery.updateConfirmation(requestStarted, serverMillis, deadlineMillis)
+				return delivery, nil
+			case 2:
+				continue
+			case 3:
+				continue reconcile
+			default:
+				return nil, fmt.Errorf("claim queued task: unknown script result %d", code)
+			}
+		}
+		return nil, ErrDeliveryTokenCollision
+	}
+	return nil, fmt.Errorf("claim queued task: reconciliation limit reached")
+}
+
+func (q *reliableQueue) renew(ctx context.Context, delivery *reliableDelivery) error {
+	requestStarted := time.Now()
+	result, err := reliableRenewScript.Run(ctx, q.client,
+		[]string{q.keys.inflight, q.keys.visibility}, delivery.token, q.lease.Milliseconds()).Result()
+	if err != nil {
+		return wrapRedisOperation("renew queued task", err)
+	}
+	values, err := reliableScriptValues(result)
+	if err != nil {
+		return err
+	}
+	code, err := reliableScriptInt(values[0])
+	if err != nil {
+		return err
+	}
+	if code != 1 {
+		return ErrDeliveryLeaseLost
+	}
+	if len(values) != 3 {
+		return fmt.Errorf("renew queued task: invalid script response")
+	}
+	serverMillis, err := reliableScriptInt(values[1])
+	if err != nil {
+		return err
+	}
+	deadlineMillis, err := reliableScriptInt(values[2])
+	if err != nil {
+		return err
+	}
+	delivery.updateConfirmation(requestStarted, serverMillis, deadlineMillis)
+	return nil
+}
+
+func (q *reliableQueue) acknowledge(ctx context.Context, delivery *reliableDelivery) error {
+	result, err := reliableAckScript.Run(ctx, q.client,
+		[]string{q.keys.inflight, q.keys.visibility, q.keys.outcomes, q.keys.repairBacklog}, delivery.token,
+		ackOutcomeRetention.Milliseconds(), ackOutcomeKeyTTL.Milliseconds()).Result()
+	if err != nil {
+		return wrapRedisOperation("acknowledge queued task", err)
+	}
+	values, err := reliableScriptValues(result)
+	if err != nil {
+		return err
+	}
+	code, err := reliableScriptInt(values[0])
+	if err != nil {
+		return err
+	}
+	if code != 1 {
+		return ErrDeliveryLeaseLost
+	}
+	return nil
+}
+
+func (q *reliableQueue) release(ctx context.Context, delivery *reliableDelivery) error {
+	result, err := reliableReleaseScript.Run(ctx, q.client,
+		[]string{q.keys.ready, q.keys.inflight, q.keys.visibility, q.keys.repairBacklog}, delivery.token).Result()
+	if err != nil {
+		return wrapRedisOperation("release queued task", err)
+	}
+	values, err := reliableScriptValues(result)
+	if err != nil {
+		return err
+	}
+	code, err := reliableScriptInt(values[0])
+	if err != nil {
+		return err
+	}
+	if code != 1 {
+		return ErrDeliveryLeaseLost
+	}
+	return nil
+}
+
+func (q *reliableQueue) deferRetry(ctx context.Context, delivery *reliableDelivery) (*reliableDelivery, error) {
+	delay := reliableRetryDelay(delivery.failures, delivery.payload)
+	for attempt := 0; attempt < maxDeliveryTokenAttempts; attempt++ {
+		newToken, err := q.tokenSource.next()
+		if err != nil {
+			return nil, err
+		}
+		requestStarted := time.Now()
+		result, err := reliableDeferScript.Run(ctx, q.client,
+			[]string{q.keys.inflight, q.keys.visibility, q.keys.outcomes, q.keys.repairBacklog},
+			delivery.token, newToken, delay.Milliseconds()).Result()
+		if err != nil {
+			return nil, wrapRedisOperation("defer queued task", err)
+		}
+		values, err := reliableScriptValues(result)
+		if err != nil {
+			return nil, err
+		}
+		code, err := reliableScriptInt(values[0])
+		if err != nil {
+			return nil, err
+		}
+		switch code {
+		case 0:
+			return nil, ErrDeliveryLeaseLost
+		case 1:
+			if len(values) != 5 {
+				return nil, fmt.Errorf("defer queued task: invalid script response")
+			}
+			envelope, err := reliableScriptBytes(values[2])
+			if err != nil {
+				return nil, err
+			}
+			failures, payload, err := decodeReliableEnvelope(envelope)
+			if err != nil {
+				return nil, err
+			}
+			serverMillis, err := reliableScriptInt(values[3])
+			if err != nil {
+				return nil, err
+			}
+			deadlineMillis, err := reliableScriptInt(values[4])
+			if err != nil {
+				return nil, err
+			}
+			next := &reliableDelivery{token: newToken, payload: payload, failures: failures}
+			next.updateConfirmation(requestStarted, serverMillis, deadlineMillis)
+			return next, nil
+		case 2:
+			continue
+		default:
+			return nil, fmt.Errorf("defer queued task: unknown script result %d", code)
+		}
+	}
+	return nil, ErrDeliveryTokenCollision
+}
+
+func reliableRetryDelay(failures uint64, payload []byte) time.Duration {
+	exponent := failures
+	if exponent > 6 {
+		exponent = 6
+	}
+	base := time.Second * time.Duration(uint64(1)<<exponent)
+	if base > 60*time.Second {
+		base = 60 * time.Second
+	}
+	seedInput := make([]byte, 8+len(payload))
+	binary.BigEndian.PutUint64(seedInput[:8], failures)
+	copy(seedInput[8:], payload)
+	digest := sha256.Sum256(seedInput)
+	// Deterministic factor in [0.8, 1.2].
+	basisPoints := 8000 + int(binary.BigEndian.Uint16(digest[:2]))%4001
+	delay := time.Duration(int64(base) * int64(basisPoints) / 10000)
+	if delay > 60*time.Second {
+		return 60 * time.Second
+	}
+	return delay
+}
+
+func decodeReliableEnvelope(envelope []byte) (uint64, []byte, error) {
+	if len(envelope) < reliableEnvelopeHeaderSize || envelope[10] != ':' {
+		return 0, nil, fmt.Errorf("reliable delivery: invalid envelope")
+	}
+	failures, err := strconv.ParseUint(string(envelope[:10]), 10, 64)
+	if err != nil {
+		return 0, nil, fmt.Errorf("reliable delivery: invalid failure count: %w", err)
+	}
+	payload := append([]byte(nil), envelope[reliableEnvelopeHeaderSize:]...)
+	return failures, payload, nil
+}
+
+func reliableScriptValues(result interface{}) ([]interface{}, error) {
+	values, ok := result.([]interface{})
+	if !ok || len(values) == 0 {
+		return nil, fmt.Errorf("reliable delivery: invalid script response %T", result)
+	}
+	return values, nil
+}
+
+func reliableScriptInt(value interface{}) (int64, error) {
+	switch typed := value.(type) {
+	case int64:
+		return typed, nil
+	case string:
+		parsed, err := strconv.ParseInt(typed, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("reliable delivery: invalid integer response: %w", err)
+		}
+		return parsed, nil
+	case []byte:
+		parsed, err := strconv.ParseInt(string(typed), 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("reliable delivery: invalid integer response: %w", err)
+		}
+		return parsed, nil
+	default:
+		return 0, fmt.Errorf("reliable delivery: invalid integer response %T", value)
+	}
+}
+
+func reliableScriptBytes(value interface{}) ([]byte, error) {
+	switch typed := value.(type) {
+	case string:
+		return []byte(typed), nil
+	case []byte:
+		return append([]byte(nil), typed...), nil
+	default:
+		return nil, fmt.Errorf("reliable delivery: invalid byte response %T", value)
+	}
+}

--- a/distributed/controller/controller_redis/reliable_queue_test.go
+++ b/distributed/controller/controller_redis/reliable_queue_test.go
@@ -1,0 +1,525 @@
+package controller_redis
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-redis/redis/v8"
+)
+
+func newReliableTestQueue(t *testing.T, queue string, lease time.Duration, source io.Reader) (*reliableQueue, redis.UniversalClient) {
+	t.Helper()
+	_, _, client := newMiniController(t)
+	return newReliableQueue(client, queue, lease, newDeliveryTokenGenerator(source)), client
+}
+
+type failingTokenReader struct{ err error }
+
+func (r failingTokenReader) Read([]byte) (int, error) { return 0, r.err }
+
+type fixedTokenReader struct {
+	token [16]byte
+	reads atomic.Int32
+}
+
+func (r *fixedTokenReader) Read(p []byte) (int, error) {
+	r.reads.Add(1)
+	for index := range p {
+		p[index] = r.token[index%len(r.token)]
+	}
+	return len(p), nil
+}
+
+type loseScriptResponseHook struct {
+	hash  string
+	err   error
+	armed atomic.Bool
+}
+
+type beforeScriptHook struct {
+	hash     string
+	err      error
+	entered  chan struct{}
+	canceled chan struct{}
+	release  <-chan struct{}
+	armed    atomic.Bool
+}
+
+func (h *beforeScriptHook) BeforeProcess(ctx context.Context, cmd redis.Cmder) (context.Context, error) {
+	if !strings.EqualFold(cmd.Name(), "evalsha") || !h.armed.Load() {
+		return ctx, nil
+	}
+	args := cmd.Args()
+	if len(args) < 2 || fmt.Sprint(args[1]) != h.hash || !h.armed.CompareAndSwap(true, false) {
+		return ctx, nil
+	}
+	if h.entered != nil {
+		close(h.entered)
+	}
+	if h.release != nil {
+		if h.canceled == nil {
+			<-h.release
+		} else {
+			select {
+			case <-ctx.Done():
+				close(h.canceled)
+				<-h.release
+			case <-h.release:
+			}
+		}
+	}
+	return ctx, h.err
+}
+
+func (*beforeScriptHook) AfterProcess(context.Context, redis.Cmder) error { return nil }
+
+func (*beforeScriptHook) BeforeProcessPipeline(ctx context.Context, _ []redis.Cmder) (context.Context, error) {
+	return ctx, nil
+}
+
+func (*beforeScriptHook) AfterProcessPipeline(context.Context, []redis.Cmder) error { return nil }
+
+func (h *loseScriptResponseHook) BeforeProcess(ctx context.Context, _ redis.Cmder) (context.Context, error) {
+	return ctx, nil
+}
+
+func (h *loseScriptResponseHook) AfterProcess(_ context.Context, cmd redis.Cmder) error {
+	if !strings.EqualFold(cmd.Name(), "evalsha") || !h.armed.Load() {
+		return nil
+	}
+	args := cmd.Args()
+	if len(args) < 2 || fmt.Sprint(args[1]) != h.hash || !h.armed.CompareAndSwap(true, false) {
+		return nil
+	}
+	return h.err
+}
+
+func (*loseScriptResponseHook) BeforeProcessPipeline(ctx context.Context, _ []redis.Cmder) (context.Context, error) {
+	return ctx, nil
+}
+
+func (*loseScriptResponseHook) AfterProcessPipeline(context.Context, []redis.Cmder) error { return nil }
+
+func TestConcurrentClaimHasSingleLeaseOwner(t *testing.T) {
+	queue := "queue:{single-owner}"
+	q, client := newReliableTestQueue(t, queue, time.Second, nil)
+	payload := []byte("serialized-task")
+	if err := client.RPush(context.Background(), queue, payload).Err(); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	results := make(chan *reliableDelivery, 2)
+	errs := make(chan error, 2)
+	var wg sync.WaitGroup
+	for index := 0; index < 2; index++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			delivery, err := q.claim(context.Background())
+			results <- delivery
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(results)
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("claim: %v", err)
+		}
+	}
+	owners := 0
+	for delivery := range results {
+		if delivery != nil {
+			owners++
+		}
+	}
+	if owners != 1 {
+		t.Fatalf("claim owners = %d, want 1", owners)
+	}
+	if got := client.HLen(context.Background(), q.keys.inflight).Val(); got != 1 {
+		t.Fatalf("inflight = %d, want 1", got)
+	}
+}
+
+func TestExpiredTokenCannotFinalizeDelivery(t *testing.T) {
+	queue := "queue:{expiry-fence}"
+	q, client := newReliableTestQueue(t, queue, 20*time.Millisecond, nil)
+	payload := []byte("expiry-task")
+	if err := client.RPush(context.Background(), queue, payload).Err(); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	delivery, err := q.claim(context.Background())
+	if err != nil || delivery == nil {
+		t.Fatalf("claim = (%v, %v), want delivery", delivery, err)
+	}
+	time.Sleep(30 * time.Millisecond)
+
+	beforeEnvelope := client.HGet(context.Background(), q.keys.inflight, delivery.token).Val()
+	beforeScore := client.ZScore(context.Background(), q.keys.visibility, delivery.token).Val()
+	for name, operation := range map[string]func() error{
+		"renew":   func() error { return q.renew(context.Background(), delivery) },
+		"ack":     func() error { return q.acknowledge(context.Background(), delivery) },
+		"release": func() error { return q.release(context.Background(), delivery) },
+	} {
+		if err := operation(); !errors.Is(err, ErrDeliveryLeaseLost) {
+			t.Fatalf("%s error = %v, want ErrDeliveryLeaseLost", name, err)
+		}
+		if got := client.HGet(context.Background(), q.keys.inflight, delivery.token).Val(); got != beforeEnvelope {
+			t.Fatalf("%s changed inflight envelope", name)
+		}
+		if got := client.ZScore(context.Background(), q.keys.visibility, delivery.token).Val(); got != beforeScore {
+			t.Fatalf("%s changed visibility score", name)
+		}
+	}
+}
+
+func TestRenewTransportFailureDoesNotAdvanceConfirmation(t *testing.T) {
+	queue := "queue:{renew-transport-failure}"
+	q, client := newReliableTestQueue(t, queue, time.Second, nil)
+	if err := client.RPush(context.Background(), queue, "renew-task").Err(); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	delivery, err := q.claim(context.Background())
+	if err != nil || delivery == nil {
+		t.Fatalf("claim = (%v, %v), want delivery", delivery, err)
+	}
+	if err := reliableRenewScript.Load(context.Background(), client).Err(); err != nil {
+		t.Fatalf("preload renew script: %v", err)
+	}
+	wantErr := errors.New("renew transport unavailable")
+	hook := &beforeScriptHook{hash: reliableRenewScript.Hash(), err: wantErr}
+	hook.armed.Store(true)
+	client.AddHook(hook)
+
+	confirmedBefore := delivery.confirmedUntil
+	scoreBefore := client.ZScore(context.Background(), q.keys.visibility, delivery.token).Val()
+	if err := q.renew(context.Background(), delivery); !errors.Is(err, wantErr) {
+		t.Fatalf("renew error = %v, want transport error", err)
+	}
+	if hook.armed.Load() {
+		t.Fatal("renew transport failure hook was not reached")
+	}
+	if !delivery.confirmedUntil.Equal(confirmedBefore) {
+		t.Fatalf("confirmedUntil advanced from %v to %v after unconfirmed renew", confirmedBefore, delivery.confirmedUntil)
+	}
+	if scoreAfter := client.ZScore(context.Background(), q.keys.visibility, delivery.token).Val(); scoreAfter != scoreBefore {
+		t.Fatalf("visibility score changed from %v to %v although Redis did not receive renew", scoreBefore, scoreAfter)
+	}
+}
+
+func TestAbandonedDeliveryReclaimedAfterVisibility(t *testing.T) {
+	queue := "queue:{reclaim}"
+	q, client := newReliableTestQueue(t, queue, 25*time.Millisecond, nil)
+	payload := []byte{0, 1, 2, 3, 255}
+	if err := client.RPush(context.Background(), queue, payload).Err(); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	first, err := q.claim(context.Background())
+	if err != nil || first == nil {
+		t.Fatalf("first claim = (%v, %v)", first, err)
+	}
+	if early, err := q.claim(context.Background()); err != nil || early != nil {
+		t.Fatalf("early reclaim = (%v, %v), want nil", early, err)
+	}
+	time.Sleep(35 * time.Millisecond)
+	second, err := q.claim(context.Background())
+	if err != nil || second == nil {
+		t.Fatalf("reclaim = (%v, %v)", second, err)
+	}
+	if second.token == first.token {
+		t.Fatal("reclaim reused delivery token")
+	}
+	if !bytes.Equal(second.payload, payload) {
+		t.Fatalf("reclaimed payload = %v, want %v", second.payload, payload)
+	}
+}
+
+func TestCrashAfterProcessBeforeAckPreservesIdentity(t *testing.T) {
+	queue := "queue:{crash-before-ack}"
+	q, client := newReliableTestQueue(t, queue, 25*time.Millisecond, nil)
+	payload := []byte(`{"id":"stable-id","name":"task","args":["exact"]}`)
+	if err := client.RPush(context.Background(), queue, payload).Err(); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	beforeCrash, err := q.claim(context.Background())
+	if err != nil || beforeCrash == nil {
+		t.Fatalf("claim before crash = (%v, %v)", beforeCrash, err)
+	}
+	time.Sleep(35 * time.Millisecond)
+	afterCrash, err := q.claim(context.Background())
+	if err != nil || afterCrash == nil {
+		t.Fatalf("claim after crash = (%v, %v)", afterCrash, err)
+	}
+	if !bytes.Equal(afterCrash.payload, beforeCrash.payload) || !bytes.Equal(afterCrash.payload, payload) {
+		t.Fatalf("redelivered bytes = %q, want exact original %q", afterCrash.payload, payload)
+	}
+	var decoded struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(afterCrash.payload, &decoded); err != nil || decoded.ID != "stable-id" {
+		t.Fatalf("redelivered Signature.ID = %q, error = %v", decoded.ID, err)
+	}
+}
+
+func TestAcknowledgementOutcomeConfirmsRetry(t *testing.T) {
+	queue := "queue:{ack-outcome}"
+	q, client := newReliableTestQueue(t, queue, 50*time.Millisecond, nil)
+	if err := client.RPush(context.Background(), queue, "ack-task").Err(); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	delivery, err := q.claim(context.Background())
+	if err != nil || delivery == nil {
+		t.Fatalf("claim = (%v, %v)", delivery, err)
+	}
+	if err := q.acknowledge(context.Background(), delivery); err != nil {
+		t.Fatalf("first ack: %v", err)
+	}
+	time.Sleep(60 * time.Millisecond)
+	if err := q.acknowledge(context.Background(), delivery); err != nil {
+		t.Fatalf("confirmation ack after lease: %v", err)
+	}
+	if score := client.ZScore(context.Background(), q.keys.outcomes, delivery.token).Val(); score == 0 {
+		t.Fatal("ack outcome missing")
+	}
+	if ttl := client.TTL(context.Background(), q.keys.outcomes).Val(); ttl <= 0 || ttl > ackOutcomeKeyTTL {
+		t.Fatalf("ack outcome TTL = %v, want (0, %v]", ttl, ackOutcomeKeyTTL)
+	}
+}
+
+func TestReliableDeliveryRedisFailuresRemainRecoverable(t *testing.T) {
+	queue := "queue:{lost-ack-response}"
+	q, client := newReliableTestQueue(t, queue, time.Second, nil)
+	lostResponse := errors.New("ack response lost")
+	hook := &loseScriptResponseHook{hash: reliableAckScript.Hash(), err: lostResponse}
+	client.AddHook(hook)
+	if err := reliableAckScript.Load(context.Background(), client).Err(); err != nil {
+		t.Fatalf("preload ack script: %v", err)
+	}
+	if err := client.RPush(context.Background(), queue, "ack-lost-task").Err(); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	delivery, err := q.claim(context.Background())
+	if err != nil || delivery == nil {
+		t.Fatalf("claim = (%v, %v)", delivery, err)
+	}
+	hook.armed.Store(true)
+	c := &ControllerRedis{finalizationTimeout: 100 * time.Millisecond, ackConfirmationWindow: 500 * time.Millisecond}
+	if err := c.acknowledgeReliableDelivery(q, delivery); err != nil {
+		t.Fatalf("bounded ack confirmation: %v", err)
+	}
+	if hook.armed.Load() {
+		t.Fatal("test hook did not lose the committed ACK response")
+	}
+	if got := client.ZScore(context.Background(), q.keys.outcomes, delivery.token).Val(); got == 0 {
+		t.Fatal("committed ACK outcome missing")
+	}
+	if got := client.HLen(context.Background(), q.keys.inflight).Val(); got != 0 {
+		t.Fatalf("inflight after confirmed ACK = %d, want 0", got)
+	}
+}
+
+func TestLuaOrphanReconciliationRetainsPayload(t *testing.T) {
+	queue := "queue:{orphan}"
+	q, client := newReliableTestQueue(t, queue, time.Second, nil)
+	payload := []byte("orphan-payload")
+	if err := client.HSet(context.Background(), q.keys.inflight, "orphan-token", append([]byte("0000000000:"), payload...)).Err(); err != nil {
+		t.Fatalf("seed orphan: %v", err)
+	}
+	delivery, err := q.claim(context.Background())
+	if err != nil || delivery == nil {
+		t.Fatalf("claim reconciled payload = (%v, %v)", delivery, err)
+	}
+	if !bytes.Equal(delivery.payload, payload) {
+		t.Fatalf("reconciled payload = %q, want %q", delivery.payload, payload)
+	}
+}
+
+func TestPermanentFailuresUseBoundedBackoff(t *testing.T) {
+	queue := "queue:{backoff}"
+	q, client := newReliableTestQueue(t, queue, time.Second, nil)
+	payload := []byte("poison-task")
+	if err := client.RPush(context.Background(), queue, payload).Err(); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	delivery, err := q.claim(context.Background())
+	if err != nil || delivery == nil {
+		t.Fatalf("claim = (%v, %v)", delivery, err)
+	}
+	ranges := []struct {
+		min time.Duration
+		max time.Duration
+	}{
+		{min: 800 * time.Millisecond, max: 1200 * time.Millisecond},
+		{min: 1600 * time.Millisecond, max: 2400 * time.Millisecond},
+		{min: 3200 * time.Millisecond, max: 4800 * time.Millisecond},
+		{min: 6400 * time.Millisecond, max: 9600 * time.Millisecond},
+		{min: 12800 * time.Millisecond, max: 19200 * time.Millisecond},
+		{min: 25600 * time.Millisecond, max: 38400 * time.Millisecond},
+		{min: 48 * time.Second, max: 60 * time.Second},
+		{min: 48 * time.Second, max: 60 * time.Second},
+	}
+	current := delivery
+	for failure, tt := range ranges {
+		next, err := q.deferRetry(context.Background(), current)
+		if err != nil {
+			t.Fatalf("defer retry %d: %v", failure+1, err)
+		}
+		if next.failures != uint64(failure+1) {
+			t.Fatalf("defer retry %d persisted failure count = %d, want %d", failure+1, next.failures, failure+1)
+		}
+		delay := next.deadline.Sub(next.serverTime)
+		if delay < tt.min || delay > tt.max {
+			t.Fatalf("failure %d delay = %v, want [%v, %v]", failure, delay, tt.min, tt.max)
+		}
+		current = next
+	}
+	if delay := reliableRetryDelay(20, payload); delay < 48*time.Second || delay > 60*time.Second {
+		t.Fatalf("saturated failure 20 delay = %v, want [48s, 60s]", delay)
+	}
+}
+
+func TestDeliveryTokenGenerationIsBounded(t *testing.T) {
+	t.Run("entropy failure", func(t *testing.T) {
+		queue := "queue:{entropy}"
+		wantErr := errors.New("entropy unavailable")
+		q, client := newReliableTestQueue(t, queue, time.Second, failingTokenReader{err: wantErr})
+		if err := client.RPush(context.Background(), queue, "task").Err(); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		if _, err := q.claim(context.Background()); !errors.Is(err, ErrDeliveryTokenUnavailable) || !errors.Is(err, wantErr) {
+			t.Fatalf("claim error = %v, want token and source errors", err)
+		}
+		if client.LLen(context.Background(), queue).Val() != 1 || client.HLen(context.Background(), q.keys.inflight).Val() != 0 {
+			t.Fatal("entropy failure mutated task")
+		}
+	})
+
+	t.Run("collision exhaustion", func(t *testing.T) {
+		queue := "queue:{collision}"
+		reader := &fixedTokenReader{}
+		q, client := newReliableTestQueue(t, queue, time.Second, reader)
+		if err := client.RPush(context.Background(), queue, "first").Err(); err != nil {
+			t.Fatalf("enqueue first: %v", err)
+		}
+		first, err := q.claim(context.Background())
+		if err != nil || first == nil {
+			t.Fatalf("first claim = (%v, %v)", first, err)
+		}
+		if err := client.RPush(context.Background(), queue, "second").Err(); err != nil {
+			t.Fatalf("enqueue second: %v", err)
+		}
+		if _, err := q.claim(context.Background()); !errors.Is(err, ErrDeliveryTokenCollision) {
+			t.Fatalf("collision claim error = %v, want ErrDeliveryTokenCollision", err)
+		}
+		if got := reader.reads.Load(); got != 5 {
+			t.Fatalf("token reads = %d, want initial claim + 4 bounded collision attempts", got)
+		}
+		if got := client.LIndex(context.Background(), queue, 0).Val(); got != "second" {
+			t.Fatalf("collision changed ready task to %q", got)
+		}
+		if got := client.HGet(context.Background(), q.keys.inflight, first.token).Val(); got == "" {
+			t.Fatal("collision overwrote existing reservation")
+		}
+	})
+
+	t.Run("deferred retry collision preserves reservation", func(t *testing.T) {
+		queue := "queue:{defer-collision}"
+		reader := &fixedTokenReader{}
+		q, client := newReliableTestQueue(t, queue, time.Second, reader)
+		if err := client.RPush(context.Background(), queue, "deferred-task").Err(); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		delivery, err := q.claim(context.Background())
+		if err != nil || delivery == nil {
+			t.Fatalf("claim = (%v, %v)", delivery, err)
+		}
+		envelopeBefore := client.HGet(context.Background(), q.keys.inflight, delivery.token).Val()
+		scoreBefore := client.ZScore(context.Background(), q.keys.visibility, delivery.token).Val()
+
+		next, err := q.deferRetry(context.Background(), delivery)
+		if !errors.Is(err, ErrDeliveryTokenCollision) || next != nil {
+			t.Fatalf("defer collision = (%v, %v), want (nil, ErrDeliveryTokenCollision)", next, err)
+		}
+		if got := reader.reads.Load(); got != 5 {
+			t.Fatalf("token reads = %d, want initial claim + 4 bounded defer attempts", got)
+		}
+		if envelopeAfter := client.HGet(context.Background(), q.keys.inflight, delivery.token).Val(); envelopeAfter != envelopeBefore {
+			t.Fatalf("defer collision changed reservation envelope from %q to %q", envelopeBefore, envelopeAfter)
+		}
+		if scoreAfter := client.ZScore(context.Background(), q.keys.visibility, delivery.token).Val(); scoreAfter != scoreBefore {
+			t.Fatalf("defer collision changed visibility score from %v to %v", scoreBefore, scoreAfter)
+		}
+	})
+}
+
+func TestLegacyQueueAndClusterKeyCompatibility(t *testing.T) {
+	var firstTags [16384]string
+	remaining := len(firstTags)
+	maxCandidate := -1
+	for candidate := 0; candidate <= 131071 && remaining > 0; candidate++ {
+		tag := fmt.Sprintf("gkit-%x", candidate)
+		slot := int(redisCRC16([]byte(tag)) % 16384)
+		if firstTags[slot] == "" {
+			firstTags[slot] = tag
+			remaining--
+			maxCandidate = candidate
+		}
+	}
+	if remaining != 0 || maxCandidate > 131071 {
+		t.Fatalf("offline candidate traversal left %d slots, max candidate %d", remaining, maxCandidate)
+	}
+	for slot, tag := range firstTags {
+		if got := redisClusterSlot("{" + tag + "}"); got != slot {
+			t.Fatalf("slot %d candidate %q hashes to %d", slot, tag, got)
+		}
+	}
+
+	reliableSlotTags.Lock()
+	reliableSlotTags.tags = make(map[int]string)
+	reliableSlotTags.Unlock()
+	for _, slot := range []int{0, 1, 8192, 16383} {
+		if tag := reliableTagForSlot(slot); tag != firstTags[slot] {
+			t.Fatalf("slot %d lazy candidate = %q, want first %q", slot, tag, firstTags[slot])
+		}
+		if again := reliableTagForSlot(slot); again != firstTags[slot] {
+			t.Fatalf("slot %d cached candidate = %q, want %q", slot, again, firstTags[slot])
+		}
+	}
+	reliableSlotTags.RLock()
+	if cached := len(reliableSlotTags.tags); cached != 4 {
+		reliableSlotTags.RUnlock()
+		t.Fatalf("lazy slot cache entries = %d, want 4", cached)
+	}
+	reliableSlotTags.RUnlock()
+
+	for _, queue := range []string{"legacy-queue", "queue:{tagged}", "queue:{broken"} {
+		keys := deriveReliableQueueKeys(queue)
+		wantSlot := redisClusterSlot(queue)
+		for _, key := range []string{keys.inflight, keys.visibility, keys.outcomes, keys.repairCursor, keys.repairBacklog} {
+			if got := redisClusterSlot(key); got != wantSlot {
+				t.Fatalf("queue %q internal key %q slot = %d, want %d", queue, key, got, wantSlot)
+			}
+		}
+	}
+	first := deriveReliableQueueKeys("first:{shared}")
+	second := deriveReliableQueueKeys("second:{shared}")
+	if first.prefix == second.prefix {
+		t.Fatal("queue digest did not distinguish same-slot queue names")
+	}
+	reliableSlotTags.RLock()
+	if cached := len(reliableSlotTags.tags); cached >= 16384 {
+		reliableSlotTags.RUnlock()
+		t.Fatalf("key derivation eagerly populated %d slot tags", cached)
+	}
+	reliableSlotTags.RUnlock()
+}

--- a/specs/103/PRODUCT.md
+++ b/specs/103/PRODUCT.md
@@ -1,0 +1,38 @@
+# Reliable Redis task delivery
+
+## Summary
+
+Redis-backed consumers keep accepted tasks recoverable until processing is acknowledged, including consumer failures, lease expiry, and Redis command ambiguity. Existing controller, processor, producer, queue-name, and serialized-task contracts remain unchanged.
+
+## Problem
+
+Removing a task from the ready queue before processing creates a loss window: decoding, processing, Redis, or process failure can leave no durable indication that the task is unfinished. Reliable delivery closes that window with at-least-once recovery while keeping the current public API.
+
+## Behavior
+
+1. An accepted task remains recoverable in either ready or reserved state until its delivery is successfully acknowledged.
+2. At any instant, only one unexpired delivery owns the right to process and finalize a reserved task.
+3. A delivery is acknowledged only after processing succeeds, or when an unregistered task is explicitly configured to be ignored.
+4. When processing returns an error, that error remains visible and the same task is retained as a deferred delivery for a later attempt.
+5. A consumer may reclaim an abandoned delivery only after its visibility period expires; reclaiming preserves the exact task bytes.
+6. A renewal changes the locally trusted delivery deadline only after Redis confirms it. A transport failure before Redis receives the renewal leaves both the trusted deadline and server-side visibility unchanged.
+7. After a delivery expires, its token cannot renew, acknowledge, or release the task, and those rejected operations do not mutate it.
+8. A failure after processing succeeds but before acknowledgement may cause another delivery, but every attempt preserves the original serialized task and task ID.
+9. `Stop` waits for an active processor to return and then waits for its in-flight renewal to finish before finalization and shutdown complete. It does not close the caller-owned Redis client, and cannot guarantee termination if the processor never returns.
+10. Acknowledgement confirmation is retained for 24 hours using Redis server time. Expired confirmation cleanup is bounded per operation, and the confirmation key has bounded lifetime after traffic stops.
+11. Existing public APIs, serialized tasks, ready queues, delayed scheduling, pending-task inspection, and tagged, untagged, or malformed-brace Redis Cluster queue names continue to work without queue renaming.
+12. A malformed serialized task remains recoverable and does not disappear merely because it cannot be decoded.
+13. A failure at an internal transition boundary retains either a recoverable task copy or durable acknowledgement evidence; it never loses both.
+14. Consecutive deferred failures increment their retained failure count and use deterministic jittered exponential delay: approximately 1, 2, 4, 8, 16, and 32 seconds, then a saturated 48-to-60-second range.
+15. An empty queue backs off to a steady 0.8-to-1.2-second polling interval, while work published at steady idle is discovered within 1.2 seconds.
+16. Token entropy failure or four consecutive token collisions returns an explicit error without mutating ready or reserved work. This applies both when claiming and when moving a delivery into deferred retry state.
+
+## Non-goals
+
+- Exactly-once processing.
+- A dead-letter queue, maximum delivery count, or permanent rejection policy.
+- Forcibly canceling a processor that does not return.
+- Global ordering across consumers or storage backends.
+- Recovery after Redis itself loses acknowledged data.
+- New public timing, retry, lease, clock, or token configuration APIs.
+- Replacing the existing list-backed queue with Redis Streams.

--- a/specs/103/TECH.md
+++ b/specs/103/TECH.md
@@ -1,0 +1,71 @@
+# Reliable Redis task delivery: technical design
+
+## Context
+
+`ControllerRedis.StartConsuming` owns the producer and processor lifetimes and joins them before returning (`distributed/controller/controller_redis/redis.go:123-196`). Delivery processing starts one renewal worker, joins it, and only then acknowledges or defers the task (`reliable_consumer.go:17-63`).
+
+The reliable queue stores private lease state and executes atomic Redis transitions (`reliable_queue.go:19-95`). Claim, renewal, acknowledgement, release, and deferred retry are implemented by the production Lua sources and their Go response decoders (`reliable_queue.go:97-665`). Public construction and the caller-owned client contract remain in `redis.go:439-510`.
+
+This document describes the implementation that ships for [PRODUCT.md](./PRODUCT.md), not a future design.
+
+## Proposed changes
+
+### Reservation state and key placement
+
+The existing queue remains a LIST of the original serialized bytes. Private same-slot keys hold inflight envelopes, visibility deadlines, acknowledgement outcomes, a repair cursor, and a repair backlog. Tagged queues reuse their tag; other queue names derive a deterministic tag for their existing Redis Cluster slot. A digest of the full queue name keeps distinct queues separate.
+
+An inflight envelope contains a saturated decimal failure count and the exact legacy payload. Claim and reconciliation validate all key types and arguments before their first write. Destination state is written before destructive source removal, and repair work is limited to 128 entries per claim. Oversized scan pages persist the unprocessed tokens in the repair backlog before advancing the cursor.
+
+### Lease time and finalization
+
+Lua uses Redis `TIME` for visibility and acknowledgement decisions. A successful claim or renewal returns both Redis server time and the confirmed deadline. The client converts their difference into a local monotonic deadline anchored before the request; `reliableQueue.renew` updates it only after a successful script response.
+
+Processing owns one delivery-scoped renewal goroutine. Processor return cancels that goroutine and joins it before acknowledgement or deferred retry begins. Finalization has a private bounded timeout. Acknowledgement retries the same token during a private confirmation window so a committed command whose response was lost can be confirmed by its retained outcome.
+
+Acknowledgement outcomes score at Redis `TIME + 24h`. One acknowledgement removes at most 128 expired outcomes and refreshes a 25-hour key TTL. Claim-side maintenance also performs bounded expiry cleanup and repairs a missing TTL from retained scores.
+
+### Retry and token safety
+
+Processing and decode failures move the envelope to a fresh reservation. The retained failure count increments and selects deterministic SHA-256 jitter over an exponentially increasing base, saturated at 60 seconds. Pre-processing cancellation uses immediate release instead.
+
+Tokens contain 128 random bits. Claim, reclaim, and deferred retry make at most four generation attempts. Every moving transition verifies the candidate is absent from inflight, visibility, acknowledgement-outcome, and repair-backlog state before writing; exhaustion leaves the original ready item or reservation byte-for-byte intact.
+
+### Shutdown and idle polling
+
+`StopConsuming` marks the controller as stopping, cancels the consume attempt, and waits for `StartConsuming` to join producers and processors. It does not cancel a processor that is already running. When that processor returns, its renewal operation is canceled and joined before finalization. The borrowed Redis client remains open.
+
+Empty claims back off from 25 milliseconds to a one-second base with deterministic plus-or-minus-20-percent jitter. Available work resets the counter. This implementation uses real timers; there is no fake-clock hook or public clock option.
+
+## Testing and validation
+
+Each PRODUCT behavior has one primary regression test:
+
+| Behavior | Primary proof | Mutation target |
+| --- | --- | --- |
+| 1 | `TestClaimPersistsUntilSuccessfulAck` | Remove the inflight write or acknowledge before processing returns. |
+| 2 | `TestConcurrentClaimHasSingleLeaseOwner` | Permit two claims to own the same ready item. |
+| 3 | `TestAckOccursOnlyAfterProcessorSuccess` | Acknowledge processor failures or every unregistered task. |
+| 4 | `TestProcessorErrorDefersDelivery` | Delete the reservation or swallow the processor error. |
+| 5 | `TestAbandonedDeliveryReclaimedAfterVisibility` | Reclaim before expiry or fail to reclaim after expiry. |
+| 6 | `TestRenewTransportFailureDoesNotAdvanceConfirmation` | Advance `confirmedUntil` after a `BeforeProcess` transport failure that never reaches Redis. |
+| 7 | `TestExpiredTokenCannotFinalizeDelivery` | Validate token existence without checking the Redis deadline. |
+| 8 | `TestCrashAfterProcessBeforeAckPreservesIdentity` | Re-serialize with a new ID or discard the reserved payload. |
+| 9 | `TestStopJoinsHeartbeatAndOwnedDeliveries` | Skip the renewal join and begin ACK/return while the renew hook is blocked. |
+| 10 | `TestReliableLuaRedis7AckOutcomeUsesRedisTimeAndBoundedCleanup` | Use a non-24-hour score, client time, or unbounded/absent expired-outcome cleanup. |
+| 11 | `TestLegacyQueueAndClusterKeyCompatibility` | Change queue names, derive another slot, or key the bounded cache by full queue name. |
+| 12 | `TestMalformedPayloadRemainsRecoverable` | Acknowledge or delete bytes after decode failure. |
+| 13 | `TestLuaFailureBoundariesRetainRecoverableCopyOrAck` | Move a destructive write before its destination copy or remove ACK evidence. |
+| 14 | `TestPermanentFailuresUseBoundedBackoff` | Return a fixed one-second delay, reset the persisted count, or remove saturation. |
+| 15 | `TestIdleClaimRequestsAreBounded` | Keep a fixed tight poll interval, omit the cap/reset, or exceed the 1.2-second discovery bound. |
+| 16 | `TestDeliveryTokenGenerationIsBounded` | Remove claim/defer collision prevalidation, retry forever, or overwrite a reservation. |
+
+Behavior 15 is measured by Redis command-hook timestamps and real wall-clock deadlines in the test; it is not a fake-clock proof. The remaining unit tests use miniredis, deterministic token readers, and command hooks. Lua semantics, acknowledgement retention/cleanup, failpoint boundaries, stale-backlog repair, and Redis server time run against Redis 7. Cluster compatibility runs against three Redis 7 masters.
+
+Required gates:
+
+- `go test -race ./distributed/controller/controller_redis`
+- focused `go test -race ./distributed/...`
+- `go vet ./distributed/controller/controller_redis ./distributed/...`
+- Redis 7 standalone live tests with `GKIT_REDIS_TEST_ADDR`
+- three-master Redis 7 Cluster tests with `GKIT_REDIS_CLUSTER_TEST_ADDR`
+- mutation checks for Behaviors 6, 9, 10, 14, and 16


### PR DESCRIPTION
## What

- Keep caller-provided Redis clients open when controller consumption stops.
- Document that `NewControllerRedis` borrows its client and leaves ownership with the caller.
- Make the live Redis consumer test cancel and join its producer, isolate and clean queue keys, close the client explicitly, and accept intentional cancellation.

## Why

The controller, backend, and locker are designed to share one injected Redis client. `StopConsuming` previously closed that client, so stopping a worker also broke backend and lock operations with `redis.ErrClosed`. The live test also leaked its producer across repeated runs and treated the expected stop cancellation as a failure.

## How

- Remove the client close from `ControllerRedis.StopConsuming`; callers close the borrowed client after all users stop.
- Add a miniredis regression test that exercises the shared client, backend, and locker after stopping the controller.
- Give the live test unique queues and deterministic producer/consumer synchronization with complete cleanup.

## Tests

- `go test -race ./distributed/controller/controller_redis ./distributed/backend/backend_redis ./distributed/locker/lock_redis -count=2`
- `go vet ./distributed/controller/controller_redis ./distributed/backend/backend_redis ./distributed/locker/lock_redis`
- Mutation check: restoring `client.Close()` makes all three shared-client regression subtests fail with `redis.ErrClosed`.
