### PR TITLE
fix(result): honor deadlines during poll waits

### DIFF
--- a/distributed/backend/result/async_result.go
+++ b/distributed/backend/result/async_result.go
@@ -68,6 +68,22 @@ func NewGroupCallbackAsyncResult(groupAsyncResult []*task.Signature, callbackAsy
 	}
 }
 
+func waitForPoll(ctx context.Context, duration time.Duration) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	timer := time.NewTimer(duration)
+	select {
+	case <-ctx.Done():
+		if !timer.Stop() {
+			<-timer.C
+		}
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
 // Get 返回结果
 func (asyncResult *AsyncResult) Get(sleepDuration time.Duration) ([]reflect.Value, error) {
 	for {
@@ -91,7 +107,9 @@ func (asyncResult *AsyncResult) GetWithTimeout(timeoutDuration, sleepDuration ti
 		default:
 			results, err := asyncResult.Monitor()
 			if results == nil && err == nil {
-				time.Sleep(sleepDuration)
+				if err := waitForPoll(ctx, sleepDuration); err != nil {
+					return nil, err
+				}
 			} else {
 				return results, err
 			}
@@ -196,7 +214,9 @@ func (chainAsyncResult *ChainAsyncResult) GetWithTimeout(timeoutDuration, sleepD
 			if results != nil {
 				return results, err
 			}
-			time.Sleep(sleepDuration)
+			if err := waitForPoll(ctx, sleepDuration); err != nil {
+				return nil, err
+			}
 		}
 	}
 }
@@ -245,7 +265,9 @@ func (groupCallbackAsyncResult *GroupCallbackAsyncResult) GetWithTimeout(timeout
 			if results != nil {
 				return results, err
 			}
-			time.Sleep(sleepDuration)
+			if err := waitForPoll(ctx, sleepDuration); err != nil {
+				return nil, err
+			}
 		}
 	}
 }

--- a/distributed/backend/result/timeout_test.go
+++ b/distributed/backend/result/timeout_test.go
@@ -1,0 +1,80 @@
+package result
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/songzhibin97/gkit/distributed/task"
+)
+
+const (
+	testTimeout    = 10 * time.Millisecond
+	testPoll       = 120 * time.Millisecond
+	testUpperBound = 100 * time.Millisecond
+)
+
+type pendingResultBackend struct{}
+
+func (*pendingResultBackend) GroupTakeOver(string, string, ...string) error { return nil }
+func (*pendingResultBackend) GroupCompleted(string) (bool, error)           { return false, nil }
+func (*pendingResultBackend) GroupTaskStatus(string) ([]*task.Status, error) {
+	return nil, nil
+}
+func (*pendingResultBackend) TriggerCompleted(string) (bool, error) { return false, nil }
+func (*pendingResultBackend) SetStatePending(*task.Signature) error { return nil }
+func (*pendingResultBackend) SetStateReceived(*task.Signature) error {
+	return nil
+}
+func (*pendingResultBackend) SetStateStarted(*task.Signature) error { return nil }
+func (*pendingResultBackend) SetStateRetry(*task.Signature) error   { return nil }
+func (*pendingResultBackend) SetStateSuccess(*task.Signature, []*task.Result) error {
+	return nil
+}
+func (*pendingResultBackend) SetStateFailure(*task.Signature, string) error { return nil }
+func (*pendingResultBackend) GetStatus(taskID string) (*task.Status, error) {
+	return &task.Status{TaskID: taskID, Status: task.StatePending}, nil
+}
+func (*pendingResultBackend) ResetTask(...string) error  { return nil }
+func (*pendingResultBackend) ResetGroup(...string) error { return nil }
+func (*pendingResultBackend) SetResultExpire(int64)      {}
+
+func TestAsyncResultGetWithTimeoutHonorsDeadlineDuringPollWait(t *testing.T) {
+	b := &pendingResultBackend{}
+	result := NewAsyncResult(&task.Signature{ID: "async"}, b)
+	assertTimeoutBounded(t, result.GetWithTimeout)
+}
+
+func TestChainAsyncResultGetWithTimeoutHonorsDeadlineDuringPollWait(t *testing.T) {
+	b := &pendingResultBackend{}
+	result := NewChainAsyncResult([]*task.Signature{{ID: "chain"}}, b)
+	assertTimeoutBounded(t, result.GetWithTimeout)
+}
+
+func TestGroupCallbackAsyncResultGetWithTimeoutHonorsDeadlineDuringPollWait(t *testing.T) {
+	b := &pendingResultBackend{}
+	result := NewGroupCallbackAsyncResult(
+		[]*task.Signature{{ID: "group"}},
+		&task.Signature{ID: "callback"},
+		b,
+	)
+	assertTimeoutBounded(t, result.GetWithTimeout)
+}
+
+func assertTimeoutBounded(t *testing.T, get func(time.Duration, time.Duration) ([]reflect.Value, error)) {
+	t.Helper()
+	started := time.Now()
+	values, err := get(testTimeout, testPoll)
+	elapsed := time.Since(started)
+	if values != nil {
+		t.Fatalf("GetWithTimeout values = %v, want nil", values)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("GetWithTimeout error = %v, want context.DeadlineExceeded", err)
+	}
+	if elapsed >= testUpperBound {
+		t.Fatalf("GetWithTimeout elapsed = %v, want < %v", elapsed, testUpperBound)
+	}
+}


### PR DESCRIPTION
## What

- Make all three result `GetWithTimeout` variants interrupt their poll wait when the timeout expires.
- Add deterministic pending-backend regressions for Async, Chain, and Group-callback results.

## Why

Each timeout loop checked its context and then called `time.Sleep(pollInterval)`. When the poll interval exceeded the remaining timeout, the API could return more than one full poll interval late; a 10ms timeout with a 120ms poll took about 122ms.

## How

Use one private context-aware timer helper at the three duplicated wait sites. The deadline path stops and drains the timer when necessary and returns the original `ctx.Err()`; the ordinary non-timeout `Get` polling behavior is unchanged.

## Tests

- `go test -race ./distributed/backend/result -count=10`
- `go vet ./distributed/backend/result`
- Regression before the fix: Async, Chain, and Group-callback each took about 122ms and exceeded the 100ms test ceiling.
- Mutations: restoring `time.Sleep` independently at each of the three sites makes only its corresponding deadline test fail at about 122ms.
