### PR TITLE
fix(tcp): bound send and receive by one deadline

### DIFF
--- a/net/tcp/conn.go
+++ b/net/tcp/conn.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"time"
 
 	"github.com/songzhibin97/gkit/cache/buffer"
@@ -39,8 +40,36 @@ type Retry struct {
 	Interval time.Duration
 }
 
+type retryWait func(time.Duration) error
+
+func sleepForRetry(interval time.Duration) error {
+	time.Sleep(interval)
+	return nil
+}
+
+func sleepForRetryUntil(deadline time.Time) retryWait {
+	return func(interval time.Duration) error {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return os.ErrDeadlineExceeded
+		}
+		if interval > remaining {
+			interval = remaining
+		}
+		time.Sleep(interval)
+		if !time.Now().Before(deadline) {
+			return os.ErrDeadlineExceeded
+		}
+		return nil
+	}
+}
+
 // Send 发送数据至对端,有重试机制
 func (c *Conn) Send(data []byte, retry *Retry) error {
+	return c.send(data, retry, sleepForRetry)
+}
+
+func (c *Conn) send(data []byte, retry *Retry, wait retryWait) error {
 	if retry == nil {
 		// Take a per-call zero-value Retry rather than mutating a package
 		// global. The previous code stored `&defaultRetry` and then wrote
@@ -62,7 +91,9 @@ func (c *Conn) Send(data []byte, retry *Retry) error {
 				if retry.Interval == 0 {
 					retry.Interval = DefaultRetryInterval
 				}
-				time.Sleep(retry.Interval)
+				if waitErr := wait(retry.Interval); waitErr != nil {
+					return fmt.Errorf("tcp send retry wait after %d of %d bytes: %w", offset, len(data), waitErr)
+				}
 				continue
 			}
 			return fmt.Errorf("tcp send after %d of %d bytes: %w", offset, len(data), err)
@@ -79,6 +110,10 @@ func (c *Conn) Send(data []byte, retry *Retry) error {
 // length < 0 从 Conn 接收所有数据，并将其返回，直到没有数据
 // length > 0 从 Conn 接收到对应的数据返回
 func (c *Conn) Recv(length int, retry *Retry) (result []byte, retErr error) {
+	return c.recv(length, retry, sleepForRetry)
+}
+
+func (c *Conn) recv(length int, retry *Retry, wait retryWait) (result []byte, retErr error) {
 	if retry == nil {
 		var local Retry
 		retry = &local
@@ -93,7 +128,9 @@ func (c *Conn) Recv(length int, retry *Retry) (result []byte, retErr error) {
 			if retry.Interval == 0 {
 				retry.Interval = DefaultRetryInterval
 			}
-			time.Sleep(retry.Interval)
+			if waitErr := wait(retry.Interval); waitErr != nil {
+				return n, waitErr
+			}
 			if n > 0 {
 				// Preserve bytes returned with a retryable error. The caller
 				// advances its offset and the next read retries the remainder.
@@ -226,15 +263,20 @@ func (c *Conn) SendWithTimeout(data []byte, timeout time.Duration, retry *Retry)
 
 // SendRecv 写入数据并读取返回
 func (c *Conn) SendRecv(data []byte, length int, retry *Retry) ([]byte, error) {
-	if err := c.Send(data, retry); err != nil {
+	return c.sendRecv(data, length, retry, sleepForRetry)
+}
+
+func (c *Conn) sendRecv(data []byte, length int, retry *Retry, wait retryWait) ([]byte, error) {
+	if err := c.send(data, retry, wait); err != nil {
 		return nil, err
 	}
-	return c.Recv(length, retry)
+	return c.recv(length, retry, wait)
 }
 
 // SendRecvWithTimeout 将数据写入并读出已经超时的链接
 func (c *Conn) SendRecvWithTimeout(data []byte, timeout time.Duration, length int, retry *Retry) (result []byte, retErr error) {
-	if err := c.SetDeadline(time.Now().Add(timeout)); err != nil {
+	deadline := time.Now().Add(timeout)
+	if err := c.SetDeadline(deadline); err != nil {
 		return nil, fmt.Errorf("tcp send receive: set deadline: %w", err)
 	}
 	defer func() {
@@ -247,7 +289,7 @@ func (c *Conn) SendRecvWithTimeout(data []byte, timeout time.Duration, length in
 			retErr = errors.Join(retErr, clearErr)
 		}
 	}()
-	return c.SendRecv(data, length, retry)
+	return c.sendRecv(data, length, retry, sleepForRetryUntil(deadline))
 }
 
 func (c *Conn) SetDeadline(t time.Time) error {

--- a/net/tcp/conn.go
+++ b/net/tcp/conn.go
@@ -233,11 +233,21 @@ func (c *Conn) SendRecv(data []byte, length int, retry *Retry) ([]byte, error) {
 }
 
 // SendRecvWithTimeout 将数据写入并读出已经超时的链接
-func (c *Conn) SendRecvWithTimeout(data []byte, timeout time.Duration, length int, retry *Retry) ([]byte, error) {
-	if err := c.Send(data, retry); err != nil {
-		return nil, err
+func (c *Conn) SendRecvWithTimeout(data []byte, timeout time.Duration, length int, retry *Retry) (result []byte, retErr error) {
+	if err := c.SetDeadline(time.Now().Add(timeout)); err != nil {
+		return nil, fmt.Errorf("tcp send receive: set deadline: %w", err)
 	}
-	return c.RecvWithTimeout(length, timeout, retry)
+	defer func() {
+		if err := c.SetDeadline(time.Time{}); err != nil {
+			clearErr := fmt.Errorf("tcp send receive: clear deadline: %w", err)
+			if retErr == nil {
+				retErr = clearErr
+				return
+			}
+			retErr = errors.Join(retErr, clearErr)
+		}
+	}()
+	return c.SendRecv(data, length, retry)
 }
 
 func (c *Conn) SetDeadline(t time.Time) error {

--- a/net/tcp/conn.go
+++ b/net/tcp/conn.go
@@ -245,20 +245,22 @@ func (c *Conn) RecvLine(retry *Retry) ([]byte, error) {
 
 // RecvWithTimeout 读取已经超时的链接
 func (c *Conn) RecvWithTimeout(length int, timeout time.Duration, retry *Retry) ([]byte, error) {
-	if err := c.SetRecvDeadline(time.Now().Add(timeout)); err != nil {
+	deadline := time.Now().Add(timeout)
+	if err := c.SetRecvDeadline(deadline); err != nil {
 		return nil, err
 	}
 	defer c.SetRecvDeadline(time.Time{})
-	return c.Recv(length, retry)
+	return c.recv(length, retry, sleepForRetryUntil(deadline))
 }
 
 // SendWithTimeout 写入数据给已经超时的链接
 func (c *Conn) SendWithTimeout(data []byte, timeout time.Duration, retry *Retry) error {
-	if err := c.SetSendDeadline(time.Now().Add(timeout)); err != nil {
+	deadline := time.Now().Add(timeout)
+	if err := c.SetSendDeadline(deadline); err != nil {
 		return err
 	}
 	defer c.SetSendDeadline(time.Time{})
-	return c.Send(data, retry)
+	return c.send(data, retry, sleepForRetryUntil(deadline))
 }
 
 // SendRecv 写入数据并读取返回

--- a/net/tcp/send_recv_timeout_test.go
+++ b/net/tcp/send_recv_timeout_test.go
@@ -1,0 +1,124 @@
+package tcp
+
+import (
+	"errors"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+type sendRecvResult struct {
+	data []byte
+	err  error
+}
+
+func TestSendRecvWithTimeoutBoundsSendAndClearsDeadline(t *testing.T) {
+	client, peer := net.Pipe()
+	defer client.Close()
+	defer peer.Close()
+	conn := NewConnByNetConn(client)
+
+	const timeout = 10 * time.Millisecond
+	result := make(chan sendRecvResult, 1)
+	started := time.Now()
+	go func() {
+		data, err := conn.SendRecvWithTimeout([]byte("blocked"), timeout, 1, nil)
+		result <- sendRecvResult{data: data, err: err}
+	}()
+
+	var outcome sendRecvResult
+	select {
+	case outcome = <-result:
+	case <-time.After(200 * time.Millisecond):
+		// The old implementation has no write deadline. Close the peer before
+		// failing so the blocked write exits and the test leaves no goroutine.
+		_ = peer.Close()
+		outcome = <-result
+		t.Fatalf("SendRecvWithTimeout remained blocked in Send for %v: %v", time.Since(started), outcome.err)
+	}
+	if outcome.err == nil {
+		t.Fatal("SendRecvWithTimeout returned nil error while the peer read nothing")
+	}
+	var netErr net.Error
+	if !errors.As(outcome.err, &netErr) || !netErr.Timeout() {
+		t.Fatalf("SendRecvWithTimeout error = %v, want timeout error", outcome.err)
+	}
+	if !strings.Contains(outcome.err.Error(), "tcp send") {
+		t.Fatalf("SendRecvWithTimeout error = %q, want send context", outcome.err)
+	}
+	if !conn.sendTimeout.IsZero() || !conn.recvTimeout.IsZero() {
+		t.Fatalf("deadlines after SendRecvWithTimeout = (send %v, recv %v), want cleared", conn.sendTimeout, conn.recvTimeout)
+	}
+
+	peerDone := make(chan error, 1)
+	go func() {
+		request := make([]byte, 2)
+		if _, err := peer.Read(request); err != nil {
+			peerDone <- err
+			return
+		}
+		_, err := peer.Write([]byte("r"))
+		peerDone <- err
+	}()
+	response, err := conn.SendRecv([]byte("ok"), 1, nil)
+	if err != nil {
+		t.Fatalf("connection remained constrained after timeout: %v", err)
+	}
+	if string(response) != "r" {
+		t.Fatalf("response after cleared deadline = %q, want %q", response, "r")
+	}
+	if err := <-peerDone; err != nil {
+		t.Fatalf("peer exchange after cleared deadline: %v", err)
+	}
+}
+
+func TestSendRecvWithTimeoutUsesSingleBudget(t *testing.T) {
+	client, peer := net.Pipe()
+	defer client.Close()
+	defer peer.Close()
+	conn := NewConnByNetConn(client)
+
+	const (
+		timeout   = 200 * time.Millisecond
+		sendDelay = 75 * time.Millisecond
+		maxTotal  = 250 * time.Millisecond
+	)
+	peerReady := make(chan struct{})
+	requestRead := make(chan struct{})
+	releasePeer := make(chan struct{})
+	peerDone := make(chan error, 1)
+	go func() {
+		close(peerReady)
+		time.Sleep(sendDelay)
+		request := make([]byte, len("request"))
+		if _, err := peer.Read(request); err != nil {
+			peerDone <- err
+			return
+		}
+		close(requestRead)
+		<-releasePeer
+		peerDone <- nil
+	}()
+	<-peerReady
+
+	started := time.Now()
+	_, err := conn.SendRecvWithTimeout([]byte("request"), timeout, 1, nil)
+	elapsed := time.Since(started)
+	close(releasePeer)
+	if peerErr := <-peerDone; peerErr != nil {
+		t.Fatalf("peer read: %v", peerErr)
+	}
+	select {
+	case <-requestRead:
+	default:
+		t.Fatal("peer did not read request; receive-phase budget was not exercised")
+	}
+	var netErr net.Error
+	if !errors.As(err, &netErr) || !netErr.Timeout() {
+		t.Fatalf("SendRecvWithTimeout error = %v, want receive timeout", err)
+	}
+	if elapsed > maxTotal {
+		t.Fatalf("SendRecvWithTimeout took %v, want one %v budget (max %v)", elapsed, timeout, maxTotal)
+	}
+}

--- a/net/tcp/send_recv_timeout_test.go
+++ b/net/tcp/send_recv_timeout_test.go
@@ -24,6 +24,17 @@ func (c *closePeerOnDeadlineConn) SetDeadline(deadline time.Time) error {
 	if err := c.Conn.SetDeadline(deadline); err != nil {
 		return err
 	}
+	return c.closePeer(deadline)
+}
+
+func (c *closePeerOnDeadlineConn) SetWriteDeadline(deadline time.Time) error {
+	if err := c.Conn.SetWriteDeadline(deadline); err != nil {
+		return err
+	}
+	return c.closePeer(deadline)
+}
+
+func (c *closePeerOnDeadlineConn) closePeer(deadline time.Time) error {
 	if !deadline.IsZero() && !c.peerClosed {
 		c.peerClosed = true
 		return c.peer.Close()
@@ -186,6 +197,48 @@ func TestSendRecvWithTimeoutBoundsReceiveRetryWait(t *testing.T) {
 	}
 	if elapsed >= 100*time.Millisecond {
 		t.Fatalf("SendRecvWithTimeout elapsed = %v, want retry wait bounded by timeout", elapsed)
+	}
+	if retry.Count != 2 {
+		t.Fatalf("retry count after timeout = %d, want 2; retries must share one deadline", retry.Count)
+	}
+}
+
+func TestSendWithTimeoutBoundsRetryWait(t *testing.T) {
+	client, peer := net.Pipe()
+	defer client.Close()
+	defer peer.Close()
+	conn := NewConnByNetConn(&closePeerOnDeadlineConn{Conn: client, peer: peer})
+	retry := &Retry{Count: 3, Interval: 120 * time.Millisecond}
+
+	started := time.Now()
+	err := conn.SendWithTimeout([]byte("request"), 10*time.Millisecond, retry)
+	elapsed := time.Since(started)
+	if !errors.Is(err, os.ErrDeadlineExceeded) {
+		t.Fatalf("SendWithTimeout error = %v, want os.ErrDeadlineExceeded", err)
+	}
+	if elapsed >= 100*time.Millisecond {
+		t.Fatalf("SendWithTimeout elapsed = %v, want retry wait bounded by timeout", elapsed)
+	}
+	if retry.Count != 2 {
+		t.Fatalf("retry count after timeout = %d, want 2; retries must share one deadline", retry.Count)
+	}
+}
+
+func TestRecvWithTimeoutBoundsRetryWait(t *testing.T) {
+	client, peer := net.Pipe()
+	defer client.Close()
+	defer peer.Close()
+	conn := NewConnByNetConn(client)
+	retry := &Retry{Count: 3, Interval: 120 * time.Millisecond}
+
+	started := time.Now()
+	_, err := conn.RecvWithTimeout(1, 10*time.Millisecond, retry)
+	elapsed := time.Since(started)
+	if !errors.Is(err, os.ErrDeadlineExceeded) {
+		t.Fatalf("RecvWithTimeout error = %v, want os.ErrDeadlineExceeded", err)
+	}
+	if elapsed >= 100*time.Millisecond {
+		t.Fatalf("RecvWithTimeout elapsed = %v, want retry wait bounded by timeout", elapsed)
 	}
 	if retry.Count != 2 {
 		t.Fatalf("retry count after timeout = %d, want 2; retries must share one deadline", retry.Count)

--- a/net/tcp/send_recv_timeout_test.go
+++ b/net/tcp/send_recv_timeout_test.go
@@ -3,6 +3,7 @@ package tcp
 import (
 	"errors"
 	"net"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -11,6 +12,23 @@ import (
 type sendRecvResult struct {
 	data []byte
 	err  error
+}
+
+type closePeerOnDeadlineConn struct {
+	net.Conn
+	peer       net.Conn
+	peerClosed bool
+}
+
+func (c *closePeerOnDeadlineConn) SetDeadline(deadline time.Time) error {
+	if err := c.Conn.SetDeadline(deadline); err != nil {
+		return err
+	}
+	if !deadline.IsZero() && !c.peerClosed {
+		c.peerClosed = true
+		return c.peer.Close()
+	}
+	return nil
 }
 
 func TestSendRecvWithTimeoutBoundsSendAndClearsDeadline(t *testing.T) {
@@ -120,5 +138,56 @@ func TestSendRecvWithTimeoutUsesSingleBudget(t *testing.T) {
 	}
 	if elapsed > maxTotal {
 		t.Fatalf("SendRecvWithTimeout took %v, want one %v budget (max %v)", elapsed, timeout, maxTotal)
+	}
+}
+
+func TestSendRecvWithTimeoutBoundsSendRetryWait(t *testing.T) {
+	client, peer := net.Pipe()
+	defer client.Close()
+	defer peer.Close()
+	conn := NewConnByNetConn(&closePeerOnDeadlineConn{Conn: client, peer: peer})
+	retry := &Retry{Count: 3, Interval: 120 * time.Millisecond}
+
+	started := time.Now()
+	_, err := conn.SendRecvWithTimeout([]byte("request"), 10*time.Millisecond, 1, retry)
+	elapsed := time.Since(started)
+	if !errors.Is(err, os.ErrDeadlineExceeded) {
+		t.Fatalf("SendRecvWithTimeout error = %v, want os.ErrDeadlineExceeded", err)
+	}
+	if elapsed >= 100*time.Millisecond {
+		t.Fatalf("SendRecvWithTimeout elapsed = %v, want retry wait bounded by timeout", elapsed)
+	}
+	if retry.Count != 2 {
+		t.Fatalf("retry count after timeout = %d, want 2; retries must share one deadline", retry.Count)
+	}
+}
+
+func TestSendRecvWithTimeoutBoundsReceiveRetryWait(t *testing.T) {
+	client, peer := net.Pipe()
+	defer client.Close()
+	defer peer.Close()
+	conn := NewConnByNetConn(client)
+	retry := &Retry{Count: 3, Interval: 120 * time.Millisecond}
+	peerDone := make(chan error, 1)
+	go func() {
+		request := make([]byte, len("request"))
+		_, err := peer.Read(request)
+		peerDone <- err
+	}()
+
+	started := time.Now()
+	_, err := conn.SendRecvWithTimeout([]byte("request"), 10*time.Millisecond, 1, retry)
+	elapsed := time.Since(started)
+	if peerErr := <-peerDone; peerErr != nil {
+		t.Fatalf("peer read: %v", peerErr)
+	}
+	if !errors.Is(err, os.ErrDeadlineExceeded) {
+		t.Fatalf("SendRecvWithTimeout error = %v, want os.ErrDeadlineExceeded", err)
+	}
+	if elapsed >= 100*time.Millisecond {
+		t.Fatalf("SendRecvWithTimeout elapsed = %v, want retry wait bounded by timeout", elapsed)
+	}
+	if retry.Count != 2 {
+		t.Fatalf("retry count after timeout = %d, want 2; retries must share one deadline", retry.Count)
 	}
 }


### PR DESCRIPTION
## What

- Apply one absolute deadline to each `SendWithTimeout`, `RecvWithTimeout`, and `SendRecvWithTimeout` call.
- Bound retry waits by the remaining operation budget without changing ordinary `Send`, `Recv`, or `SendRecv` retry behavior.
- Clear the connection deadline before returning so the connection remains reusable.
- Add deterministic `net.Pipe` regression coverage for blocked I/O, retry waits, and the shared send/receive timeout budget.

## Why

`SendRecvWithTimeout` previously called `Send` before installing any deadline. A peer that stopped reading could therefore block the method indefinitely. The receive phase also started a fresh timeout after the send completed. Finally, all three timeout APIs used uninterruptible retry sleeps, so a 10ms timeout with a 120ms retry interval could take hundreds of milliseconds.

## How

- Set the appropriate socket deadline before I/O and pass the same absolute deadline through every retry wait.
- Clamp retry sleeps to the remaining budget and return `os.ErrDeadlineExceeded` when it expires.
- Preserve the existing send/receive error context.
- Surface any failure to set or clear the deadline, joining a clear failure with the operation error when both occur.

## Tests

- `go test -race ./net/tcp -count=20`
- `go vet ./net/tcp`
- Mutations: moving the deadline setup after `Send`, restoring raw retry sleeps, or routing any timeout API through ordinary retry waits makes its corresponding regression fail.
