### PR TITLE
fix(distributed): add durable chord delivery

### DIFF
--- a/distributed/backend/backend_db/db.go
+++ b/distributed/backend/backend_db/db.go
@@ -200,10 +200,13 @@ func (b *BackendSQLDB) ResetGroup(groupIDs ...string) error {
 // duplicate task IDs must de-duplicate first; otherwise the upsert
 // (ON CONFLICT id) cannot dedupe.
 func (b *BackendSQLDB) autoMigrate() error {
-	return b.gClient.AutoMigrate(
+	if err := b.gClient.AutoMigrate(
 		task.GroupMeta{},
 		task.Status{},
-	)
+	); err != nil {
+		return err
+	}
+	return b.migrateDurableChord()
 }
 
 // NewBackendSQLDB constructs a SQL-backed Backend. Returns nil on failure

--- a/distributed/backend/backend_db/durable_chord.go
+++ b/distributed/backend/backend_db/durable_chord.go
@@ -4,15 +4,27 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/songzhibin97/gkit/distributed/backend"
 	"github.com/songzhibin97/gkit/distributed/task"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
+	gormlogger "gorm.io/gorm/logger"
 )
 
 var _ backend.DurableChordBackend = (*BackendSQLDB)(nil)
+
+var durableChordSilentLogger = gormlogger.Default.LogMode(gormlogger.Silent)
+
+func (b *BackendSQLDB) durableDB(ctx context.Context) *gorm.DB {
+	db := b.gClient.Session(&gorm.Session{Logger: durableChordSilentLogger})
+	if ctx != nil {
+		db = db.WithContext(ctx)
+	}
+	return db
+}
 
 type chordDeliveryModel struct {
 	DeliveryKey         string     `gorm:"column:delivery_key;primaryKey;size:160"`
@@ -64,7 +76,7 @@ func (b *BackendSQLDB) RegisterChord(ctx context.Context, registration backend.C
 	}
 	delivery := backend.NewChordDelivery(registration, owner, time.Now())
 	for attempt := 0; attempt < 8; attempt++ {
-		err = b.gClient.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		err = b.durableDB(ctx).Transaction(func(tx *gorm.DB) error {
 			var existing chordDeliveryModel
 			findErr := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where("group_id = ?", registration.GroupID).First(&existing).Error
 			if findErr == nil {
@@ -101,7 +113,7 @@ func (b *BackendSQLDB) RegisterChord(ctx context.Context, registration backend.C
 		// attaching to the committed winner. If its transaction has not yet
 		// committed, retry the bounded registration operation.
 		var existing chordDeliveryModel
-		if findErr := b.gClient.WithContext(ctx).Where("group_id = ?", registration.GroupID).First(&existing).Error; findErr == nil {
+		if findErr := b.durableDB(ctx).Where("group_id = ?", registration.GroupID).First(&existing).Error; findErr == nil {
 			var current backend.ChordDelivery
 			if decodeErr := json.Unmarshal(existing.Record, &current); decodeErr != nil {
 				return backend.ChordRegistrationRef{}, decodeErr
@@ -112,7 +124,7 @@ func (b *BackendSQLDB) RegisterChord(ctx context.Context, registration backend.C
 			return backend.ChordRegistrationRef{DeliveryKey: current.DeliveryKey, Owner: current.RegistrationOwner, Version: current.RegistrationVersion, Created: false}, nil
 		}
 		if attempt == 7 {
-			return backend.ChordRegistrationRef{}, err
+			return backend.ChordRegistrationRef{}, fmt.Errorf("register sql chord: %w", err)
 		}
 		timer := time.NewTimer(time.Duration(attempt+1) * 2 * time.Millisecond)
 		select {
@@ -135,7 +147,7 @@ func (b *BackendSQLDB) AbortRegistration(ctx context.Context, ref backend.ChordR
 	if !ref.Created {
 		return backend.ErrChordRegistrationOwnershipLost
 	}
-	return b.gClient.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	err := b.durableDB(ctx).Transaction(func(tx *gorm.DB) error {
 		var model chordDeliveryModel
 		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where("delivery_key = ?", ref.DeliveryKey).First(&model).Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -161,6 +173,10 @@ func (b *BackendSQLDB) AbortRegistration(ctx context.Context, ref backend.ChordR
 		}
 		return tx.Where("delivery_key = ?", ref.DeliveryKey).Delete(&chordDeliveryModel{}).Error
 	})
+	if err != nil {
+		return fmt.Errorf("abort sql chord registration: %w", err)
+	}
+	return nil
 }
 
 func (b *BackendSQLDB) ClaimMemberPublication(ctx context.Context, claim backend.ChordMemberClaim) (lease backend.ChordMemberLease, claimed bool, err error) {
@@ -196,7 +212,7 @@ func (b *BackendSQLDB) ScanChordDeliveries(ctx context.Context, scan backend.Cho
 	if limit <= 0 {
 		limit = 100
 	}
-	query := b.gClient.WithContext(ctx).Order("delivery_key ASC").Limit(limit + 1)
+	query := b.durableDB(ctx).Order("delivery_key ASC").Limit(limit + 1)
 	if scan.Cursor != "" {
 		query = query.Where("delivery_key > ?", scan.Cursor)
 	}
@@ -233,7 +249,7 @@ func (b *BackendSQLDB) ReconcileChord(ctx context.Context, deliveryKey string) e
 	if !needsSetup {
 		return nil
 	}
-	if err := b.gClient.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	if err := b.durableDB(ctx).Transaction(func(tx *gorm.DB) error {
 		ids := make([]string, len(delivery.Members))
 		for index := range delivery.Members {
 			ids[index] = delivery.Members[index].TaskID
@@ -304,7 +320,7 @@ func (b *BackendSQLDB) ClaimCallbackPublication(ctx context.Context, claim backe
 		if err := json.Unmarshal(delivery.CallbackPayload, &callback); err != nil {
 			return lease, false, err
 		}
-		if err := b.gClient.WithContext(ctx).Clauses(clause.OnConflict{DoNothing: true}).Create(task.NewPendingState(&callback)).Error; err != nil {
+		if err := b.durableDB(ctx).Clauses(clause.OnConflict{DoNothing: true}).Create(task.NewPendingState(&callback)).Error; err != nil {
 			return lease, false, err
 		}
 	}
@@ -340,7 +356,7 @@ func (b *BackendSQLDB) CleanupTerminalChordDeliveries(ctx context.Context, now t
 		limit = 100
 	}
 	var keys []string
-	if err := b.gClient.WithContext(ctx).Model(&chordDeliveryModel{}).
+	if err := b.durableDB(ctx).Model(&chordDeliveryModel{}).
 		Where("terminal_expire_at IS NOT NULL AND terminal_expire_at <= ?", now).
 		Order("terminal_expire_at ASC").Limit(limit).Pluck("delivery_key", &keys).Error; err != nil {
 		return 0, err
@@ -348,7 +364,7 @@ func (b *BackendSQLDB) CleanupTerminalChordDeliveries(ctx context.Context, now t
 	if len(keys) == 0 {
 		return 0, nil
 	}
-	err := b.gClient.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	err := b.durableDB(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.Where("delivery_key IN ?", keys).Delete(&chordMemberReceiptModel{}).Error; err != nil {
 			return err
 		}
@@ -362,7 +378,7 @@ func (b *BackendSQLDB) CleanupTerminalChordDeliveries(ctx context.Context, now t
 
 func (b *BackendSQLDB) getChordDelivery(ctx context.Context, deliveryKey string) (*backend.ChordDelivery, error) {
 	var model chordDeliveryModel
-	if err := b.gClient.WithContext(ctx).Where("delivery_key = ?", deliveryKey).First(&model).Error; err != nil {
+	if err := b.durableDB(ctx).Where("delivery_key = ?", deliveryKey).First(&model).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, backend.ErrChordNotFound
 		}
@@ -378,7 +394,7 @@ func (b *BackendSQLDB) getChordDelivery(ctx context.Context, deliveryKey string)
 func (b *BackendSQLDB) updateChordDelivery(ctx context.Context, deliveryKey string, mutate func(*backend.ChordDelivery) (bool, error)) error {
 	for attempt := 0; attempt < 16; attempt++ {
 		retry := false
-		err := b.gClient.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		err := b.durableDB(ctx).Transaction(func(tx *gorm.DB) error {
 			var model chordDeliveryModel
 			if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where("delivery_key = ?", deliveryKey).First(&model).Error; err != nil {
 				if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -418,7 +434,7 @@ func (b *BackendSQLDB) updateChordDelivery(ctx context.Context, deliveryKey stri
 			return syncChordMemberRows(tx, &delivery)
 		})
 		if err != nil {
-			return err
+			return fmt.Errorf("update sql chord delivery: %w", err)
 		}
 		if !retry {
 			return nil
@@ -493,5 +509,5 @@ func syncChordMemberRows(tx *gorm.DB, delivery *backend.ChordDelivery) error {
 }
 
 func (b *BackendSQLDB) migrateDurableChord() error {
-	return b.gClient.AutoMigrate(&chordDeliveryModel{}, &chordMemberPublicationModel{}, &chordMemberReceiptModel{})
+	return b.durableDB(nil).AutoMigrate(&chordDeliveryModel{}, &chordMemberPublicationModel{}, &chordMemberReceiptModel{})
 }

--- a/distributed/backend/backend_db/durable_chord.go
+++ b/distributed/backend/backend_db/durable_chord.go
@@ -1,0 +1,497 @@
+package backend_db
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/songzhibin97/gkit/distributed/backend"
+	"github.com/songzhibin97/gkit/distributed/task"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+var _ backend.DurableChordBackend = (*BackendSQLDB)(nil)
+
+type chordDeliveryModel struct {
+	DeliveryKey         string     `gorm:"column:delivery_key;primaryKey;size:160"`
+	GroupID             string     `gorm:"column:group_id;uniqueIndex:uq_chord_delivery_group;size:255"`
+	DefinitionHash      string     `gorm:"column:definition_hash;size:64;not null"`
+	RegistrationOwner   string     `gorm:"column:registration_owner;size:64;not null"`
+	RegistrationVersion int64      `gorm:"column:registration_version;not null"`
+	Version             int64      `gorm:"column:version;not null"`
+	State               string     `gorm:"column:state;index:idx_chord_delivery_state;size:32;not null"`
+	TerminalAt          *time.Time `gorm:"column:terminal_at"`
+	TerminalExpireAt    *time.Time `gorm:"column:terminal_expire_at;index:idx_chord_terminal_expire"`
+	Record              []byte     `gorm:"column:record;not null"`
+}
+
+func (chordDeliveryModel) TableName() string { return "chord_deliveries" }
+
+type chordMemberPublicationModel struct {
+	ID          uint       `gorm:"primaryKey"`
+	DeliveryKey string     `gorm:"column:delivery_key;uniqueIndex:uq_chord_member_publication,priority:1;index;size:160"`
+	Ordinal     int        `gorm:"column:ordinal;uniqueIndex:uq_chord_member_publication,priority:2"`
+	TaskID      string     `gorm:"column:task_id;size:255;not null"`
+	Payload     []byte     `gorm:"column:payload;not null"`
+	State       string     `gorm:"column:state;index:idx_chord_member_state;size:32;not null"`
+	Version     int64      `gorm:"column:version;not null"`
+	LeaseOwner  string     `gorm:"column:lease_owner;size:64"`
+	LeaseExpiry *time.Time `gorm:"column:lease_expiry"`
+}
+
+func (chordMemberPublicationModel) TableName() string { return "chord_member_publications" }
+
+type chordMemberReceiptModel struct {
+	ID          uint   `gorm:"primaryKey"`
+	DeliveryKey string `gorm:"column:delivery_key;uniqueIndex:uq_chord_member_receipt,priority:1;index;size:160"`
+	Ordinal     int    `gorm:"column:ordinal;uniqueIndex:uq_chord_member_receipt,priority:2"`
+	TaskID      string `gorm:"column:task_id;size:255;not null"`
+	Outcome     string `gorm:"column:outcome;size:16;not null"`
+	Results     []byte `gorm:"column:results"`
+}
+
+func (chordMemberReceiptModel) TableName() string { return "chord_member_receipts" }
+
+func (b *BackendSQLDB) RegisterChord(ctx context.Context, registration backend.ChordRegistration) (backend.ChordRegistrationRef, error) {
+	if err := backend.FinalizeChordRegistration(&registration); err != nil {
+		return backend.ChordRegistrationRef{}, err
+	}
+	owner, err := backend.NewChordOwner()
+	if err != nil {
+		return backend.ChordRegistrationRef{}, err
+	}
+	delivery := backend.NewChordDelivery(registration, owner, time.Now())
+	for attempt := 0; attempt < 8; attempt++ {
+		err = b.gClient.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+			var existing chordDeliveryModel
+			findErr := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where("group_id = ?", registration.GroupID).First(&existing).Error
+			if findErr == nil {
+				var current backend.ChordDelivery
+				if err := json.Unmarshal(existing.Record, &current); err != nil {
+					return err
+				}
+				if !backend.ChordRegistrationMatches(&current, registration) {
+					return backend.ErrChordRegistrationConflict
+				}
+				delivery = current
+				return nil
+			}
+			if !errors.Is(findErr, gorm.ErrRecordNotFound) {
+				return findErr
+			}
+			model, err := makeChordDeliveryModel(&delivery)
+			if err != nil {
+				return err
+			}
+			if err := tx.Create(&model).Error; err != nil {
+				return err
+			}
+			return syncChordMemberRows(tx, &delivery)
+		})
+		if err == nil {
+			break
+		}
+		if errors.Is(err, backend.ErrChordRegistrationConflict) {
+			return backend.ChordRegistrationRef{}, err
+		}
+		// A concurrent identical registration can win the unique group-ID
+		// insert after our initial missing-row read. Resolve that race by
+		// attaching to the committed winner. If its transaction has not yet
+		// committed, retry the bounded registration operation.
+		var existing chordDeliveryModel
+		if findErr := b.gClient.WithContext(ctx).Where("group_id = ?", registration.GroupID).First(&existing).Error; findErr == nil {
+			var current backend.ChordDelivery
+			if decodeErr := json.Unmarshal(existing.Record, &current); decodeErr != nil {
+				return backend.ChordRegistrationRef{}, decodeErr
+			}
+			if !backend.ChordRegistrationMatches(&current, registration) {
+				return backend.ChordRegistrationRef{}, backend.ErrChordRegistrationConflict
+			}
+			return backend.ChordRegistrationRef{DeliveryKey: current.DeliveryKey, Owner: current.RegistrationOwner, Version: current.RegistrationVersion, Created: false}, nil
+		}
+		if attempt == 7 {
+			return backend.ChordRegistrationRef{}, err
+		}
+		timer := time.NewTimer(time.Duration(attempt+1) * 2 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return backend.ChordRegistrationRef{}, ctx.Err()
+		case <-timer.C:
+		}
+	}
+	created := delivery.RegistrationOwner == owner
+	return backend.ChordRegistrationRef{DeliveryKey: delivery.DeliveryKey, Owner: delivery.RegistrationOwner, Version: delivery.RegistrationVersion, Created: created}, nil
+}
+
+func (b *BackendSQLDB) AbortRegistration(ctx context.Context, ref backend.ChordRegistrationRef) error {
+	if !ref.Created {
+		return backend.ErrChordRegistrationOwnershipLost
+	}
+	return b.gClient.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var model chordDeliveryModel
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where("delivery_key = ?", ref.DeliveryKey).First(&model).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil
+			}
+			return err
+		}
+		var delivery backend.ChordDelivery
+		if err := json.Unmarshal(model.Record, &delivery); err != nil {
+			return err
+		}
+		if delivery.RegistrationOwner != ref.Owner || delivery.RegistrationVersion != ref.Version {
+			return backend.ErrChordRegistrationOwnershipLost
+		}
+		if delivery.MemberPublicationStarted {
+			return backend.ErrChordPublicationStarted
+		}
+		if err := tx.Where("delivery_key = ?", ref.DeliveryKey).Delete(&chordMemberReceiptModel{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("delivery_key = ?", ref.DeliveryKey).Delete(&chordMemberPublicationModel{}).Error; err != nil {
+			return err
+		}
+		return tx.Where("delivery_key = ?", ref.DeliveryKey).Delete(&chordDeliveryModel{}).Error
+	})
+}
+
+func (b *BackendSQLDB) ClaimMemberPublication(ctx context.Context, claim backend.ChordMemberClaim) (lease backend.ChordMemberLease, claimed bool, err error) {
+	err = b.updateChordDelivery(ctx, claim.DeliveryKey, func(delivery *backend.ChordDelivery) (bool, error) {
+		var transitionErr error
+		lease, claimed, transitionErr = backend.ClaimChordMember(delivery, claim)
+		return claimed, transitionErr
+	})
+	return lease, claimed, err
+}
+
+func (b *BackendSQLDB) RecordMemberPublishOutcome(ctx context.Context, lease backend.ChordMemberLease, outcome backend.ChordPublishOutcome) error {
+	return b.updateChordDelivery(ctx, lease.DeliveryKey, func(delivery *backend.ChordDelivery) (bool, error) {
+		if err := backend.ApplyChordMemberPublishOutcome(delivery, lease, outcome); err != nil {
+			return false, err
+		}
+		return true, nil
+	})
+}
+
+func (b *BackendSQLDB) RecordMemberTerminal(ctx context.Context, deliveryKey string, ordinal int, taskID string, outcome backend.MemberTerminalOutcome, results []*task.Result) error {
+	return b.updateChordDelivery(ctx, deliveryKey, func(delivery *backend.ChordDelivery) (bool, error) {
+		before := delivery.Version
+		if err := backend.ApplyChordMemberTerminal(delivery, ordinal, taskID, outcome, results, time.Now()); err != nil {
+			return false, err
+		}
+		return delivery.Version != before, nil
+	})
+}
+
+func (b *BackendSQLDB) ScanChordDeliveries(ctx context.Context, scan backend.ChordScan) (backend.ChordDeliveryPage, error) {
+	limit := scan.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+	query := b.gClient.WithContext(ctx).Order("delivery_key ASC").Limit(limit + 1)
+	if scan.Cursor != "" {
+		query = query.Where("delivery_key > ?", scan.Cursor)
+	}
+	var models []chordDeliveryModel
+	if err := query.Find(&models).Error; err != nil {
+		return backend.ChordDeliveryPage{}, err
+	}
+	page := backend.ChordDeliveryPage{}
+	for _, model := range models {
+		var delivery backend.ChordDelivery
+		if err := json.Unmarshal(model.Record, &delivery); err != nil {
+			return backend.ChordDeliveryPage{}, err
+		}
+		page.Deliveries = append(page.Deliveries, delivery)
+	}
+	if len(page.Deliveries) > limit {
+		page.Deliveries = page.Deliveries[:limit]
+		page.NextCursor = page.Deliveries[len(page.Deliveries)-1].DeliveryKey
+	}
+	return page, nil
+}
+
+func (b *BackendSQLDB) ReconcileChord(ctx context.Context, deliveryKey string) error {
+	delivery, err := b.getChordDelivery(ctx, deliveryKey)
+	if err != nil {
+		return err
+	}
+	needsSetup := false
+	for index := range delivery.Members {
+		if delivery.Members[index].State == backend.ChordMemberSetup {
+			needsSetup = true
+		}
+	}
+	if !needsSetup {
+		return nil
+	}
+	if err := b.gClient.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		ids := make([]string, len(delivery.Members))
+		for index := range delivery.Members {
+			ids[index] = delivery.Members[index].TaskID
+		}
+		var group task.GroupMeta
+		groupErr := tx.Where("id = ?", delivery.GroupID).First(&group).Error
+		if errors.Is(groupErr, gorm.ErrRecordNotFound) {
+			group = *task.InitGroupMeta(delivery.GroupID, delivery.GroupName, b.resultExpire, ids...)
+			if err := tx.Create(&group).Error; err != nil {
+				return err
+			}
+		} else if groupErr != nil {
+			return groupErr
+		} else if !sameChordStrings([]string(group.TaskIDs), ids) {
+			return backend.ErrChordRegistrationConflict
+		}
+		for index := range delivery.Members {
+			var signature task.Signature
+			if err := json.Unmarshal(delivery.Members[index].Payload, &signature); err != nil {
+				return err
+			}
+			var existing task.Status
+			statusErr := tx.Where("id = ?", signature.ID).First(&existing).Error
+			if errors.Is(statusErr, gorm.ErrRecordNotFound) {
+				if err := tx.Create(task.NewPendingState(&signature)).Error; err != nil {
+					return err
+				}
+			} else if statusErr != nil {
+				return statusErr
+			} else if existing.GroupID != delivery.GroupID {
+				return backend.ErrChordRegistrationConflict
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+	// State publication is intentionally done after setup transaction commits.
+	return b.markChordMembersReady(ctx, deliveryKey)
+}
+
+func sameChordStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func (b *BackendSQLDB) markChordMembersReady(ctx context.Context, deliveryKey string) error {
+	return b.updateChordDelivery(ctx, deliveryKey, func(delivery *backend.ChordDelivery) (bool, error) {
+		backend.PrepareChordMembers(delivery, time.Now())
+		return true, nil
+	})
+}
+
+func (b *BackendSQLDB) ClaimCallbackPublication(ctx context.Context, claim backend.ChordCallbackClaim) (lease backend.ChordCallbackLease, claimed bool, err error) {
+	delivery, err := b.getChordDelivery(ctx, claim.DeliveryKey)
+	if err != nil {
+		return lease, false, err
+	}
+	if len(delivery.CallbackPayload) > 0 {
+		var callback task.Signature
+		if err := json.Unmarshal(delivery.CallbackPayload, &callback); err != nil {
+			return lease, false, err
+		}
+		if err := b.gClient.WithContext(ctx).Clauses(clause.OnConflict{DoNothing: true}).Create(task.NewPendingState(&callback)).Error; err != nil {
+			return lease, false, err
+		}
+	}
+	err = b.updateChordDelivery(ctx, claim.DeliveryKey, func(current *backend.ChordDelivery) (bool, error) {
+		var transitionErr error
+		lease, claimed, transitionErr = backend.ClaimChordCallback(current, claim)
+		return claimed, transitionErr
+	})
+	return lease, claimed, err
+}
+
+func (b *BackendSQLDB) RecordCallbackPublishOutcome(ctx context.Context, lease backend.ChordCallbackLease, outcome backend.ChordPublishOutcome) error {
+	return b.updateChordDelivery(ctx, lease.DeliveryKey, func(delivery *backend.ChordDelivery) (bool, error) {
+		if err := backend.ApplyChordCallbackPublishOutcome(delivery, lease, outcome); err != nil {
+			return false, err
+		}
+		return true, nil
+	})
+}
+
+func (b *BackendSQLDB) RecordCallbackTerminal(ctx context.Context, deliveryKey string, outcome backend.CallbackTerminalOutcome) error {
+	return b.updateChordDelivery(ctx, deliveryKey, func(delivery *backend.ChordDelivery) (bool, error) {
+		before := delivery.Version
+		if err := backend.ApplyChordCallbackTerminal(delivery, outcome, time.Now()); err != nil {
+			return false, err
+		}
+		return delivery.Version != before, nil
+	})
+}
+
+func (b *BackendSQLDB) CleanupTerminalChordDeliveries(ctx context.Context, now time.Time, limit int) (int, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	var keys []string
+	if err := b.gClient.WithContext(ctx).Model(&chordDeliveryModel{}).
+		Where("terminal_expire_at IS NOT NULL AND terminal_expire_at <= ?", now).
+		Order("terminal_expire_at ASC").Limit(limit).Pluck("delivery_key", &keys).Error; err != nil {
+		return 0, err
+	}
+	if len(keys) == 0 {
+		return 0, nil
+	}
+	err := b.gClient.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("delivery_key IN ?", keys).Delete(&chordMemberReceiptModel{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("delivery_key IN ?", keys).Delete(&chordMemberPublicationModel{}).Error; err != nil {
+			return err
+		}
+		return tx.Where("delivery_key IN ?", keys).Delete(&chordDeliveryModel{}).Error
+	})
+	return len(keys), err
+}
+
+func (b *BackendSQLDB) getChordDelivery(ctx context.Context, deliveryKey string) (*backend.ChordDelivery, error) {
+	var model chordDeliveryModel
+	if err := b.gClient.WithContext(ctx).Where("delivery_key = ?", deliveryKey).First(&model).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, backend.ErrChordNotFound
+		}
+		return nil, err
+	}
+	var delivery backend.ChordDelivery
+	if err := json.Unmarshal(model.Record, &delivery); err != nil {
+		return nil, err
+	}
+	return &delivery, nil
+}
+
+func (b *BackendSQLDB) updateChordDelivery(ctx context.Context, deliveryKey string, mutate func(*backend.ChordDelivery) (bool, error)) error {
+	for attempt := 0; attempt < 16; attempt++ {
+		retry := false
+		err := b.gClient.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+			var model chordDeliveryModel
+			if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where("delivery_key = ?", deliveryKey).First(&model).Error; err != nil {
+				if errors.Is(err, gorm.ErrRecordNotFound) {
+					return backend.ErrChordNotFound
+				}
+				return err
+			}
+			var delivery backend.ChordDelivery
+			if err := json.Unmarshal(model.Record, &delivery); err != nil {
+				return err
+			}
+			changed, err := mutate(&delivery)
+			if err != nil || !changed {
+				return err
+			}
+			updated, err := makeChordDeliveryModel(&delivery)
+			if err != nil {
+				return err
+			}
+			result := tx.Model(&chordDeliveryModel{}).Where("delivery_key = ? AND version = ?", deliveryKey, model.Version).Updates(map[string]interface{}{
+				"definition_hash":      updated.DefinitionHash,
+				"registration_owner":   updated.RegistrationOwner,
+				"registration_version": updated.RegistrationVersion,
+				"version":              updated.Version,
+				"state":                updated.State,
+				"terminal_at":          updated.TerminalAt,
+				"terminal_expire_at":   updated.TerminalExpireAt,
+				"record":               updated.Record,
+			})
+			if result.Error != nil {
+				return result.Error
+			}
+			if result.RowsAffected != 1 {
+				retry = true
+				return nil
+			}
+			return syncChordMemberRows(tx, &delivery)
+		})
+		if err != nil {
+			return err
+		}
+		if !retry {
+			return nil
+		}
+	}
+	return errors.New("sql chord CAS exhausted")
+}
+
+func makeChordDeliveryModel(delivery *backend.ChordDelivery) (chordDeliveryModel, error) {
+	body, err := json.Marshal(delivery)
+	if err != nil {
+		return chordDeliveryModel{}, err
+	}
+	var terminalAt *time.Time
+	if !delivery.TerminalAt.IsZero() {
+		value := delivery.TerminalAt
+		terminalAt = &value
+	}
+	return chordDeliveryModel{
+		DeliveryKey:         delivery.DeliveryKey,
+		GroupID:             delivery.GroupID,
+		DefinitionHash:      delivery.DefinitionHash,
+		RegistrationOwner:   delivery.RegistrationOwner,
+		RegistrationVersion: delivery.RegistrationVersion,
+		Version:             delivery.Version,
+		State:               string(delivery.CallbackState),
+		TerminalAt:          terminalAt,
+		TerminalExpireAt:    delivery.TerminalExpireAt,
+		Record:              body,
+	}, nil
+}
+
+func syncChordMemberRows(tx *gorm.DB, delivery *backend.ChordDelivery) error {
+	for index := range delivery.Members {
+		member := &delivery.Members[index]
+		var leaseExpiry *time.Time
+		if !member.LeaseExpiresAt.IsZero() {
+			value := member.LeaseExpiresAt
+			leaseExpiry = &value
+		}
+		publication := chordMemberPublicationModel{
+			DeliveryKey: delivery.DeliveryKey,
+			Ordinal:     member.Ordinal,
+			TaskID:      member.TaskID,
+			Payload:     member.Payload,
+			State:       string(member.State),
+			Version:     member.Version,
+			LeaseOwner:  member.LeaseOwner,
+			LeaseExpiry: leaseExpiry,
+		}
+		if err := tx.Clauses(clause.OnConflict{
+			Columns:   []clause.Column{{Name: "delivery_key"}, {Name: "ordinal"}},
+			DoUpdates: clause.AssignmentColumns([]string{"task_id", "payload", "state", "version", "lease_owner", "lease_expiry"}),
+		}).Create(&publication).Error; err != nil {
+			return err
+		}
+		if member.Receipt != nil {
+			results, err := json.Marshal(member.Receipt.Results)
+			if err != nil {
+				return err
+			}
+			receipt := chordMemberReceiptModel{DeliveryKey: delivery.DeliveryKey, Ordinal: member.Ordinal, TaskID: member.TaskID, Outcome: string(member.Receipt.Outcome), Results: results}
+			if err := tx.Clauses(clause.OnConflict{
+				Columns:   []clause.Column{{Name: "delivery_key"}, {Name: "ordinal"}},
+				DoUpdates: clause.AssignmentColumns([]string{"task_id", "outcome", "results"}),
+			}).Create(&receipt).Error; err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (b *BackendSQLDB) migrateDurableChord() error {
+	return b.gClient.AutoMigrate(&chordDeliveryModel{}, &chordMemberPublicationModel{}, &chordMemberReceiptModel{})
+}

--- a/distributed/backend/backend_db/durable_chord_contract_regression_test.go
+++ b/distributed/backend/backend_db/durable_chord_contract_regression_test.go
@@ -1,0 +1,53 @@
+package backend_db
+
+import (
+	"database/sql"
+	"os"
+	"testing"
+
+	"github.com/glebarez/sqlite"
+	"github.com/songzhibin97/gkit/distributed/backend/chordtest"
+	"gorm.io/gorm"
+)
+
+func TestDurableChordContract(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend := &BackendSQLDB{gClient: db, resultExpire: -1}
+	if err := backend.autoMigrate(); err != nil {
+		t.Fatal(err)
+	}
+	chordtest.Run(t, backend)
+}
+
+func TestDurableChordContractLiveSQL(t *testing.T) {
+	tests := []struct {
+		name   string
+		driver string
+		dbType string
+		env    string
+	}{
+		{name: "mysql", driver: "mysql", dbType: "mysql", env: "GKIT_MYSQL_DSN"},
+		{name: "postgres", driver: "pgx", dbType: "pgsql", env: "GKIT_POSTGRES_DSN"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dsn := os.Getenv(tt.env)
+			if dsn == "" {
+				t.Skip(tt.env + " is required for live durable chord contract")
+			}
+			db, err := sql.Open(tt.driver, dsn)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = db.Close() })
+			value, err := NewBackendSQLDBE(db, -1, tt.dbType, &gorm.Config{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			chordtest.Run(t, value.(*BackendSQLDB))
+		})
+	}
+}

--- a/distributed/backend/backend_db/durable_chord_logging_regression_test.go
+++ b/distributed/backend/backend_db/durable_chord_logging_regression_test.go
@@ -1,0 +1,209 @@
+package backend_db
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	stdlog "log"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/glebarez/sqlite"
+	"github.com/songzhibin97/gkit/distributed/backend"
+	"github.com/songzhibin97/gkit/distributed/task"
+	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
+)
+
+const issue104LoggingSecret = "synthetic-secret-token-issue104"
+
+func TestDurableChordSQLFailureDoesNotLogPayloads(t *testing.T) {
+	var captured bytes.Buffer
+	logConfig := gormlogger.Config{LogLevel: gormlogger.Info, Colorful: false, ParameterizedQueries: false}
+	db, err := gorm.Open(sqlite.Open(fmt.Sprintf("file:issue104-log-%d?mode=memory&cache=shared", time.Now().UnixNano())), &gorm.Config{
+		Logger: gormlogger.New(stdlog.New(&captured, "", 0), logConfig),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := &BackendSQLDB{gClient: db, resultExpire: -1}
+	if err := b.autoMigrate(); err != nil {
+		t.Fatal(err)
+	}
+	assertDurableSQLFailureDoesNotLogPayloads(t, b, &captured, "sqlite")
+}
+
+func TestDurableChordSQLFailureDoesNotLogPayloadsLive(t *testing.T) {
+	tests := []struct {
+		name   string
+		driver string
+		dbType string
+		env    string
+	}{
+		{name: "mysql", driver: "mysql", dbType: "mysql", env: "GKIT_MYSQL_DSN"},
+		{name: "postgres", driver: "pgx", dbType: "pgsql", env: "GKIT_POSTGRES_DSN"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dsn := os.Getenv(tc.env)
+			if dsn == "" {
+				t.Skip(tc.env + " is required for live durable logging test")
+			}
+			sqlDB, err := sql.Open(tc.driver, dsn)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = sqlDB.Close() })
+			var captured bytes.Buffer
+			logConfig := gormlogger.Config{LogLevel: gormlogger.Info, Colorful: false, ParameterizedQueries: false}
+			value, err := NewBackendSQLDBE(sqlDB, -1, tc.dbType, &gorm.Config{
+				Logger: gormlogger.New(stdlog.New(&captured, "", 0), logConfig),
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertDurableSQLFailureDoesNotLogPayloads(t, value.(*BackendSQLDB), &captured, tc.name)
+		})
+	}
+}
+
+func assertDurableSQLFailureDoesNotLogPayloads(t *testing.T, b *BackendSQLDB, captured *bytes.Buffer, dialect string) {
+	t.Helper()
+	registration, artifacts := issue104SensitiveRegistration(t, fmt.Sprintf("logging-%s-%d", dialect, time.Now().UnixNano()))
+	ref, err := b.RegisterChord(context.Background(), registration)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := b.ReconcileChord(context.Background(), ref.DeliveryKey); err != nil {
+		t.Fatal(err)
+	}
+	lease, claimed, err := b.ClaimMemberPublication(context.Background(), backend.ChordMemberClaim{
+		DeliveryKey: ref.DeliveryKey,
+		Ordinal:     0,
+		Owner:       "logging-owner",
+		Now:         time.Now(),
+	})
+	if err != nil || !claimed {
+		t.Fatalf("member claim = %t, %v", claimed, err)
+	}
+	removeTrigger := installIssue104FailingUpdateTrigger(t, b, dialect)
+	t.Cleanup(removeTrigger)
+	captured.Reset()
+	forcedErr := b.RecordMemberPublishOutcome(context.Background(), lease, backend.ChordPublishOutcome{
+		Kind:  backend.ChordPublishOutcomeUnknown,
+		Now:   time.Now(),
+		Error: issue104LoggingSecret + ":" + artifacts.rawMember,
+	})
+	if forcedErr == nil || !strings.Contains(forcedErr.Error(), "forced durable update failure") {
+		t.Fatalf("RecordMemberPublishOutcome error = %v, want observable forced failure", forcedErr)
+	}
+	logs := captured.String()
+	for _, forbidden := range []string{
+		issue104LoggingSecret,
+		artifacts.rawMember,
+		artifacts.rawCallback,
+		artifacts.memberBase64,
+		artifacts.callbackBase64,
+		"private-arg-value",
+		"private-meta-value",
+	} {
+		if strings.Contains(logs, forbidden) {
+			t.Fatalf("captured GORM logger leaked %q in %q", forbidden, logs)
+		}
+	}
+	if !strings.Contains(forcedErr.Error(), "update sql chord delivery") {
+		t.Fatalf("RecordMemberPublishOutcome error lacks operation context: %v", forcedErr)
+	}
+}
+
+func installIssue104FailingUpdateTrigger(t *testing.T, b *BackendSQLDB, dialect string) func() {
+	t.Helper()
+	const trigger = "gkit_issue104_fail_chord_update"
+	switch dialect {
+	case "sqlite":
+		if err := b.gClient.Exec("DROP TRIGGER IF EXISTS " + trigger).Error; err != nil {
+			t.Fatal(err)
+		}
+		if err := b.gClient.Exec("CREATE TRIGGER " + trigger + " BEFORE UPDATE ON chord_deliveries BEGIN SELECT RAISE(FAIL, 'forced durable update failure'); END").Error; err != nil {
+			t.Fatal(err)
+		}
+		return func() { _ = b.gClient.Exec("DROP TRIGGER IF EXISTS " + trigger).Error }
+	case "mysql":
+		if err := b.gClient.Exec("DROP TRIGGER IF EXISTS " + trigger).Error; err != nil {
+			t.Fatal(err)
+		}
+		if err := b.gClient.Exec("CREATE TRIGGER " + trigger + " BEFORE UPDATE ON chord_deliveries FOR EACH ROW SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'forced durable update failure'").Error; err != nil {
+			t.Fatal(err)
+		}
+		return func() { _ = b.gClient.Exec("DROP TRIGGER IF EXISTS " + trigger).Error }
+	case "postgres":
+		if err := b.gClient.Exec("DROP TRIGGER IF EXISTS " + trigger + " ON chord_deliveries").Error; err != nil {
+			t.Fatal(err)
+		}
+		if err := b.gClient.Exec("CREATE OR REPLACE FUNCTION gkit_issue104_fail_chord_update_fn() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'forced durable update failure'; END $$").Error; err != nil {
+			t.Fatal(err)
+		}
+		if err := b.gClient.Exec("CREATE TRIGGER " + trigger + " BEFORE UPDATE ON chord_deliveries FOR EACH ROW EXECUTE FUNCTION gkit_issue104_fail_chord_update_fn()").Error; err != nil {
+			t.Fatal(err)
+		}
+		return func() {
+			_ = b.gClient.Exec("DROP TRIGGER IF EXISTS " + trigger + " ON chord_deliveries").Error
+			_ = b.gClient.Exec("DROP FUNCTION IF EXISTS gkit_issue104_fail_chord_update_fn()").Error
+		}
+	default:
+		t.Fatalf("unsupported trigger dialect %q", dialect)
+		return func() {}
+	}
+}
+
+type issue104SensitiveArtifacts struct {
+	rawMember      string
+	rawCallback    string
+	memberBase64   string
+	callbackBase64 string
+}
+
+func issue104SensitiveRegistration(t *testing.T, groupID string) (backend.ChordRegistration, issue104SensitiveArtifacts) {
+	t.Helper()
+	deliveryKey := backend.ChordDeliveryKey(groupID, "logging-callback")
+	callback := task.NewSignature("logging-callback", "callback")
+	callback.Args = []task.Arg{{Type: "string", Value: "private-arg-value"}}
+	callback.Meta.Set("private-meta", "private-meta-value")
+	callback.Meta.Set(backend.DurableChordDeliveryKeyMeta, deliveryKey)
+	callbackPayload, err := json.Marshal(callback)
+	if err != nil {
+		t.Fatal(err)
+	}
+	member := task.NewSignature(groupID+"-member", "member")
+	member.GroupID = groupID
+	member.Args = []task.Arg{{Type: "string", Value: "private-arg-value"}}
+	member.Meta.Set("private-meta", "private-meta-value")
+	member.Meta.Set(backend.DurableChordDeliveryKeyMeta, deliveryKey)
+	member.Meta.Set(backend.DurableChordMemberMeta, true)
+	member.Meta.Set(backend.DurableChordMemberOrdinal, 0)
+	memberPayload, err := json.Marshal(member)
+	if err != nil {
+		t.Fatal(err)
+	}
+	registration := backend.ChordRegistration{
+		GroupID:   groupID,
+		GroupName: "logging-group",
+		Retention: -1,
+		Callback:  callbackPayload,
+		Members:   []backend.ChordMemberRegistration{{Ordinal: 0, TaskID: member.ID, Payload: memberPayload}},
+	}
+	if err := backend.FinalizeChordRegistration(&registration); err != nil {
+		t.Fatal(err)
+	}
+	return registration, issue104SensitiveArtifacts{
+		rawMember:      string(memberPayload),
+		rawCallback:    string(callbackPayload),
+		memberBase64:   base64.StdEncoding.EncodeToString(memberPayload),
+		callbackBase64: base64.StdEncoding.EncodeToString(callbackPayload),
+	}
+}

--- a/distributed/backend/backend_db/durable_chord_schema_regression_test.go
+++ b/distributed/backend/backend_db/durable_chord_schema_regression_test.go
@@ -1,0 +1,107 @@
+package backend_db
+
+import (
+	"database/sql"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/songzhibin97/gkit/distributed/task"
+	"gorm.io/gorm"
+	"gorm.io/gorm/schema"
+)
+
+func TestDurableChordCurrentMasterSchemaContract(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		model     interface{}
+		field     string
+		indexName string
+	}{
+		{name: "group", model: &task.GroupMeta{}, field: "GroupID", indexName: "uq_group_meta_group_id"},
+		{name: "status", model: &task.Status{}, field: "TaskID", indexName: "uq_status_task_id"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			parsed, err := schema.Parse(tt.model, &sync.Map{}, schema.NamingStrategy{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			field := parsed.LookUpField(tt.field)
+			if field == nil || field.Size != 191 {
+				t.Fatalf("%s size = %v, want 191", tt.field, field)
+			}
+			index := parsed.LookIndex(tt.indexName)
+			if index == nil || index.Class != "UNIQUE" || len(index.Fields) != 1 || index.Fields[0].DBName != "id" {
+				t.Fatalf("%s index = %#v, want unique id index", tt.indexName, index)
+			}
+		})
+	}
+}
+
+func TestDurableChordCurrentMasterSchemaLiveSQL(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		driver string
+		dbType string
+		env    string
+	}{
+		{name: "mysql", driver: "mysql", dbType: "mysql", env: "GKIT_MYSQL_DSN"},
+		{name: "postgres", driver: "pgx", dbType: "pgsql", env: "GKIT_POSTGRES_DSN"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			dsn := os.Getenv(tt.env)
+			if dsn == "" {
+				t.Skip(tt.env + " is required for live schema verification")
+			}
+			db, err := sql.Open(tt.driver, dsn)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = db.Close() })
+			value, err := NewBackendSQLDBE(db, -1, tt.dbType, &gorm.Config{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			backend := value.(*BackendSQLDB)
+			assertLiveIdentifierSchema(t, backend.gClient, &task.GroupMeta{}, "id", "uq_group_meta_group_id")
+			assertLiveIdentifierSchema(t, backend.gClient, &task.Status{}, "id", "uq_status_task_id")
+		})
+	}
+}
+
+func assertLiveIdentifierSchema(t *testing.T, db *gorm.DB, model interface{}, columnName, indexName string) {
+	t.Helper()
+	columns, err := db.Migrator().ColumnTypes(model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundColumn := false
+	for _, column := range columns {
+		if column.Name() != columnName {
+			continue
+		}
+		foundColumn = true
+		length, ok := column.Length()
+		if !ok || length != 191 {
+			t.Fatalf("%T.%s length = %d, %t; want 191", model, columnName, length, ok)
+		}
+	}
+	if !foundColumn {
+		t.Fatalf("%T.%s column not found", model, columnName)
+	}
+	indexes, err := db.Migrator().GetIndexes(model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, index := range indexes {
+		if index.Name() != indexName {
+			continue
+		}
+		unique, ok := index.Unique()
+		if !ok || !unique {
+			t.Fatalf("%s unique = %t, %t; want true", indexName, unique, ok)
+		}
+		return
+	}
+	t.Fatalf("unique index %s not found", indexName)
+}

--- a/distributed/backend/backend_mongodb/durable_chord.go
+++ b/distributed/backend/backend_mongodb/durable_chord.go
@@ -1,0 +1,340 @@
+package backend_mongodb
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/songzhibin97/gkit/distributed/backend"
+	"github.com/songzhibin97/gkit/distributed/task"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+var _ backend.DurableChordBackend = (*BackendMongoDB)(nil)
+
+type mongoChordDocument struct {
+	ID                    string `bson:"_id"`
+	backend.ChordDelivery `bson:",inline"`
+}
+
+func (b *BackendMongoDB) RegisterChord(ctx context.Context, registration backend.ChordRegistration) (backend.ChordRegistrationRef, error) {
+	if err := b.ensureChordIndexes(ctx); err != nil {
+		return backend.ChordRegistrationRef{}, err
+	}
+	if err := backend.FinalizeChordRegistration(&registration); err != nil {
+		return backend.ChordRegistrationRef{}, err
+	}
+	owner, err := backend.NewChordOwner()
+	if err != nil {
+		return backend.ChordRegistrationRef{}, err
+	}
+	delivery := backend.NewChordDelivery(registration, owner, time.Now())
+	document := mongoChordDocument{ID: delivery.DeliveryKey, ChordDelivery: delivery}
+	if _, err := b.chordTable.InsertOne(ctx, &document); err == nil {
+		return backend.ChordRegistrationRef{DeliveryKey: delivery.DeliveryKey, Owner: owner, Version: delivery.RegistrationVersion, Created: true}, nil
+	} else if !mongo.IsDuplicateKeyError(err) {
+		return backend.ChordRegistrationRef{}, fmt.Errorf("insert chord registration: %w", err)
+	}
+	var existing mongoChordDocument
+	if err := b.chordTable.FindOne(ctx, bson.M{"group_id": registration.GroupID}).Decode(&existing); err != nil {
+		return backend.ChordRegistrationRef{}, err
+	}
+	if !backend.ChordRegistrationMatches(&existing.ChordDelivery, registration) {
+		return backend.ChordRegistrationRef{}, backend.ErrChordRegistrationConflict
+	}
+	return backend.ChordRegistrationRef{DeliveryKey: existing.DeliveryKey, Owner: existing.RegistrationOwner, Version: existing.RegistrationVersion, Created: false}, nil
+}
+
+func (b *BackendMongoDB) AbortRegistration(ctx context.Context, ref backend.ChordRegistrationRef) error {
+	if !ref.Created {
+		return backend.ErrChordRegistrationOwnershipLost
+	}
+	result, err := b.chordTable.DeleteOne(ctx, bson.M{
+		"_id":                        ref.DeliveryKey,
+		"registration_owner":         ref.Owner,
+		"registration_version":       ref.Version,
+		"member_publication_started": false,
+	})
+	if err != nil {
+		return err
+	}
+	if result.DeletedCount == 1 {
+		return nil
+	}
+	var existing mongoChordDocument
+	if err := b.chordTable.FindOne(ctx, bson.M{"_id": ref.DeliveryKey}).Decode(&existing); err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return nil
+		}
+		return err
+	}
+	if existing.RegistrationOwner != ref.Owner || existing.RegistrationVersion != ref.Version {
+		return backend.ErrChordRegistrationOwnershipLost
+	}
+	return backend.ErrChordPublicationStarted
+}
+
+func (b *BackendMongoDB) ClaimMemberPublication(ctx context.Context, claim backend.ChordMemberClaim) (lease backend.ChordMemberLease, claimed bool, err error) {
+	err = b.updateChordDelivery(ctx, claim.DeliveryKey, func(delivery *backend.ChordDelivery) (bool, error) {
+		var transitionErr error
+		lease, claimed, transitionErr = backend.ClaimChordMember(delivery, claim)
+		return claimed, transitionErr
+	})
+	return lease, claimed, err
+}
+
+func (b *BackendMongoDB) RecordMemberPublishOutcome(ctx context.Context, lease backend.ChordMemberLease, outcome backend.ChordPublishOutcome) error {
+	return b.updateChordDelivery(ctx, lease.DeliveryKey, func(delivery *backend.ChordDelivery) (bool, error) {
+		if err := backend.ApplyChordMemberPublishOutcome(delivery, lease, outcome); err != nil {
+			return false, err
+		}
+		return true, nil
+	})
+}
+
+func (b *BackendMongoDB) RecordMemberTerminal(ctx context.Context, deliveryKey string, ordinal int, taskID string, outcome backend.MemberTerminalOutcome, results []*task.Result) error {
+	return b.updateChordDelivery(ctx, deliveryKey, func(delivery *backend.ChordDelivery) (bool, error) {
+		before := delivery.Version
+		if err := backend.ApplyChordMemberTerminal(delivery, ordinal, taskID, outcome, results, time.Now()); err != nil {
+			return false, err
+		}
+		return delivery.Version != before, nil
+	})
+}
+
+func (b *BackendMongoDB) ScanChordDeliveries(ctx context.Context, scan backend.ChordScan) (backend.ChordDeliveryPage, error) {
+	if err := b.ensureChordIndexes(ctx); err != nil {
+		return backend.ChordDeliveryPage{}, err
+	}
+	limit := scan.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+	filter := bson.M{}
+	if scan.Cursor != "" {
+		filter["_id"] = bson.M{"$gt": scan.Cursor}
+	}
+	cursor, err := b.chordTable.Find(ctx, filter, options.Find().SetSort(bson.D{{Key: "_id", Value: 1}}).SetLimit(int64(limit+1)))
+	if err != nil {
+		return backend.ChordDeliveryPage{}, err
+	}
+	defer cursor.Close(ctx)
+	page := backend.ChordDeliveryPage{}
+	for cursor.Next(ctx) {
+		var document mongoChordDocument
+		if err := cursor.Decode(&document); err != nil {
+			return backend.ChordDeliveryPage{}, err
+		}
+		page.Deliveries = append(page.Deliveries, document.ChordDelivery)
+	}
+	if err := cursor.Err(); err != nil {
+		return backend.ChordDeliveryPage{}, err
+	}
+	if len(page.Deliveries) > limit {
+		page.Deliveries = page.Deliveries[:limit]
+		page.NextCursor = page.Deliveries[len(page.Deliveries)-1].DeliveryKey
+	}
+	return page, nil
+}
+
+func (b *BackendMongoDB) ReconcileChord(ctx context.Context, deliveryKey string) error {
+	delivery, err := b.getChordDelivery(ctx, deliveryKey)
+	if err != nil {
+		return err
+	}
+	needsSetup := false
+	for index := range delivery.Members {
+		if delivery.Members[index].State == backend.ChordMemberSetup {
+			needsSetup = true
+		}
+	}
+	if !needsSetup {
+		return nil
+	}
+	ids := make([]string, len(delivery.Members))
+	for index := range delivery.Members {
+		ids[index] = delivery.Members[index].TaskID
+	}
+	group := task.InitGroupMeta(delivery.GroupID, delivery.GroupName, b.resultExpire, ids...)
+	if _, err := b.groupTable.UpdateOne(ctx, bson.M{"_id": delivery.GroupID}, bson.M{"$setOnInsert": group}, options.Update().SetUpsert(true)); err != nil {
+		return err
+	}
+	var existingGroup task.GroupMeta
+	if err := b.groupTable.FindOne(ctx, bson.M{"_id": delivery.GroupID}).Decode(&existingGroup); err != nil {
+		return err
+	}
+	if !sameChordStrings([]string(existingGroup.TaskIDs), ids) {
+		return backend.ErrChordRegistrationConflict
+	}
+	for index := range delivery.Members {
+		var signature task.Signature
+		if err := json.Unmarshal(delivery.Members[index].Payload, &signature); err != nil {
+			return err
+		}
+		status := task.NewPendingState(&signature)
+		if _, err := b.taskTable.UpdateOne(ctx, bson.M{"_id": signature.ID}, bson.M{"$setOnInsert": status}, options.Update().SetUpsert(true)); err != nil {
+			return err
+		}
+		var existingStatus task.Status
+		if err := b.taskTable.FindOne(ctx, bson.M{"_id": signature.ID}).Decode(&existingStatus); err != nil {
+			return err
+		}
+		if existingStatus.GroupID != delivery.GroupID {
+			return backend.ErrChordRegistrationConflict
+		}
+	}
+	return b.updateChordDelivery(ctx, deliveryKey, func(current *backend.ChordDelivery) (bool, error) {
+		backend.PrepareChordMembers(current, time.Now())
+		return true, nil
+	})
+}
+
+func sameChordStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func (b *BackendMongoDB) ClaimCallbackPublication(ctx context.Context, claim backend.ChordCallbackClaim) (lease backend.ChordCallbackLease, claimed bool, err error) {
+	delivery, err := b.getChordDelivery(ctx, claim.DeliveryKey)
+	if err != nil {
+		return lease, false, err
+	}
+	if len(delivery.CallbackPayload) > 0 {
+		var callback task.Signature
+		if err := json.Unmarshal(delivery.CallbackPayload, &callback); err != nil {
+			return lease, false, err
+		}
+		status := task.NewPendingState(&callback)
+		if _, err := b.taskTable.UpdateOne(ctx, bson.M{"_id": callback.ID}, bson.M{"$setOnInsert": status}, options.Update().SetUpsert(true)); err != nil {
+			return lease, false, err
+		}
+	}
+	err = b.updateChordDelivery(ctx, claim.DeliveryKey, func(current *backend.ChordDelivery) (bool, error) {
+		var transitionErr error
+		lease, claimed, transitionErr = backend.ClaimChordCallback(current, claim)
+		return claimed, transitionErr
+	})
+	return lease, claimed, err
+}
+
+func (b *BackendMongoDB) RecordCallbackPublishOutcome(ctx context.Context, lease backend.ChordCallbackLease, outcome backend.ChordPublishOutcome) error {
+	return b.updateChordDelivery(ctx, lease.DeliveryKey, func(delivery *backend.ChordDelivery) (bool, error) {
+		if err := backend.ApplyChordCallbackPublishOutcome(delivery, lease, outcome); err != nil {
+			return false, err
+		}
+		return true, nil
+	})
+}
+
+func (b *BackendMongoDB) RecordCallbackTerminal(ctx context.Context, deliveryKey string, outcome backend.CallbackTerminalOutcome) error {
+	return b.updateChordDelivery(ctx, deliveryKey, func(delivery *backend.ChordDelivery) (bool, error) {
+		before := delivery.Version
+		if err := backend.ApplyChordCallbackTerminal(delivery, outcome, time.Now()); err != nil {
+			return false, err
+		}
+		return delivery.Version != before, nil
+	})
+}
+
+func (b *BackendMongoDB) CleanupTerminalChordDeliveries(ctx context.Context, now time.Time, limit int) (int, error) {
+	if err := b.ensureChordIndexes(ctx); err != nil {
+		return 0, err
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	cursor, err := b.chordTable.Find(ctx, bson.M{"terminal_expire_at": bson.M{"$lte": now}}, options.Find().SetProjection(bson.M{"_id": 1}).SetLimit(int64(limit)))
+	if err != nil {
+		return 0, err
+	}
+	defer cursor.Close(ctx)
+	ids := make([]string, 0, limit)
+	for cursor.Next(ctx) {
+		var value struct {
+			ID string `bson:"_id"`
+		}
+		if err := cursor.Decode(&value); err != nil {
+			return len(ids), err
+		}
+		ids = append(ids, value.ID)
+	}
+	if len(ids) == 0 {
+		return 0, cursor.Err()
+	}
+	result, err := b.chordTable.DeleteMany(ctx, bson.M{"_id": bson.M{"$in": ids}})
+	return int(result.DeletedCount), err
+}
+
+func (b *BackendMongoDB) getChordDelivery(ctx context.Context, deliveryKey string) (*backend.ChordDelivery, error) {
+	if err := b.ensureChordIndexes(ctx); err != nil {
+		return nil, err
+	}
+	var document mongoChordDocument
+	if err := b.chordTable.FindOne(ctx, bson.M{"_id": deliveryKey}).Decode(&document); err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return nil, backend.ErrChordNotFound
+		}
+		return nil, err
+	}
+	return &document.ChordDelivery, nil
+}
+
+func (b *BackendMongoDB) updateChordDelivery(ctx context.Context, deliveryKey string, mutate func(*backend.ChordDelivery) (bool, error)) error {
+	if err := b.ensureChordIndexes(ctx); err != nil {
+		return err
+	}
+	for attempt := 0; attempt < 16; attempt++ {
+		var document mongoChordDocument
+		if err := b.chordTable.FindOne(ctx, bson.M{"_id": deliveryKey}).Decode(&document); err != nil {
+			if errors.Is(err, mongo.ErrNoDocuments) {
+				return backend.ErrChordNotFound
+			}
+			return err
+		}
+		version := document.Version
+		changed, err := mutate(&document.ChordDelivery)
+		if err != nil || !changed {
+			return err
+		}
+		result, err := b.chordTable.ReplaceOne(ctx, bson.M{"_id": deliveryKey, "version": version}, &document)
+		if err != nil {
+			return err
+		}
+		if result.ModifiedCount == 1 {
+			return nil
+		}
+	}
+	return errors.New("mongo chord CAS exhausted")
+}
+
+func (b *BackendMongoDB) createChordIndexes(ctx context.Context) error {
+	zero := int32(0)
+	models := []mongo.IndexModel{
+		{Keys: bson.D{{Key: "delivery_key", Value: 1}}, Options: options.Index().SetName("gkit_chord_delivery_key").SetUnique(true)},
+		{Keys: bson.D{{Key: "group_id", Value: 1}}, Options: options.Index().SetName("gkit_chord_group_id").SetUnique(true)},
+		{Keys: bson.D{{Key: "terminal_expire_at", Value: 1}}, Options: options.Index().SetName("gkit_chord_terminal_expiry").SetExpireAfterSeconds(zero)},
+		{Keys: bson.D{{Key: "callback_state", Value: 1}, {Key: "callback_next_attempt_at", Value: 1}}, Options: options.Index().SetName("gkit_chord_due")},
+	}
+	if _, err := b.chordTable.Indexes().CreateMany(ctx, models); err != nil {
+		return fmt.Errorf("backend_mongodb: create chord indexes: %w", err)
+	}
+	return nil
+}
+
+func (b *BackendMongoDB) ensureChordIndexes(ctx context.Context) error {
+	b.chordIndexOnce.Do(func() {
+		b.chordIndexErr = b.createChordIndexes(ctx)
+	})
+	return b.chordIndexErr
+}

--- a/distributed/backend/backend_mongodb/durable_chord.go
+++ b/distributed/backend/backend_mongodb/durable_chord.go
@@ -273,7 +273,10 @@ func (b *BackendMongoDB) CleanupTerminalChordDeliveries(ctx context.Context, now
 		return 0, cursor.Err()
 	}
 	result, err := b.chordTable.DeleteMany(ctx, bson.M{"_id": bson.M{"$in": ids}})
-	return int(result.DeletedCount), err
+	if err != nil {
+		return 0, fmt.Errorf("delete terminal chord deliveries: %w", err)
+	}
+	return int(result.DeletedCount), nil
 }
 
 func (b *BackendMongoDB) getChordDelivery(ctx context.Context, deliveryKey string) (*backend.ChordDelivery, error) {

--- a/distributed/backend/backend_mongodb/durable_chord_cleanup_regression_test.go
+++ b/distributed/backend/backend_mongodb/durable_chord_cleanup_regression_test.go
@@ -1,0 +1,86 @@
+package backend_mongodb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/event"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func TestCleanupTerminalChordDeliveriesCancellationAfterDeleteStarts(t *testing.T) {
+	uri := os.Getenv("GKIT_MONGO_URI")
+	if uri == "" {
+		t.Skip("GKIT_MONGO_URI is required for live durable chord cleanup")
+	}
+
+	var armed atomic.Bool
+	var deleteStarted atomic.Bool
+	var cleanupCancel atomic.Value
+	cleanupCancel.Store(context.CancelFunc(func() {}))
+	monitor := &event.CommandMonitor{
+		Started: func(_ context.Context, command *event.CommandStartedEvent) {
+			if command.CommandName != "delete" || !armed.CompareAndSwap(true, false) {
+				return
+			}
+			deleteStarted.Store(true)
+			cleanupCancel.Load().(context.CancelFunc)()
+		},
+	}
+
+	connectCtx, connectCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer connectCancel()
+	client, err := mongo.Connect(connectCtx, options.Client().ApplyURI(uri).SetMonitor(monitor))
+	if err != nil {
+		t.Fatal(err)
+	}
+	database := fmt.Sprintf("gkit_issue106_cleanup_%d", time.Now().UnixNano())
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := client.Database(database).Drop(cleanupCtx); err != nil {
+			t.Errorf("drop test database: %v", err)
+		}
+		if err := client.Disconnect(cleanupCtx); err != nil {
+			t.Errorf("disconnect MongoDB client: %v", err)
+		}
+	})
+
+	value, err := NewBackendMongoDBE(client, -1, SetDatabaseName(database))
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend := value.(*BackendMongoDB)
+	if _, err := backend.chordTable.InsertOne(context.Background(), bson.M{
+		"_id":                "terminal-cleanup-cancellation",
+		"terminal_expire_at": time.Now().Add(-time.Hour),
+	}); err != nil {
+		t.Fatalf("insert terminal chord delivery: %v", err)
+	}
+
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cleanupCancel.Store(context.CancelFunc(cancel))
+	armed.Store(true)
+	deleted, err := backend.CleanupTerminalChordDeliveries(cleanupCtx, time.Now(), 1)
+	if !deleteStarted.Load() {
+		t.Fatal("DeleteMany command did not start before cleanup returned")
+	}
+	if deleted != 0 {
+		t.Fatalf("deleted = %d, want 0 after canceled DeleteMany", deleted)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("cleanup error = %v, want context.Canceled", err)
+	}
+	if !strings.Contains(err.Error(), "delete terminal chord deliveries") {
+		t.Fatalf("cleanup error lacks operation context: %v", err)
+	}
+}

--- a/distributed/backend/backend_mongodb/durable_chord_contract_regression_test.go
+++ b/distributed/backend/backend_mongodb/durable_chord_contract_regression_test.go
@@ -1,0 +1,34 @@
+package backend_mongodb
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/songzhibin97/gkit/distributed/backend/chordtest"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func TestDurableChordContract(t *testing.T) {
+	uri := os.Getenv("GKIT_MONGO_URI")
+	if uri == "" {
+		t.Skip("GKIT_MONGO_URI is required for live durable chord contract")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	client, err := mongo.Connect(ctx, options.Client().ApplyURI(uri))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = client.Disconnect(context.Background()) })
+	database := fmt.Sprintf("gkit_issue104_%d", time.Now().UnixNano())
+	t.Cleanup(func() { _ = client.Database(database).Drop(context.Background()) })
+	value, err := NewBackendMongoDBE(client, -1, SetDatabaseName(database))
+	if err != nil {
+		t.Fatal(err)
+	}
+	chordtest.Run(t, value.(*BackendMongoDB))
+}

--- a/distributed/backend/backend_mongodb/mongo.go
+++ b/distributed/backend/backend_mongodb/mongo.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"sync"
 	"time"
 
 	"github.com/songzhibin97/gkit/distributed/task"
@@ -35,7 +36,10 @@ type BackendMongoDB struct {
 	// taskTable taskTable
 	taskTable *mongo.Collection
 	// groupTable groupTable
-	groupTable *mongo.Collection
+	groupTable     *mongo.Collection
+	chordTable     *mongo.Collection
+	chordIndexOnce sync.Once
+	chordIndexErr  error
 }
 
 // SetResultExpire normalizes and stores the retention value for compatibility.
@@ -303,11 +307,20 @@ func NewBackendMongoDBE(client *mongo.Client, resultExpire int64, options ...opt
 		resultExpire: normalizedExpire,
 		taskTable:    client.Database(c.databaseName).Collection(c.tableTaskName),
 		groupTable:   client.Database(c.databaseName).Collection(c.tableGroupName),
+		chordTable:   client.Database(c.databaseName).Collection("chord_deliveries"),
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), mongoIndexSetupTimeout)
 	defer cancel()
 	if err := b.createIndexes(ctx, taskModels, groupModels); err != nil {
 		return nil, err
+	}
+	// A negative retention value has historically guaranteed that construction
+	// performs no MongoDB I/O. Preserve that compatibility contract and create
+	// durable-chord indexes lazily on the first durable operation instead.
+	if normalizedExpire >= 0 {
+		if err := b.ensureChordIndexes(ctx); err != nil {
+			return nil, err
+		}
 	}
 	return &b, nil
 }

--- a/distributed/backend/backend_redis/durable_chord.go
+++ b/distributed/backend/backend_redis/durable_chord.go
@@ -2,10 +2,10 @@ package backend_redis
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
@@ -14,7 +14,78 @@ import (
 	"github.com/songzhibin97/gkit/distributed/task"
 )
 
-const redisChordRecordPattern = "gkit:chord:*:record"
+const (
+	redisChordDeliveryIndexKey = "gkit:chord:{index}:deliveries:v1"
+	redisChordTerminalIndexKey = "gkit:chord:{index}:terminal:v1"
+	redisChordIndexStateKey    = "gkit:chord:{index}:delivery-state:v1"
+	redisChordCursorPrefix     = "chord-index-v1."
+)
+
+const (
+	redisChordPrepareIndexScript = `
+local current = redis.call('HGET', KEYS[2], ARGV[1])
+if current and string.sub(current, 1, 9) == 'deleting:' then
+  return current
+end
+redis.call('ZADD', KEYS[1], 0, ARGV[1])
+if not current or string.sub(current, 1, 8) == 'pending:' then
+  redis.call('HSET', KEYS[2], ARGV[1], 'pending:' .. ARGV[2])
+end
+return ''`
+	redisChordCommitIndexScript = `
+redis.call('ZADD', KEYS[1], 0, ARGV[1])
+local current = redis.call('HGET', KEYS[2], ARGV[1])
+if not current or current == 'pending:' .. ARGV[2] then
+  redis.call('HSET', KEYS[2], ARGV[1], 'committed:' .. ARGV[3])
+end
+return 1`
+	redisChordForceCommitIndexScript = `
+redis.call('ZADD', KEYS[1], 0, ARGV[1])
+redis.call('HSET', KEYS[2], ARGV[1], 'committed:' .. ARGV[2])
+return 1`
+	redisChordEnsureIndexScript = `
+redis.call('ZADD', KEYS[1], 0, ARGV[1])
+local current = redis.call('HGET', KEYS[2], ARGV[1])
+if not current then
+  redis.call('HSET', KEYS[2], ARGV[1], 'committed:' .. ARGV[2])
+end
+return 1`
+	redisChordRemoveIndexScript = `
+local current = redis.call('HGET', KEYS[3], ARGV[1])
+if (ARGV[2] == '' and not current) or current == ARGV[2] then
+  redis.call('ZREM', KEYS[1], ARGV[1])
+  redis.call('ZREM', KEYS[2], ARGV[1])
+  redis.call('HDEL', KEYS[3], ARGV[1])
+  return 1
+end
+return 0`
+	redisChordBeginDeleteScript = `
+local current = redis.call('HGET', KEYS[1], ARGV[1])
+if current and (string.sub(current, 1, 8) == 'pending:' or string.sub(current, 1, 9) == 'deleting:') then
+  return 0
+end
+if current and current ~= 'committed:' .. ARGV[2] then
+  return 0
+end
+redis.call('HSET', KEYS[1], ARGV[1], 'deleting:' .. ARGV[3])
+return 1`
+	redisChordRestoreIndexScript = `
+if redis.call('HGET', KEYS[1], ARGV[1]) == 'deleting:' .. ARGV[2] then
+  redis.call('HSET', KEYS[1], ARGV[1], 'committed:' .. ARGV[3])
+  return 1
+end
+return 0`
+	redisChordDeleteRecordScript = `
+local body = redis.call('GET', KEYS[1])
+if not body then
+  return 0
+end
+local ok, record = pcall(cjson.decode, body)
+if not ok or record['registration_owner'] ~= ARGV[1] then
+  return 0
+end
+return redis.call('DEL', KEYS[1])`
+)
 
 var _ backend.DurableChordBackend = (*BackendRedis)(nil)
 
@@ -43,16 +114,61 @@ func (b *BackendRedis) RegisterChord(ctx context.Context, registration backend.C
 	if err != nil {
 		return backend.ChordRegistrationRef{}, fmt.Errorf("marshal chord registration: %w", err)
 	}
+	// Publish a pending index generation before the record. Scanners never
+	// delete pending generations, and the final transition to committed fences
+	// stale hole cleanup from removing a newly created record's index.
+	for attempt := 0; ; attempt++ {
+		state, prepareErr := b.prepareChordIndex(ctx, delivery.DeliveryKey, owner)
+		if prepareErr != nil {
+			return backend.ChordRegistrationRef{}, prepareErr
+		}
+		if !strings.HasPrefix(state, "deleting:") {
+			break
+		}
+		if _, loadErr := b.loadChordDelivery(ctx, key); errors.Is(loadErr, redis.Nil) {
+			if err := b.removeChordIndexesIfState(ctx, delivery.DeliveryKey, state); err != nil {
+				return backend.ChordRegistrationRef{}, err
+			}
+			continue
+		} else if loadErr != nil {
+			return backend.ChordRegistrationRef{}, loadErr
+		}
+		if attempt == 15 {
+			return backend.ChordRegistrationRef{}, errors.New("redis chord registration blocked by deletion")
+		}
+		timer := time.NewTimer(time.Duration(attempt+1) * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return backend.ChordRegistrationRef{}, ctx.Err()
+		case <-timer.C:
+		}
+	}
 	created, err := b.client.SetNX(ctx, key, body, 0).Result()
 	if err != nil {
 		return backend.ChordRegistrationRef{}, fmt.Errorf("register redis chord: %w", err)
 	}
 	if created {
+		if err := b.forceCommitChordIndex(ctx, delivery.DeliveryKey, owner); err != nil {
+			return backend.ChordRegistrationRef{}, err
+		}
 		return backend.ChordRegistrationRef{DeliveryKey: delivery.DeliveryKey, Owner: owner, Version: delivery.RegistrationVersion, Created: true}, nil
 	}
 	existing, err := b.loadChordDelivery(ctx, key)
 	if err != nil {
 		return backend.ChordRegistrationRef{}, err
+	}
+	if existing.DeliveryKey == delivery.DeliveryKey {
+		if err := b.commitChordIndex(ctx, existing.DeliveryKey, owner, existing.RegistrationOwner); err != nil {
+			return backend.ChordRegistrationRef{}, err
+		}
+	} else {
+		if err := b.ensureChordIndex(ctx, existing.DeliveryKey, existing.RegistrationOwner); err != nil {
+			return backend.ChordRegistrationRef{}, err
+		}
+		if err := b.removeChordIndexesIfState(ctx, delivery.DeliveryKey, "pending:"+owner); err != nil {
+			return backend.ChordRegistrationRef{}, err
+		}
 	}
 	if !backend.ChordRegistrationMatches(existing, registration) {
 		return backend.ChordRegistrationRef{}, backend.ErrChordRegistrationConflict
@@ -69,6 +185,12 @@ func (b *BackendRedis) AbortRegistration(ctx context.Context, ref backend.ChordR
 		return err
 	}
 	for attempt := 0; attempt < 8; attempt++ {
+		deleteToken, tokenErr := backend.NewChordOwner()
+		if tokenErr != nil {
+			return tokenErr
+		}
+		deleteAcquired := false
+		var deleteCmd *redis.Cmd
 		err = b.client.Watch(ctx, func(tx *redis.Tx) error {
 			delivery, loadErr := loadRedisChordFromCmd(ctx, tx, key)
 			if errors.Is(loadErr, redis.Nil) {
@@ -83,14 +205,40 @@ func (b *BackendRedis) AbortRegistration(ctx context.Context, ref backend.ChordR
 			if delivery.MemberPublicationStarted {
 				return backend.ErrChordPublicationStarted
 			}
+			acquired, acquireErr := b.beginChordDelete(ctx, delivery.DeliveryKey, delivery.RegistrationOwner, deleteToken)
+			if acquireErr != nil {
+				return acquireErr
+			}
+			if !acquired {
+				return redis.TxFailedErr
+			}
+			deleteAcquired = true
 			_, pipelineErr := tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
-				pipe.Del(ctx, key)
+				deleteCmd = pipe.Eval(ctx, redisChordDeleteRecordScript, []string{key}, delivery.RegistrationOwner)
 				return nil
 			})
+			if pipelineErr != nil {
+				_ = b.restoreChordIndex(ctx, delivery.DeliveryKey, deleteToken, delivery.RegistrationOwner)
+			}
 			return pipelineErr
 		}, key)
 		if !errors.Is(err, redis.TxFailedErr) {
-			return err
+			if err != nil {
+				return err
+			}
+			if deleteAcquired && deleteCmd != nil {
+				if _, deleteErr := deleteCmd.Int(); deleteErr != nil {
+					_ = b.restoreChordIndex(ctx, ref.DeliveryKey, deleteToken, ref.Owner)
+					return deleteErr
+				}
+			}
+			if deleteAcquired {
+				return b.removeChordIndexesIfState(ctx, ref.DeliveryKey, "deleting:"+deleteToken)
+			}
+			return b.removeChordIndexesIfState(ctx, ref.DeliveryKey, "committed:"+ref.Owner)
+		}
+		if deleteAcquired {
+			_ = b.restoreChordIndex(ctx, ref.DeliveryKey, deleteToken, ref.Owner)
 		}
 	}
 	return fmt.Errorf("abort redis chord: %w", redis.TxFailedErr)
@@ -137,34 +285,86 @@ func (b *BackendRedis) RecordMemberTerminal(ctx context.Context, deliveryKey str
 }
 
 func (b *BackendRedis) ScanChordDeliveries(ctx context.Context, scan backend.ChordScan) (backend.ChordDeliveryPage, error) {
-	keys, err := b.scanChordRecordKeys(ctx)
-	if err != nil {
-		return backend.ChordDeliveryPage{}, err
-	}
-	deliveries := make([]backend.ChordDelivery, 0, len(keys))
-	for _, key := range keys {
-		delivery, loadErr := b.loadChordDelivery(ctx, key)
-		if errors.Is(loadErr, redis.Nil) {
-			continue
-		}
-		if loadErr != nil {
-			return backend.ChordDeliveryPage{}, loadErr
-		}
-		if scan.Cursor == "" || delivery.DeliveryKey > scan.Cursor {
-			deliveries = append(deliveries, *delivery)
-		}
-	}
-	backend.SortChordDeliveries(deliveries)
 	limit := scan.Limit
 	if limit <= 0 {
 		limit = 100
 	}
-	page := backend.ChordDeliveryPage{}
-	if len(deliveries) > limit {
-		page.Deliveries = deliveries[:limit]
-		page.NextCursor = page.Deliveries[len(page.Deliveries)-1].DeliveryKey
-	} else {
-		page.Deliveries = deliveries
+	lastKey, err := decodeRedisChordCursor(scan.Cursor)
+	if err != nil {
+		return backend.ChordDeliveryPage{}, err
+	}
+	minimum := "-"
+	if lastKey != "" {
+		minimum = "(" + lastKey
+	}
+	candidates, err := b.client.ZRangeByLex(ctx, redisChordDeliveryIndexKey, &redis.ZRangeBy{
+		Min:    minimum,
+		Max:    "+",
+		Offset: 0,
+		Count:  int64(limit + 1),
+	}).Result()
+	if err != nil {
+		return backend.ChordDeliveryPage{}, fmt.Errorf("scan redis chord index: %w", err)
+	}
+	page := backend.ChordDeliveryPage{Deliveries: make([]backend.ChordDelivery, 0, limit)}
+	processedLast := lastKey
+	hasMore := false
+	for _, deliveryKey := range candidates {
+		if len(page.Deliveries) == limit {
+			hasMore = true
+			break
+		}
+		processedLast = deliveryKey
+		key, keyErr := redisChordRecordKey(deliveryKey)
+		if keyErr != nil {
+			_ = b.removeChordIndexes(ctx, deliveryKey)
+			continue
+		}
+		delivery, loadErr := b.loadChordDelivery(ctx, key)
+		if errors.Is(loadErr, redis.Nil) {
+			state, stateErr := b.chordIndexState(ctx, deliveryKey)
+			if stateErr != nil {
+				return backend.ChordDeliveryPage{}, stateErr
+			}
+			if strings.HasPrefix(state, "pending:") || strings.HasPrefix(state, "deleting:") {
+				continue
+			}
+			// A registration may have created the record after the first GET.
+			// Recheck before conditionally removing only the unchanged generation.
+			delivery, loadErr = b.loadChordDelivery(ctx, key)
+			if errors.Is(loadErr, redis.Nil) {
+				if err := b.removeChordIndexesIfState(ctx, deliveryKey, state); err != nil {
+					return backend.ChordDeliveryPage{}, err
+				}
+				continue
+			}
+			if loadErr != nil {
+				return backend.ChordDeliveryPage{}, loadErr
+			}
+		}
+		if loadErr != nil {
+			return backend.ChordDeliveryPage{}, loadErr
+		}
+		if err := b.ensureChordIndex(ctx, delivery.DeliveryKey, delivery.RegistrationOwner); err != nil {
+			return backend.ChordDeliveryPage{}, err
+		}
+		if delivery.DeliveryKey != deliveryKey {
+			state, stateErr := b.chordIndexState(ctx, deliveryKey)
+			if stateErr != nil {
+				return backend.ChordDeliveryPage{}, stateErr
+			}
+			if err := b.removeChordIndexesIfState(ctx, deliveryKey, state); err != nil {
+				return backend.ChordDeliveryPage{}, err
+			}
+			continue
+		}
+		page.Deliveries = append(page.Deliveries, *delivery)
+	}
+	if !hasMore && len(candidates) == limit+1 {
+		hasMore = true
+	}
+	if hasMore && processedLast != "" {
+		page.NextCursor = encodeRedisChordCursor(processedLast)
 	}
 	return page, nil
 }
@@ -301,29 +501,74 @@ func (b *BackendRedis) RecordCallbackTerminal(ctx context.Context, deliveryKey s
 }
 
 func (b *BackendRedis) CleanupTerminalChordDeliveries(ctx context.Context, now time.Time, limit int) (int, error) {
-	keys, err := b.scanChordRecordKeys(ctx)
-	if err != nil {
-		return 0, err
-	}
 	if limit <= 0 {
 		limit = 100
 	}
+	due, err := b.client.ZRangeByScore(ctx, redisChordTerminalIndexKey, &redis.ZRangeBy{
+		Min:    "-inf",
+		Max:    fmt.Sprintf("%d", now.UnixMilli()),
+		Offset: 0,
+		Count:  int64(limit),
+	}).Result()
+	if err != nil {
+		return 0, fmt.Errorf("scan redis terminal chord index: %w", err)
+	}
 	removed := 0
-	for _, key := range keys {
-		if removed >= limit {
-			break
+	for _, deliveryKey := range due {
+		key, keyErr := redisChordRecordKey(deliveryKey)
+		if keyErr != nil {
+			_ = b.removeChordIndexes(ctx, deliveryKey)
+			continue
 		}
 		delivery, loadErr := b.loadChordDelivery(ctx, key)
 		if errors.Is(loadErr, redis.Nil) {
+			state, stateErr := b.chordIndexState(ctx, deliveryKey)
+			if stateErr != nil {
+				return removed, stateErr
+			}
+			if strings.HasPrefix(state, "pending:") {
+				continue
+			}
+			if err := b.removeChordIndexesIfState(ctx, deliveryKey, state); err != nil {
+				return removed, err
+			}
 			continue
 		}
 		if loadErr != nil {
 			return removed, loadErr
 		}
-		if delivery.TerminalExpireAt != nil && !delivery.TerminalExpireAt.After(now) {
-			if err := b.client.Del(ctx, key).Err(); err != nil {
+		if delivery.TerminalExpireAt == nil {
+			if err := b.client.ZRem(ctx, redisChordTerminalIndexKey, deliveryKey).Err(); err != nil {
 				return removed, err
 			}
+			continue
+		}
+		if delivery.TerminalExpireAt.After(now) {
+			if err := b.client.ZAdd(ctx, redisChordTerminalIndexKey, &redis.Z{Score: float64(delivery.TerminalExpireAt.UnixMilli()), Member: deliveryKey}).Err(); err != nil {
+				return removed, err
+			}
+			continue
+		}
+		deleteToken, tokenErr := backend.NewChordOwner()
+		if tokenErr != nil {
+			return removed, tokenErr
+		}
+		acquired, acquireErr := b.beginChordDelete(ctx, deliveryKey, delivery.RegistrationOwner, deleteToken)
+		if acquireErr != nil {
+			return removed, acquireErr
+		}
+		if !acquired {
+			continue
+		}
+		deleted, err := b.deleteChordRecordIfOwner(ctx, key, delivery.RegistrationOwner)
+		if err != nil {
+			_ = b.restoreChordIndex(ctx, deliveryKey, deleteToken, delivery.RegistrationOwner)
+			return removed, err
+		}
+		if err := b.removeChordIndexesIfState(ctx, deliveryKey, "deleting:"+deleteToken); err != nil {
+			return removed, err
+		}
+		if deleted > 0 {
 			removed++
 		}
 	}
@@ -332,6 +577,8 @@ func (b *BackendRedis) CleanupTerminalChordDeliveries(ctx context.Context, now t
 
 func (b *BackendRedis) updateChordDelivery(ctx context.Context, key string, mutate func(*backend.ChordDelivery) (bool, error)) error {
 	for attempt := 0; attempt < 16; attempt++ {
+		var terminalDeliveryKey string
+		var terminalExpireAt *time.Time
 		err := b.client.Watch(ctx, func(tx *redis.Tx) error {
 			delivery, err := loadRedisChordFromCmd(ctx, tx, key)
 			if err != nil {
@@ -341,8 +588,13 @@ func (b *BackendRedis) updateChordDelivery(ctx context.Context, key string, muta
 				return err
 			}
 			changed, err := mutate(delivery)
-			if err != nil || !changed {
+			if err != nil {
 				return err
+			}
+			terminalDeliveryKey = delivery.DeliveryKey
+			terminalExpireAt = delivery.TerminalExpireAt
+			if !changed {
+				return nil
 			}
 			body, err := json.Marshal(delivery)
 			if err != nil {
@@ -362,7 +614,15 @@ func (b *BackendRedis) updateChordDelivery(ctx context.Context, key string, muta
 			return err
 		}, key)
 		if !errors.Is(err, redis.TxFailedErr) {
-			return err
+			if err != nil {
+				return err
+			}
+			if terminalExpireAt != nil {
+				if err := b.client.ZAdd(ctx, redisChordTerminalIndexKey, &redis.Z{Score: float64(terminalExpireAt.UnixMilli()), Member: terminalDeliveryKey}).Err(); err != nil {
+					return fmt.Errorf("index terminal redis chord: %w", err)
+				}
+			}
+			return nil
 		}
 	}
 	return fmt.Errorf("redis chord CAS exhausted: %w", redis.TxFailedErr)
@@ -388,39 +648,114 @@ func loadRedisChordFromCmd(ctx context.Context, getter redisChordGetter, key str
 	return &delivery, nil
 }
 
-func (b *BackendRedis) scanChordRecordKeys(ctx context.Context) ([]string, error) {
-	keys := make(map[string]struct{})
-	scanClient := func(client redis.Cmdable) error {
-		var cursor uint64
-		for {
-			batch, next, err := client.Scan(ctx, cursor, redisChordRecordPattern, 100).Result()
-			if err != nil {
-				return err
-			}
-			for _, key := range batch {
-				keys[key] = struct{}{}
-			}
-			cursor = next
-			if cursor == 0 {
-				return nil
-			}
-		}
+func encodeRedisChordCursor(lastKey string) string {
+	return redisChordCursorPrefix + base64.RawURLEncoding.EncodeToString([]byte(lastKey))
+}
+
+func decodeRedisChordCursor(cursor string) (string, error) {
+	if cursor == "" {
+		return "", nil
 	}
-	if cluster, ok := b.client.(*redis.ClusterClient); ok {
-		if err := cluster.ForEachMaster(ctx, func(ctx context.Context, client *redis.Client) error {
-			return scanClient(client)
-		}); err != nil {
-			return nil, err
-		}
-	} else if err := scanClient(b.client); err != nil {
-		return nil, err
+	if !strings.HasPrefix(cursor, redisChordCursorPrefix) {
+		return "", errors.New("invalid redis chord cursor")
 	}
-	result := make([]string, 0, len(keys))
-	for key := range keys {
-		result = append(result, key)
+	value, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(cursor, redisChordCursorPrefix))
+	if err != nil {
+		return "", errors.New("invalid redis chord cursor")
 	}
-	sort.Strings(result)
-	return result, nil
+	lastKey := string(value)
+	if _, err := redisChordRecordKey(lastKey); err != nil {
+		return "", errors.New("invalid redis chord cursor")
+	}
+	return lastKey, nil
+}
+
+func (b *BackendRedis) prepareChordIndex(ctx context.Context, deliveryKey, owner string) (string, error) {
+	value, err := b.client.Eval(ctx, redisChordPrepareIndexScript,
+		[]string{redisChordDeliveryIndexKey, redisChordIndexStateKey}, deliveryKey, owner).Text()
+	if err != nil {
+		return "", fmt.Errorf("prepare redis chord index: %w", err)
+	}
+	return value, nil
+}
+
+func (b *BackendRedis) commitChordIndex(ctx context.Context, deliveryKey, expectedOwner, recordOwner string) error {
+	if err := b.client.Eval(ctx, redisChordCommitIndexScript,
+		[]string{redisChordDeliveryIndexKey, redisChordIndexStateKey}, deliveryKey, expectedOwner, recordOwner).Err(); err != nil {
+		return fmt.Errorf("commit redis chord index: %w", err)
+	}
+	return nil
+}
+
+func (b *BackendRedis) forceCommitChordIndex(ctx context.Context, deliveryKey, recordOwner string) error {
+	if err := b.client.Eval(ctx, redisChordForceCommitIndexScript,
+		[]string{redisChordDeliveryIndexKey, redisChordIndexStateKey}, deliveryKey, recordOwner).Err(); err != nil {
+		return fmt.Errorf("commit created redis chord index: %w", err)
+	}
+	return nil
+}
+
+func (b *BackendRedis) ensureChordIndex(ctx context.Context, deliveryKey, recordOwner string) error {
+	if err := b.client.Eval(ctx, redisChordEnsureIndexScript,
+		[]string{redisChordDeliveryIndexKey, redisChordIndexStateKey}, deliveryKey, recordOwner).Err(); err != nil {
+		return fmt.Errorf("repair redis chord index: %w", err)
+	}
+	return nil
+}
+
+func (b *BackendRedis) chordIndexState(ctx context.Context, deliveryKey string) (string, error) {
+	state, err := b.client.HGet(ctx, redisChordIndexStateKey, deliveryKey).Result()
+	if errors.Is(err, redis.Nil) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("read redis chord index state: %w", err)
+	}
+	return state, nil
+}
+
+func (b *BackendRedis) beginChordDelete(ctx context.Context, deliveryKey, recordOwner, deleteToken string) (bool, error) {
+	acquired, err := b.client.Eval(ctx, redisChordBeginDeleteScript,
+		[]string{redisChordIndexStateKey}, deliveryKey, recordOwner, deleteToken).Int()
+	if err != nil {
+		return false, fmt.Errorf("fence redis chord deletion: %w", err)
+	}
+	return acquired == 1, nil
+}
+
+func (b *BackendRedis) restoreChordIndex(ctx context.Context, deliveryKey, deleteToken, recordOwner string) error {
+	if err := b.client.Eval(ctx, redisChordRestoreIndexScript,
+		[]string{redisChordIndexStateKey}, deliveryKey, deleteToken, recordOwner).Err(); err != nil {
+		return fmt.Errorf("restore redis chord index: %w", err)
+	}
+	return nil
+}
+
+func (b *BackendRedis) deleteChordRecordIfOwner(ctx context.Context, recordKey, recordOwner string) (int64, error) {
+	deleted, err := b.client.Eval(ctx, redisChordDeleteRecordScript, []string{recordKey}, recordOwner).Int64()
+	if err != nil {
+		return 0, fmt.Errorf("delete redis chord record: %w", err)
+	}
+	return deleted, nil
+}
+
+func (b *BackendRedis) removeChordIndexesIfState(ctx context.Context, deliveryKey, expectedState string) error {
+	if err := b.client.Eval(ctx, redisChordRemoveIndexScript,
+		[]string{redisChordDeliveryIndexKey, redisChordTerminalIndexKey, redisChordIndexStateKey}, deliveryKey, expectedState).Err(); err != nil {
+		return fmt.Errorf("remove redis chord indexes: %w", err)
+	}
+	return nil
+}
+
+func (b *BackendRedis) removeChordIndexes(ctx context.Context, deliveryKey string) error {
+	if err := b.client.Eval(ctx, `
+redis.call('ZREM', KEYS[1], ARGV[1])
+redis.call('ZREM', KEYS[2], ARGV[1])
+redis.call('HDEL', KEYS[3], ARGV[1])
+return 1`, []string{redisChordDeliveryIndexKey, redisChordTerminalIndexKey, redisChordIndexStateKey}, deliveryKey).Err(); err != nil {
+		return fmt.Errorf("remove redis chord indexes: %w", err)
+	}
+	return nil
 }
 
 func sameStrings(left, right []string) bool {

--- a/distributed/backend/backend_redis/durable_chord.go
+++ b/distributed/backend/backend_redis/durable_chord.go
@@ -1,0 +1,436 @@
+package backend_redis
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/go-redis/redis/v8"
+	"github.com/songzhibin97/gkit/distributed/backend"
+	"github.com/songzhibin97/gkit/distributed/task"
+)
+
+const redisChordRecordPattern = "gkit:chord:*:record"
+
+var _ backend.DurableChordBackend = (*BackendRedis)(nil)
+
+func redisChordRecordKey(deliveryKey string) (string, error) {
+	parts := strings.Split(deliveryKey, ":")
+	if len(parts) != 4 || parts[0] != "chord" || parts[1] != "v1" || parts[2] == "" {
+		return "", fmt.Errorf("invalid chord delivery key %q", deliveryKey)
+	}
+	return "gkit:chord:{" + parts[2] + "}:record", nil
+}
+
+func (b *BackendRedis) RegisterChord(ctx context.Context, registration backend.ChordRegistration) (backend.ChordRegistrationRef, error) {
+	if err := backend.FinalizeChordRegistration(&registration); err != nil {
+		return backend.ChordRegistrationRef{}, err
+	}
+	owner, err := backend.NewChordOwner()
+	if err != nil {
+		return backend.ChordRegistrationRef{}, err
+	}
+	key, err := redisChordRecordKey(registration.DeliveryKey)
+	if err != nil {
+		return backend.ChordRegistrationRef{}, err
+	}
+	delivery := backend.NewChordDelivery(registration, owner, time.Now())
+	body, err := json.Marshal(&delivery)
+	if err != nil {
+		return backend.ChordRegistrationRef{}, fmt.Errorf("marshal chord registration: %w", err)
+	}
+	created, err := b.client.SetNX(ctx, key, body, 0).Result()
+	if err != nil {
+		return backend.ChordRegistrationRef{}, fmt.Errorf("register redis chord: %w", err)
+	}
+	if created {
+		return backend.ChordRegistrationRef{DeliveryKey: delivery.DeliveryKey, Owner: owner, Version: delivery.RegistrationVersion, Created: true}, nil
+	}
+	existing, err := b.loadChordDelivery(ctx, key)
+	if err != nil {
+		return backend.ChordRegistrationRef{}, err
+	}
+	if !backend.ChordRegistrationMatches(existing, registration) {
+		return backend.ChordRegistrationRef{}, backend.ErrChordRegistrationConflict
+	}
+	return backend.ChordRegistrationRef{DeliveryKey: existing.DeliveryKey, Owner: existing.RegistrationOwner, Version: existing.RegistrationVersion, Created: false}, nil
+}
+
+func (b *BackendRedis) AbortRegistration(ctx context.Context, ref backend.ChordRegistrationRef) error {
+	if !ref.Created {
+		return backend.ErrChordRegistrationOwnershipLost
+	}
+	key, err := redisChordRecordKey(ref.DeliveryKey)
+	if err != nil {
+		return err
+	}
+	for attempt := 0; attempt < 8; attempt++ {
+		err = b.client.Watch(ctx, func(tx *redis.Tx) error {
+			delivery, loadErr := loadRedisChordFromCmd(ctx, tx, key)
+			if errors.Is(loadErr, redis.Nil) {
+				return nil
+			}
+			if loadErr != nil {
+				return loadErr
+			}
+			if delivery.RegistrationOwner != ref.Owner || delivery.RegistrationVersion != ref.Version {
+				return backend.ErrChordRegistrationOwnershipLost
+			}
+			if delivery.MemberPublicationStarted {
+				return backend.ErrChordPublicationStarted
+			}
+			_, pipelineErr := tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+				pipe.Del(ctx, key)
+				return nil
+			})
+			return pipelineErr
+		}, key)
+		if !errors.Is(err, redis.TxFailedErr) {
+			return err
+		}
+	}
+	return fmt.Errorf("abort redis chord: %w", redis.TxFailedErr)
+}
+
+func (b *BackendRedis) ClaimMemberPublication(ctx context.Context, claim backend.ChordMemberClaim) (lease backend.ChordMemberLease, claimed bool, err error) {
+	key, err := redisChordRecordKey(claim.DeliveryKey)
+	if err != nil {
+		return lease, false, err
+	}
+	err = b.updateChordDelivery(ctx, key, func(delivery *backend.ChordDelivery) (bool, error) {
+		var transitionErr error
+		lease, claimed, transitionErr = backend.ClaimChordMember(delivery, claim)
+		return claimed, transitionErr
+	})
+	return lease, claimed, err
+}
+
+func (b *BackendRedis) RecordMemberPublishOutcome(ctx context.Context, lease backend.ChordMemberLease, outcome backend.ChordPublishOutcome) error {
+	key, err := redisChordRecordKey(lease.DeliveryKey)
+	if err != nil {
+		return err
+	}
+	return b.updateChordDelivery(ctx, key, func(delivery *backend.ChordDelivery) (bool, error) {
+		if err := backend.ApplyChordMemberPublishOutcome(delivery, lease, outcome); err != nil {
+			return false, err
+		}
+		return true, nil
+	})
+}
+
+func (b *BackendRedis) RecordMemberTerminal(ctx context.Context, deliveryKey string, ordinal int, taskID string, outcome backend.MemberTerminalOutcome, results []*task.Result) error {
+	key, err := redisChordRecordKey(deliveryKey)
+	if err != nil {
+		return err
+	}
+	return b.updateChordDelivery(ctx, key, func(delivery *backend.ChordDelivery) (bool, error) {
+		before := delivery.Version
+		if err := backend.ApplyChordMemberTerminal(delivery, ordinal, taskID, outcome, results, time.Now()); err != nil {
+			return false, err
+		}
+		return delivery.Version != before, nil
+	})
+}
+
+func (b *BackendRedis) ScanChordDeliveries(ctx context.Context, scan backend.ChordScan) (backend.ChordDeliveryPage, error) {
+	keys, err := b.scanChordRecordKeys(ctx)
+	if err != nil {
+		return backend.ChordDeliveryPage{}, err
+	}
+	deliveries := make([]backend.ChordDelivery, 0, len(keys))
+	for _, key := range keys {
+		delivery, loadErr := b.loadChordDelivery(ctx, key)
+		if errors.Is(loadErr, redis.Nil) {
+			continue
+		}
+		if loadErr != nil {
+			return backend.ChordDeliveryPage{}, loadErr
+		}
+		if scan.Cursor == "" || delivery.DeliveryKey > scan.Cursor {
+			deliveries = append(deliveries, *delivery)
+		}
+	}
+	backend.SortChordDeliveries(deliveries)
+	limit := scan.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+	page := backend.ChordDeliveryPage{}
+	if len(deliveries) > limit {
+		page.Deliveries = deliveries[:limit]
+		page.NextCursor = page.Deliveries[len(page.Deliveries)-1].DeliveryKey
+	} else {
+		page.Deliveries = deliveries
+	}
+	return page, nil
+}
+
+func (b *BackendRedis) ReconcileChord(ctx context.Context, deliveryKey string) error {
+	key, err := redisChordRecordKey(deliveryKey)
+	if err != nil {
+		return err
+	}
+	delivery, err := b.loadChordDelivery(ctx, key)
+	if err != nil {
+		return err
+	}
+	needsSetup := false
+	for index := range delivery.Members {
+		if delivery.Members[index].State == backend.ChordMemberSetup {
+			needsSetup = true
+			break
+		}
+	}
+	if !needsSetup {
+		return nil
+	}
+	taskIDs := make([]string, len(delivery.Members))
+	for index := range delivery.Members {
+		taskIDs[index] = delivery.Members[index].TaskID
+	}
+	group, groupErr := b.getGroup(delivery.GroupID)
+	if errors.Is(groupErr, redis.Nil) {
+		if err := b.GroupTakeOver(delivery.GroupID, delivery.GroupName, taskIDs...); err != nil && !errors.Is(err, ErrGroupAlreadyExists) {
+			return err
+		}
+	} else if groupErr != nil {
+		return groupErr
+	} else if !sameStrings([]string(group.TaskIDs), taskIDs) {
+		return backend.ErrChordRegistrationConflict
+	}
+	for index := range delivery.Members {
+		var signature task.Signature
+		if err := json.Unmarshal(delivery.Members[index].Payload, &signature); err != nil {
+			return fmt.Errorf("decode durable member %d: %w", index, err)
+		}
+		pending, err := json.Marshal(task.NewPendingState(&signature))
+		if err != nil {
+			return err
+		}
+		expiration := b.resultExpire
+		if expiration < 0 {
+			expiration = 0
+		}
+		created, err := b.client.SetNX(ctx, signature.ID, pending, time.Duration(expiration)*time.Second).Result()
+		if err != nil {
+			return err
+		}
+		if !created {
+			value, err := b.client.Get(ctx, signature.ID).Bytes()
+			if err != nil {
+				return err
+			}
+			var existing task.Status
+			if err := json.Unmarshal(value, &existing); err != nil {
+				return err
+			}
+			if existing.GroupID != delivery.GroupID {
+				return backend.ErrChordRegistrationConflict
+			}
+		}
+	}
+	return b.updateChordDelivery(ctx, key, func(current *backend.ChordDelivery) (bool, error) {
+		backend.PrepareChordMembers(current, time.Now())
+		return true, nil
+	})
+}
+
+func (b *BackendRedis) ClaimCallbackPublication(ctx context.Context, claim backend.ChordCallbackClaim) (lease backend.ChordCallbackLease, claimed bool, err error) {
+	key, err := redisChordRecordKey(claim.DeliveryKey)
+	if err != nil {
+		return lease, false, err
+	}
+	delivery, err := b.loadChordDelivery(ctx, key)
+	if err != nil {
+		return lease, false, err
+	}
+	if len(delivery.CallbackPayload) > 0 {
+		var callback task.Signature
+		if err := json.Unmarshal(delivery.CallbackPayload, &callback); err != nil {
+			return lease, false, err
+		}
+		pending, err := json.Marshal(task.NewPendingState(&callback))
+		if err != nil {
+			return lease, false, err
+		}
+		expiration := b.resultExpire
+		if expiration < 0 {
+			expiration = 0
+		}
+		if _, err := b.client.SetNX(ctx, callback.ID, pending, time.Duration(expiration)*time.Second).Result(); err != nil {
+			return lease, false, err
+		}
+	}
+	err = b.updateChordDelivery(ctx, key, func(current *backend.ChordDelivery) (bool, error) {
+		var transitionErr error
+		lease, claimed, transitionErr = backend.ClaimChordCallback(current, claim)
+		return claimed, transitionErr
+	})
+	return lease, claimed, err
+}
+
+func (b *BackendRedis) RecordCallbackPublishOutcome(ctx context.Context, lease backend.ChordCallbackLease, outcome backend.ChordPublishOutcome) error {
+	key, err := redisChordRecordKey(lease.DeliveryKey)
+	if err != nil {
+		return err
+	}
+	return b.updateChordDelivery(ctx, key, func(delivery *backend.ChordDelivery) (bool, error) {
+		if err := backend.ApplyChordCallbackPublishOutcome(delivery, lease, outcome); err != nil {
+			return false, err
+		}
+		return true, nil
+	})
+}
+
+func (b *BackendRedis) RecordCallbackTerminal(ctx context.Context, deliveryKey string, outcome backend.CallbackTerminalOutcome) error {
+	key, err := redisChordRecordKey(deliveryKey)
+	if err != nil {
+		return err
+	}
+	return b.updateChordDelivery(ctx, key, func(delivery *backend.ChordDelivery) (bool, error) {
+		before := delivery.Version
+		if err := backend.ApplyChordCallbackTerminal(delivery, outcome, time.Now()); err != nil {
+			return false, err
+		}
+		return delivery.Version != before, nil
+	})
+}
+
+func (b *BackendRedis) CleanupTerminalChordDeliveries(ctx context.Context, now time.Time, limit int) (int, error) {
+	keys, err := b.scanChordRecordKeys(ctx)
+	if err != nil {
+		return 0, err
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	removed := 0
+	for _, key := range keys {
+		if removed >= limit {
+			break
+		}
+		delivery, loadErr := b.loadChordDelivery(ctx, key)
+		if errors.Is(loadErr, redis.Nil) {
+			continue
+		}
+		if loadErr != nil {
+			return removed, loadErr
+		}
+		if delivery.TerminalExpireAt != nil && !delivery.TerminalExpireAt.After(now) {
+			if err := b.client.Del(ctx, key).Err(); err != nil {
+				return removed, err
+			}
+			removed++
+		}
+	}
+	return removed, nil
+}
+
+func (b *BackendRedis) updateChordDelivery(ctx context.Context, key string, mutate func(*backend.ChordDelivery) (bool, error)) error {
+	for attempt := 0; attempt < 16; attempt++ {
+		err := b.client.Watch(ctx, func(tx *redis.Tx) error {
+			delivery, err := loadRedisChordFromCmd(ctx, tx, key)
+			if err != nil {
+				if errors.Is(err, redis.Nil) {
+					return backend.ErrChordNotFound
+				}
+				return err
+			}
+			changed, err := mutate(delivery)
+			if err != nil || !changed {
+				return err
+			}
+			body, err := json.Marshal(delivery)
+			if err != nil {
+				return err
+			}
+			expiration := time.Duration(0)
+			if delivery.TerminalExpireAt != nil {
+				expiration = time.Until(*delivery.TerminalExpireAt)
+				if expiration <= 0 {
+					expiration = time.Millisecond
+				}
+			}
+			_, err = tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+				pipe.Set(ctx, key, body, expiration)
+				return nil
+			})
+			return err
+		}, key)
+		if !errors.Is(err, redis.TxFailedErr) {
+			return err
+		}
+	}
+	return fmt.Errorf("redis chord CAS exhausted: %w", redis.TxFailedErr)
+}
+
+func (b *BackendRedis) loadChordDelivery(ctx context.Context, key string) (*backend.ChordDelivery, error) {
+	return loadRedisChordFromCmd(ctx, b.client, key)
+}
+
+type redisChordGetter interface {
+	Get(context.Context, string) *redis.StringCmd
+}
+
+func loadRedisChordFromCmd(ctx context.Context, getter redisChordGetter, key string) (*backend.ChordDelivery, error) {
+	body, err := getter.Get(ctx, key).Bytes()
+	if err != nil {
+		return nil, err
+	}
+	var delivery backend.ChordDelivery
+	if err := json.Unmarshal(body, &delivery); err != nil {
+		return nil, fmt.Errorf("decode redis chord %q: %w", key, err)
+	}
+	return &delivery, nil
+}
+
+func (b *BackendRedis) scanChordRecordKeys(ctx context.Context) ([]string, error) {
+	keys := make(map[string]struct{})
+	scanClient := func(client redis.Cmdable) error {
+		var cursor uint64
+		for {
+			batch, next, err := client.Scan(ctx, cursor, redisChordRecordPattern, 100).Result()
+			if err != nil {
+				return err
+			}
+			for _, key := range batch {
+				keys[key] = struct{}{}
+			}
+			cursor = next
+			if cursor == 0 {
+				return nil
+			}
+		}
+	}
+	if cluster, ok := b.client.(*redis.ClusterClient); ok {
+		if err := cluster.ForEachMaster(ctx, func(ctx context.Context, client *redis.Client) error {
+			return scanClient(client)
+		}); err != nil {
+			return nil, err
+		}
+	} else if err := scanClient(b.client); err != nil {
+		return nil, err
+	}
+	result := make([]string, 0, len(keys))
+	for key := range keys {
+		result = append(result, key)
+	}
+	sort.Strings(result)
+	return result, nil
+}
+
+func sameStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}

--- a/distributed/backend/backend_redis/durable_chord.go
+++ b/distributed/backend/backend_redis/durable_chord.go
@@ -15,11 +15,14 @@ import (
 )
 
 const (
-	redisChordDeliveryIndexKey = "gkit:chord:{index}:deliveries:v1"
-	redisChordTerminalIndexKey = "gkit:chord:{index}:terminal:v1"
-	redisChordIndexStateKey    = "gkit:chord:{index}:delivery-state:v1"
+	redisChordKeyPrefix        = "gkit:chord:"
+	redisChordDeliveryIndexKey = redisChordKeyPrefix + "{index}:deliveries:v1"
+	redisChordTerminalIndexKey = redisChordKeyPrefix + "{index}:terminal:v1"
+	redisChordIndexStateKey    = redisChordKeyPrefix + "{index}:delivery-state:v1"
 	redisChordCursorPrefix     = "chord-index-v1."
 )
+
+var errInvalidRedisChordRecord = errors.New("invalid redis chord record")
 
 const (
 	redisChordPrepareIndexScript = `
@@ -94,11 +97,14 @@ func redisChordRecordKey(deliveryKey string) (string, error) {
 	if len(parts) != 4 || parts[0] != "chord" || parts[1] != "v1" || parts[2] == "" {
 		return "", fmt.Errorf("invalid chord delivery key %q", deliveryKey)
 	}
-	return "gkit:chord:{" + parts[2] + "}:record", nil
+	return redisChordKeyPrefix + "{" + parts[2] + "}:record", nil
 }
 
 func (b *BackendRedis) RegisterChord(ctx context.Context, registration backend.ChordRegistration) (backend.ChordRegistrationRef, error) {
 	if err := backend.FinalizeChordRegistration(&registration); err != nil {
+		return backend.ChordRegistrationRef{}, err
+	}
+	if err := validateRedisChordRegistration(registration); err != nil {
 		return backend.ChordRegistrationRef{}, err
 	}
 	owner, err := backend.NewChordOwner()
@@ -156,7 +162,13 @@ func (b *BackendRedis) RegisterChord(ctx context.Context, registration backend.C
 	}
 	existing, err := b.loadChordDelivery(ctx, key)
 	if err != nil {
+		if errors.Is(err, errInvalidRedisChordRecord) {
+			return backend.ChordRegistrationRef{}, b.rejectOccupiedChordRecord(ctx, delivery.DeliveryKey, owner, key)
+		}
 		return backend.ChordRegistrationRef{}, err
+	}
+	if !validRedisChordRecord(existing, key) {
+		return backend.ChordRegistrationRef{}, b.rejectOccupiedChordRecord(ctx, delivery.DeliveryKey, owner, key)
 	}
 	if existing.DeliveryKey == delivery.DeliveryKey {
 		if err := b.commitChordIndex(ctx, existing.DeliveryKey, owner, existing.RegistrationOwner); err != nil {
@@ -378,6 +390,9 @@ func (b *BackendRedis) ReconcileChord(ctx context.Context, deliveryKey string) e
 	if err != nil {
 		return err
 	}
+	if err := validateRedisChordDeliverySetup(delivery); err != nil {
+		return err
+	}
 	needsSetup := false
 	for index := range delivery.Members {
 		if delivery.Members[index].State == backend.ChordMemberSetup {
@@ -451,6 +466,9 @@ func (b *BackendRedis) ClaimCallbackPublication(ctx context.Context, claim backe
 	if len(delivery.CallbackPayload) > 0 {
 		var callback task.Signature
 		if err := json.Unmarshal(delivery.CallbackPayload, &callback); err != nil {
+			return lease, false, err
+		}
+		if err := validateRedisUserKey("callback", callback.ID); err != nil {
 			return lease, false, err
 		}
 		pending, err := json.Marshal(task.NewPendingState(&callback))
@@ -643,9 +661,74 @@ func loadRedisChordFromCmd(ctx context.Context, getter redisChordGetter, key str
 	}
 	var delivery backend.ChordDelivery
 	if err := json.Unmarshal(body, &delivery); err != nil {
-		return nil, fmt.Errorf("decode redis chord %q: %w", key, err)
+		return nil, fmt.Errorf("%w: decode redis chord %q: %v", errInvalidRedisChordRecord, key, err)
 	}
 	return &delivery, nil
+}
+
+func validateRedisChordRegistration(registration backend.ChordRegistration) error {
+	if err := validateRedisUserKey("group", registration.GroupID); err != nil {
+		return err
+	}
+	for index, member := range registration.Members {
+		if err := validateRedisUserKey(fmt.Sprintf("member %d", index), member.TaskID); err != nil {
+			return err
+		}
+		var signature task.Signature
+		if err := json.Unmarshal(member.Payload, &signature); err != nil {
+			return fmt.Errorf("%w: decode redis member %d: %v", backend.ErrChordInvalidInput, index, err)
+		}
+		if signature.ID != member.TaskID {
+			return fmt.Errorf("%w: redis member %d payload id %q does not match registration id %q", backend.ErrChordInvalidInput, index, signature.ID, member.TaskID)
+		}
+		if err := validateRedisUserKey(fmt.Sprintf("member %d", index), signature.ID); err != nil {
+			return err
+		}
+	}
+	var callback task.Signature
+	if err := json.Unmarshal(registration.Callback, &callback); err != nil {
+		return fmt.Errorf("%w: decode redis callback: %v", backend.ErrChordInvalidInput, err)
+	}
+	return validateRedisUserKey("callback", callback.ID)
+}
+
+func validateRedisChordDeliverySetup(delivery *backend.ChordDelivery) error {
+	if delivery == nil {
+		return fmt.Errorf("%w: nil redis chord delivery", backend.ErrChordInvalidInput)
+	}
+	if err := validateRedisUserKey("group", delivery.GroupID); err != nil {
+		return err
+	}
+	for index, member := range delivery.Members {
+		if err := validateRedisUserKey(fmt.Sprintf("member %d", index), member.TaskID); err != nil {
+			return err
+		}
+		var signature task.Signature
+		if err := json.Unmarshal(member.Payload, &signature); err != nil {
+			return fmt.Errorf("%w: decode redis member %d: %v", backend.ErrChordInvalidInput, index, err)
+		}
+		if signature.ID != member.TaskID {
+			return fmt.Errorf("%w: redis member %d payload id %q does not match stored id %q", backend.ErrChordInvalidInput, index, signature.ID, member.TaskID)
+		}
+		if err := validateRedisUserKey(fmt.Sprintf("member %d", index), signature.ID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validRedisChordRecord(delivery *backend.ChordDelivery, recordKey string) bool {
+	if delivery == nil || delivery.DeliveryKey == "" || delivery.GroupID == "" || delivery.RegistrationOwner == "" || delivery.RegistrationVersion <= 0 {
+		return false
+	}
+	key, err := redisChordRecordKey(delivery.DeliveryKey)
+	return err == nil && key == recordKey
+}
+
+func (b *BackendRedis) rejectOccupiedChordRecord(ctx context.Context, deliveryKey, owner, recordKey string) error {
+	collisionErr := fmt.Errorf("%w: redis chord record %q is occupied by incompatible data", backend.ErrChordRegistrationConflict, recordKey)
+	cleanupErr := b.removeChordIndexesIfState(ctx, deliveryKey, "pending:"+owner)
+	return errors.Join(collisionErr, cleanupErr)
 }
 
 func encodeRedisChordCursor(lastKey string) string {

--- a/distributed/backend/backend_redis/durable_chord_contract_regression_test.go
+++ b/distributed/backend/backend_redis/durable_chord_contract_regression_test.go
@@ -1,0 +1,16 @@
+package backend_redis
+
+import (
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/go-redis/redis/v8"
+	"github.com/songzhibin97/gkit/distributed/backend/chordtest"
+)
+
+func TestDurableChordContract(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	chordtest.Run(t, NewBackendRedis(client, -1).(*BackendRedis))
+}

--- a/distributed/backend/backend_redis/durable_chord_namespace_regression_test.go
+++ b/distributed/backend/backend_redis/durable_chord_namespace_regression_test.go
@@ -1,0 +1,156 @@
+package backend_redis
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/go-redis/redis/v8"
+	"github.com/songzhibin97/gkit/distributed/backend"
+	"github.com/songzhibin97/gkit/distributed/task"
+)
+
+func TestRedisRawKeyWritersRejectDurableChordNamespace(t *testing.T) {
+	tests := []struct {
+		name  string
+		write func(*BackendRedis, string) error
+	}{
+		{name: "group takeover", write: func(b *BackendRedis, id string) error { return b.GroupTakeOver(id, "group", "member") }},
+		{name: "group completion", write: func(b *BackendRedis, id string) error { _, err := b.TriggerCompleted(id); return err }},
+		{name: "task pending", write: func(b *BackendRedis, id string) error {
+			return b.SetStatePending(&task.Signature{ID: id, Name: "task"})
+		}},
+		{name: "task received", write: func(b *BackendRedis, id string) error {
+			return b.SetStateReceived(&task.Signature{ID: id, Name: "task"})
+		}},
+		{name: "task started", write: func(b *BackendRedis, id string) error {
+			return b.SetStateStarted(&task.Signature{ID: id, Name: "task"})
+		}},
+		{name: "task retry", write: func(b *BackendRedis, id string) error { return b.SetStateRetry(&task.Signature{ID: id, Name: "task"}) }},
+		{name: "task success", write: func(b *BackendRedis, id string) error {
+			return b.SetStateSuccess(&task.Signature{ID: id, Name: "task"}, nil)
+		}},
+		{name: "task failure", write: func(b *BackendRedis, id string) error {
+			return b.SetStateFailure(&task.Signature{ID: id, Name: "task"}, "failure")
+		}},
+		{name: "task reset", write: func(b *BackendRedis, id string) error { return b.ResetTask(id) }},
+		{name: "group reset", write: func(b *BackendRedis, id string) error { return b.ResetGroup(id) }},
+	}
+
+	for index, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mr := miniredis.RunT(t)
+			client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+			t.Cleanup(func() { _ = client.Close() })
+			b := NewBackendRedis(client, -1).(*BackendRedis)
+			id := fmt.Sprintf("gkit:chord:{user-%d}:record", index)
+			const legacyValue = "legacy-user-value"
+			if err := client.Set(context.Background(), id, legacyValue, 0).Err(); err != nil {
+				t.Fatalf("seed legacy key: %v", err)
+			}
+
+			err := tt.write(b, id)
+			if !errors.Is(err, backend.ErrChordInvalidInput) {
+				t.Fatalf("write error = %v, want ErrChordInvalidInput for reserved Redis key", err)
+			}
+			if got := client.Get(context.Background(), id).Val(); got != legacyValue {
+				t.Fatalf("reserved writer changed legacy value to %q", got)
+			}
+		})
+	}
+
+	t.Run("fresh reserved group", func(t *testing.T) {
+		mr := miniredis.RunT(t)
+		client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+		t.Cleanup(func() { _ = client.Close() })
+		b := NewBackendRedis(client, -1).(*BackendRedis)
+		const id = "gkit:chord:{fresh-user}:record"
+		if err := b.GroupTakeOver(id, "group", "member"); !errors.Is(err, backend.ErrChordInvalidInput) {
+			t.Fatalf("fresh reserved GroupTakeOver error = %v, want ErrChordInvalidInput", err)
+		}
+		if _, err := client.Get(context.Background(), id).Result(); !errors.Is(err, redis.Nil) {
+			t.Fatalf("fresh reserved key was created: %v", err)
+		}
+	})
+}
+
+func TestRedisChordRegistrationFailsClosedOnLegacyRecordCollision(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		body func(*testing.T, string) []byte
+	}{
+		{
+			name: "legacy task status",
+			body: func(t *testing.T, id string) []byte {
+				t.Helper()
+				body, err := json.Marshal(task.NewPendingState(&task.Signature{ID: id, Name: "legacy"}))
+				if err != nil {
+					t.Fatal(err)
+				}
+				return body
+			},
+		},
+		{name: "malformed legacy value", body: func(*testing.T, string) []byte { return []byte("legacy-non-json-value") }},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			mr := miniredis.RunT(t)
+			client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+			t.Cleanup(func() { _ = client.Close() })
+			b := NewBackendRedis(client, -1).(*BackendRedis)
+			registration := namespaceRegistration(t, "legacy-collision-"+tt.name)
+			recordKey, err := redisChordRecordKey(registration.DeliveryKey)
+			if err != nil {
+				t.Fatal(err)
+			}
+			legacyBody := tt.body(t, recordKey)
+			if err := client.Set(context.Background(), recordKey, legacyBody, 0).Err(); err != nil {
+				t.Fatal(err)
+			}
+
+			if _, err := b.RegisterChord(context.Background(), registration); !errors.Is(err, backend.ErrChordRegistrationConflict) {
+				t.Fatalf("RegisterChord error = %v, want ErrChordRegistrationConflict", err)
+			}
+			if got := client.Get(context.Background(), recordKey).Val(); got != string(legacyBody) {
+				t.Fatalf("legacy record changed to %q", got)
+			}
+			if _, err := client.ZScore(context.Background(), redisChordDeliveryIndexKey, registration.DeliveryKey).Result(); !errors.Is(err, redis.Nil) {
+				t.Fatalf("failed registration left delivery index: %v", err)
+			}
+			if _, err := client.HGet(context.Background(), redisChordIndexStateKey, registration.DeliveryKey).Result(); !errors.Is(err, redis.Nil) {
+				t.Fatalf("failed registration left index state: %v", err)
+			}
+			if _, err := client.ZScore(context.Background(), redisChordDeliveryIndexKey, "").Result(); !errors.Is(err, redis.Nil) {
+				t.Fatalf("legacy value created an empty delivery index: %v", err)
+			}
+		})
+	}
+}
+
+func namespaceRegistration(t *testing.T, suffix string) backend.ChordRegistration {
+	t.Helper()
+	groupID := "namespace-group-" + suffix
+	callback := task.NewSignature("namespace-callback-"+suffix, "callback")
+	callbackBody, err := json.Marshal(callback)
+	if err != nil {
+		t.Fatal(err)
+	}
+	member := task.NewSignature("namespace-member-"+suffix, "member")
+	memberBody, err := json.Marshal(member)
+	if err != nil {
+		t.Fatal(err)
+	}
+	registration := backend.ChordRegistration{
+		GroupID:   groupID,
+		GroupName: "namespace",
+		Retention: -1,
+		Callback:  callbackBody,
+		Members:   []backend.ChordMemberRegistration{{Ordinal: 0, TaskID: member.ID, Payload: memberBody}},
+	}
+	if err := backend.FinalizeChordRegistration(&registration); err != nil {
+		t.Fatal(err)
+	}
+	return registration
+}

--- a/distributed/backend/backend_redis/durable_chord_pagination_regression_test.go
+++ b/distributed/backend/backend_redis/durable_chord_pagination_regression_test.go
@@ -1,0 +1,863 @@
+package backend_redis
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/go-redis/redis/v8"
+	"github.com/songzhibin97/gkit/distributed/backend"
+	"github.com/songzhibin97/gkit/distributed/task"
+)
+
+type issue104CommandCountHook struct {
+	mu   sync.Mutex
+	gets int
+}
+
+type issue104FailCommandHook struct {
+	mu      sync.Mutex
+	command string
+	fail    bool
+}
+
+type issue104SetNXBarrierHook struct {
+	once    sync.Once
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (h *issue104SetNXBarrierHook) BeforeProcess(ctx context.Context, cmd redis.Cmder) (context.Context, error) {
+	if strings.EqualFold(cmd.Name(), "setnx") {
+		h.once.Do(func() {
+			close(h.entered)
+			<-h.release
+		})
+	}
+	return ctx, nil
+}
+
+func (*issue104SetNXBarrierHook) AfterProcess(context.Context, redis.Cmder) error { return nil }
+func (h *issue104SetNXBarrierHook) BeforeProcessPipeline(ctx context.Context, _ []redis.Cmder) (context.Context, error) {
+	return ctx, nil
+}
+func (*issue104SetNXBarrierHook) AfterProcessPipeline(context.Context, []redis.Cmder) error {
+	return nil
+}
+
+type issue104DeleteBarrierHook struct {
+	recordKey       string
+	deleted         chan struct{}
+	release         chan struct{}
+	sawDeleting     chan struct{}
+	deleteOnce      sync.Once
+	registrationOne sync.Once
+}
+
+type issue104PreDeleteBarrierHook struct {
+	fenced      chan struct{}
+	deleteReady chan struct{}
+	release     chan struct{}
+	fenceOnce   sync.Once
+	deleteOnce  sync.Once
+}
+
+type issue104StaleScannerBarrierHook struct {
+	ensureReady   chan struct{}
+	releaseEnsure chan struct{}
+	setNXReady    chan struct{}
+	releaseSetNX  chan struct{}
+	ensureOnce    sync.Once
+	setNXOnce     sync.Once
+}
+
+func (h *issue104StaleScannerBarrierHook) BeforeProcess(ctx context.Context, cmd redis.Cmder) (context.Context, error) {
+	args := cmd.Args()
+	if strings.EqualFold(cmd.Name(), "eval") && len(args) > 1 && fmt.Sprint(args[1]) == redisChordEnsureIndexScript {
+		h.ensureOnce.Do(func() {
+			close(h.ensureReady)
+			<-h.releaseEnsure
+		})
+	}
+	if strings.EqualFold(cmd.Name(), "setnx") {
+		h.setNXOnce.Do(func() {
+			close(h.setNXReady)
+			<-h.releaseSetNX
+		})
+	}
+	return ctx, nil
+}
+
+func (*issue104StaleScannerBarrierHook) AfterProcess(context.Context, redis.Cmder) error { return nil }
+func (h *issue104StaleScannerBarrierHook) BeforeProcessPipeline(ctx context.Context, cmds []redis.Cmder) (context.Context, error) {
+	for _, cmd := range cmds {
+		if _, err := h.BeforeProcess(ctx, cmd); err != nil {
+			return ctx, err
+		}
+	}
+	return ctx, nil
+}
+func (*issue104StaleScannerBarrierHook) AfterProcessPipeline(context.Context, []redis.Cmder) error {
+	return nil
+}
+
+func (h *issue104PreDeleteBarrierHook) BeforeProcess(ctx context.Context, cmd redis.Cmder) (context.Context, error) {
+	args := cmd.Args()
+	if strings.EqualFold(cmd.Name(), "eval") && len(args) > 1 && fmt.Sprint(args[1]) == redisChordDeleteRecordScript {
+		h.deleteOnce.Do(func() {
+			close(h.deleteReady)
+			<-h.release
+		})
+	}
+	return ctx, nil
+}
+
+func (h *issue104PreDeleteBarrierHook) AfterProcess(_ context.Context, cmd redis.Cmder) error {
+	args := cmd.Args()
+	if strings.EqualFold(cmd.Name(), "eval") && len(args) > 1 && fmt.Sprint(args[1]) == redisChordBeginDeleteScript {
+		if value, err := cmd.(*redis.Cmd).Int(); err == nil && value == 1 {
+			h.fenceOnce.Do(func() { close(h.fenced) })
+		}
+	}
+	return nil
+}
+
+func (h *issue104PreDeleteBarrierHook) BeforeProcessPipeline(ctx context.Context, cmds []redis.Cmder) (context.Context, error) {
+	for _, cmd := range cmds {
+		if _, err := h.BeforeProcess(ctx, cmd); err != nil {
+			return ctx, err
+		}
+	}
+	return ctx, nil
+}
+func (*issue104PreDeleteBarrierHook) AfterProcessPipeline(context.Context, []redis.Cmder) error {
+	return nil
+}
+
+func (h *issue104DeleteBarrierHook) BeforeProcess(ctx context.Context, _ redis.Cmder) (context.Context, error) {
+	return ctx, nil
+}
+
+func (h *issue104DeleteBarrierHook) AfterProcess(_ context.Context, cmd redis.Cmder) error {
+	args := cmd.Args()
+	if strings.EqualFold(cmd.Name(), "eval") && len(args) > 3 && fmt.Sprint(args[1]) == redisChordDeleteRecordScript && fmt.Sprint(args[3]) == h.recordKey {
+		h.deleteOnce.Do(func() {
+			close(h.deleted)
+			<-h.release
+		})
+	}
+	if strings.EqualFold(cmd.Name(), "eval") && len(args) > 1 && fmt.Sprint(args[1]) == redisChordPrepareIndexScript {
+		if value, err := cmd.(*redis.Cmd).Text(); err == nil && strings.HasPrefix(value, "deleting:") {
+			h.registrationOne.Do(func() { close(h.sawDeleting) })
+		}
+	}
+	return nil
+}
+
+func (h *issue104DeleteBarrierHook) BeforeProcessPipeline(ctx context.Context, _ []redis.Cmder) (context.Context, error) {
+	return ctx, nil
+}
+func (h *issue104DeleteBarrierHook) AfterProcessPipeline(ctx context.Context, cmds []redis.Cmder) error {
+	for _, cmd := range cmds {
+		if err := h.AfterProcess(ctx, cmd); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (h *issue104FailCommandHook) BeforeProcess(ctx context.Context, cmd redis.Cmder) (context.Context, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.fail && strings.EqualFold(cmd.Name(), h.command) {
+		h.fail = false
+		return ctx, errors.New("injected redis registration failure")
+	}
+	return ctx, nil
+}
+
+func (*issue104FailCommandHook) AfterProcess(context.Context, redis.Cmder) error { return nil }
+func (h *issue104FailCommandHook) BeforeProcessPipeline(ctx context.Context, _ []redis.Cmder) (context.Context, error) {
+	return ctx, nil
+}
+func (*issue104FailCommandHook) AfterProcessPipeline(context.Context, []redis.Cmder) error {
+	return nil
+}
+
+func (h *issue104CommandCountHook) BeforeProcess(ctx context.Context, _ redis.Cmder) (context.Context, error) {
+	return ctx, nil
+}
+
+func (h *issue104CommandCountHook) AfterProcess(_ context.Context, cmd redis.Cmder) error {
+	if strings.EqualFold(cmd.Name(), "get") {
+		h.mu.Lock()
+		h.gets++
+		h.mu.Unlock()
+	}
+	return nil
+}
+
+func (h *issue104CommandCountHook) BeforeProcessPipeline(ctx context.Context, _ []redis.Cmder) (context.Context, error) {
+	return ctx, nil
+}
+
+func (h *issue104CommandCountHook) AfterProcessPipeline(_ context.Context, cmds []redis.Cmder) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, cmd := range cmds {
+		if strings.EqualFold(cmd.Name(), "get") {
+			h.gets++
+		}
+	}
+	return nil
+}
+
+func (h *issue104CommandCountHook) reset() {
+	h.mu.Lock()
+	h.gets = 0
+	h.mu.Unlock()
+}
+
+func (h *issue104CommandCountHook) count() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.gets
+}
+
+func TestDurableChordRedisBoundedPagination(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	runDurableChordRedisBoundedPagination(t, client)
+}
+
+func TestDurableChordRedisPaginationRepairsHolesAndPartialRegistration(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	b := NewBackendRedis(client, -1).(*BackendRedis)
+	ctx := context.Background()
+
+	for index := 0; index < 25; index++ {
+		registration := issue104PaginationRegistration(t, fmt.Sprintf("hole-group-%02d", index))
+		if _, err := b.RegisterChord(ctx, registration); err != nil {
+			t.Fatal(err)
+		}
+	}
+	indexed, err := client.ZRange(ctx, redisChordDeliveryIndexKey, 0, -1).Result()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, deliveryKey := range indexed[:7] {
+		recordKey, err := redisChordRecordKey(deliveryKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := client.Del(ctx, recordKey).Err(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	seen := make(map[string]struct{})
+	cursor := ""
+	for {
+		page, err := b.ScanChordDeliveries(ctx, backend.ChordScan{Cursor: cursor, Limit: 5})
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, delivery := range page.Deliveries {
+			if _, duplicate := seen[delivery.DeliveryKey]; duplicate {
+				t.Fatalf("duplicate delivery after holes: %s", delivery.DeliveryKey)
+			}
+			seen[delivery.DeliveryKey] = struct{}{}
+		}
+		if page.NextCursor == "" {
+			break
+		}
+		cursor = page.NextCursor
+	}
+	if len(seen) != 18 {
+		t.Fatalf("deliveries after holes = %d, want 18", len(seen))
+	}
+	if got := client.ZCard(ctx, redisChordDeliveryIndexKey).Val(); got != 18 {
+		t.Fatalf("repaired delivery index size = %d, want 18", got)
+	}
+
+	missingIndexRegistration := issue104PaginationRegistration(t, "missing-index-group")
+	missingRef, err := b.RegisterChord(ctx, missingIndexRegistration)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := client.ZRem(ctx, redisChordDeliveryIndexKey, missingRef.DeliveryKey).Err(); err != nil {
+		t.Fatal(err)
+	}
+	attached, err := b.RegisterChord(ctx, missingIndexRegistration)
+	if err != nil || attached.Created {
+		t.Fatalf("repair registration = %#v, %v", attached, err)
+	}
+	if scoreErr := client.ZScore(ctx, redisChordDeliveryIndexKey, missingRef.DeliveryKey).Err(); scoreErr != nil {
+		t.Fatalf("missing index was not repaired: %v", scoreErr)
+	}
+
+	failHook := &issue104FailCommandHook{command: "setnx", fail: true}
+	client.AddHook(failHook)
+	partial := issue104PaginationRegistration(t, "partial-index-group")
+	if _, err := b.RegisterChord(ctx, partial); err == nil || !strings.Contains(err.Error(), "injected redis registration failure") {
+		t.Fatalf("partial registration error = %v", err)
+	}
+	if scoreErr := client.ZScore(ctx, redisChordDeliveryIndexKey, partial.DeliveryKey).Err(); scoreErr != nil {
+		t.Fatalf("index-first partial registration left no repairable hole: %v", scoreErr)
+	}
+	page, err := b.ScanChordDeliveries(ctx, backend.ChordScan{Limit: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, delivery := range page.Deliveries {
+		if delivery.DeliveryKey == partial.DeliveryKey {
+			t.Fatal("index hole surfaced as a delivery")
+		}
+	}
+	if state := client.HGet(ctx, redisChordIndexStateKey, partial.DeliveryKey).Val(); !strings.HasPrefix(state, "pending:") {
+		t.Fatalf("partial registration state = %q, want fenced pending generation", state)
+	}
+	retried, err := b.RegisterChord(ctx, partial)
+	if err != nil || !retried.Created {
+		t.Fatalf("partial registration retry = %#v, %v", retried, err)
+	}
+	if state := client.HGet(ctx, redisChordIndexStateKey, partial.DeliveryKey).Val(); state != "committed:"+retried.Owner {
+		t.Fatalf("retried registration state = %q, want committed owner", state)
+	}
+
+	if _, err := b.ScanChordDeliveries(ctx, backend.ChordScan{Cursor: "raw-delivery-key", Limit: 5}); err == nil {
+		t.Fatal("raw/invalid Redis chord cursor was accepted")
+	}
+}
+
+func TestDurableChordRedisPendingRegistrationFencesHoleCleanup(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	barrier := &issue104SetNXBarrierHook{entered: make(chan struct{}), release: make(chan struct{})}
+	client.AddHook(barrier)
+	b := NewBackendRedis(client, -1).(*BackendRedis)
+	registration := issue104PaginationRegistration(t, "pending-registration-race")
+
+	type registerResult struct {
+		ref backend.ChordRegistrationRef
+		err error
+	}
+	result := make(chan registerResult, 1)
+	go func() {
+		ref, err := b.RegisterChord(context.Background(), registration)
+		result <- registerResult{ref: ref, err: err}
+	}()
+	<-barrier.entered
+	page, err := b.ScanChordDeliveries(context.Background(), backend.ChordScan{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Deliveries) != 0 {
+		t.Fatalf("pending registration surfaced before SETNX: %#v", page.Deliveries)
+	}
+	if scoreErr := client.ZScore(context.Background(), redisChordDeliveryIndexKey, registration.DeliveryKey).Err(); scoreErr != nil {
+		t.Fatalf("scanner removed pending index generation: %v", scoreErr)
+	}
+	close(barrier.release)
+	registered := <-result
+	if registered.err != nil || !registered.ref.Created {
+		t.Fatalf("registration result = %#v, %v", registered.ref, registered.err)
+	}
+	if state := client.HGet(context.Background(), redisChordIndexStateKey, registration.DeliveryKey).Val(); state != "committed:"+registered.ref.Owner {
+		t.Fatalf("registration state = %q, want committed owner", state)
+	}
+}
+
+func TestDurableChordRedisAttachPrepareDoesNotPoisonCommittedOwner(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	b := NewBackendRedis(client, -1).(*BackendRedis)
+	ctx := context.Background()
+	registration := issue104PaginationRegistration(t, "attach-prepare-crash")
+	oldRef, err := b.RegisterChord(ctx, registration)
+	if err != nil {
+		t.Fatal(err)
+	}
+	barrier := &issue104SetNXBarrierHook{entered: make(chan struct{}), release: make(chan struct{})}
+	client.AddHook(barrier)
+
+	type registerResult struct {
+		ref backend.ChordRegistrationRef
+		err error
+	}
+	attachDone := make(chan registerResult, 1)
+	go func() {
+		ref, attachErr := b.RegisterChord(ctx, registration)
+		attachDone <- registerResult{ref: ref, err: attachErr}
+	}()
+	<-barrier.entered
+	if state := client.HGet(ctx, redisChordIndexStateKey, oldRef.DeliveryKey).Val(); state != "committed:"+oldRef.Owner {
+		t.Fatalf("attach prepare changed committed owner to %q", state)
+	}
+	if err := b.AbortRegistration(ctx, oldRef); err != nil {
+		t.Fatalf("original owner could not abort after attach stopped at SETNX: %v", err)
+	}
+	close(barrier.release)
+	replacement := <-attachDone
+	if replacement.err != nil || !replacement.ref.Created {
+		t.Fatalf("replacement after abort = %#v, %v", replacement.ref, replacement.err)
+	}
+	if state := client.HGet(ctx, redisChordIndexStateKey, replacement.ref.DeliveryKey).Val(); state != "committed:"+replacement.ref.Owner {
+		t.Fatalf("replacement state = %q, want committed owner", state)
+	}
+}
+
+func TestDurableChordRedisStaleScannerCannotOverwritePendingGeneration(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	b := NewBackendRedis(client, -1).(*BackendRedis)
+	ctx := context.Background()
+	registration := issue104PaginationRegistration(t, "stale-scanner-generation-race")
+	oldRef, err := b.RegisterChord(ctx, registration)
+	if err != nil {
+		t.Fatal(err)
+	}
+	barrier := &issue104StaleScannerBarrierHook{
+		ensureReady:   make(chan struct{}),
+		releaseEnsure: make(chan struct{}),
+		setNXReady:    make(chan struct{}),
+		releaseSetNX:  make(chan struct{}),
+	}
+	client.AddHook(barrier)
+	scanDone := make(chan error, 1)
+	go func() {
+		_, scanErr := b.ScanChordDeliveries(ctx, backend.ChordScan{Limit: 10})
+		scanDone <- scanErr
+	}()
+	<-barrier.ensureReady
+	if err := b.AbortRegistration(ctx, oldRef); err != nil {
+		t.Fatal(err)
+	}
+
+	type registerResult struct {
+		ref backend.ChordRegistrationRef
+		err error
+	}
+	registerDone := make(chan registerResult, 1)
+	go func() {
+		ref, registerErr := b.RegisterChord(ctx, registration)
+		registerDone <- registerResult{ref: ref, err: registerErr}
+	}()
+	<-barrier.setNXReady
+	pendingState := client.HGet(ctx, redisChordIndexStateKey, oldRef.DeliveryKey).Val()
+	if !strings.HasPrefix(pendingState, "pending:") {
+		t.Fatalf("replacement state = %q, want pending generation", pendingState)
+	}
+	close(barrier.releaseEnsure)
+	if err := <-scanDone; err != nil {
+		t.Fatal(err)
+	}
+	if state := client.HGet(ctx, redisChordIndexStateKey, oldRef.DeliveryKey).Val(); state != pendingState {
+		t.Fatalf("stale scanner changed pending generation from %q to %q", pendingState, state)
+	}
+	close(barrier.releaseSetNX)
+	registered := <-registerDone
+	if registered.err != nil || !registered.ref.Created {
+		t.Fatalf("replacement registration = %#v, %v", registered.ref, registered.err)
+	}
+	if state := client.HGet(ctx, redisChordIndexStateKey, registered.ref.DeliveryKey).Val(); state != "committed:"+registered.ref.Owner {
+		t.Fatalf("replacement state = %q, want committed owner", state)
+	}
+	if err := b.AbortRegistration(ctx, registered.ref); err != nil {
+		t.Fatalf("replacement owner could not acquire abort fence: %v", err)
+	}
+}
+
+func TestDurableChordRedisCleanupFencesConcurrentReregistration(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	b := NewBackendRedis(client, -1).(*BackendRedis)
+	ctx := context.Background()
+	registration := issue104PaginationRegistration(t, "cleanup-reregistration-race")
+	oldRef, err := b.RegisterChord(ctx, registration)
+	if err != nil {
+		t.Fatal(err)
+	}
+	recordKey, err := redisChordRecordKey(oldRef.DeliveryKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	delivery, err := b.loadChordDelivery(ctx, recordKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	past := time.Now().Add(-time.Minute)
+	delivery.TerminalExpireAt = &past
+	body, err := json.Marshal(delivery)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := client.Set(ctx, recordKey, body, 0).Err(); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.ZAdd(ctx, redisChordTerminalIndexKey, &redis.Z{Score: float64(past.UnixMilli()), Member: oldRef.DeliveryKey}).Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	barrier := &issue104DeleteBarrierHook{
+		recordKey:   recordKey,
+		deleted:     make(chan struct{}),
+		release:     make(chan struct{}),
+		sawDeleting: make(chan struct{}),
+	}
+	client.AddHook(barrier)
+	cleanupResult := make(chan error, 1)
+	go func() {
+		_, cleanupErr := b.CleanupTerminalChordDeliveries(ctx, time.Now(), 1)
+		cleanupResult <- cleanupErr
+	}()
+	<-barrier.deleted
+	oldDeletingState := client.HGet(ctx, redisChordIndexStateKey, oldRef.DeliveryKey).Val()
+	if !strings.HasPrefix(oldDeletingState, "deleting:") {
+		t.Fatalf("cleanup state = %q, want deleting generation", oldDeletingState)
+	}
+
+	type registerResult struct {
+		ref backend.ChordRegistrationRef
+		err error
+	}
+	registerDone := make(chan registerResult, 1)
+	go func() {
+		ref, registerErr := b.RegisterChord(ctx, registration)
+		registerDone <- registerResult{ref: ref, err: registerErr}
+	}()
+	<-barrier.sawDeleting
+	close(barrier.release)
+	if err := <-cleanupResult; err != nil {
+		t.Fatal(err)
+	}
+	registered := <-registerDone
+	if registered.err != nil || !registered.ref.Created {
+		t.Fatalf("concurrent registration = %#v, %v", registered.ref, registered.err)
+	}
+	if err := b.removeChordIndexesIfState(ctx, registered.ref.DeliveryKey, oldDeletingState); err != nil {
+		t.Fatal(err)
+	}
+	if scoreErr := client.ZScore(ctx, redisChordDeliveryIndexKey, registered.ref.DeliveryKey).Err(); scoreErr != nil {
+		t.Fatalf("stale cleanup removed new discovery index: %v", scoreErr)
+	}
+	page, err := b.ScanChordDeliveries(ctx, backend.ChordScan{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Deliveries) != 1 || page.Deliveries[0].RegistrationOwner != registered.ref.Owner {
+		t.Fatalf("new generation is not discoverable: %#v", page.Deliveries)
+	}
+}
+
+func TestDurableChordRedisAbortFencesConcurrentReregistration(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	b := NewBackendRedis(client, -1).(*BackendRedis)
+	ctx := context.Background()
+	registration := issue104PaginationRegistration(t, "abort-reregistration-race")
+	oldRef, err := b.RegisterChord(ctx, registration)
+	if err != nil {
+		t.Fatal(err)
+	}
+	recordKey, err := redisChordRecordKey(oldRef.DeliveryKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	barrier := &issue104DeleteBarrierHook{
+		recordKey:   recordKey,
+		deleted:     make(chan struct{}),
+		release:     make(chan struct{}),
+		sawDeleting: make(chan struct{}),
+	}
+	client.AddHook(barrier)
+	abortDone := make(chan error, 1)
+	go func() { abortDone <- b.AbortRegistration(ctx, oldRef) }()
+	<-barrier.deleted
+	oldDeletingState := client.HGet(ctx, redisChordIndexStateKey, oldRef.DeliveryKey).Val()
+	if !strings.HasPrefix(oldDeletingState, "deleting:") {
+		t.Fatalf("abort state = %q, want deleting generation", oldDeletingState)
+	}
+
+	type registerResult struct {
+		ref backend.ChordRegistrationRef
+		err error
+	}
+	registerDone := make(chan registerResult, 1)
+	go func() {
+		ref, registerErr := b.RegisterChord(ctx, registration)
+		registerDone <- registerResult{ref: ref, err: registerErr}
+	}()
+	<-barrier.sawDeleting
+	close(barrier.release)
+	if err := <-abortDone; err != nil {
+		t.Fatal(err)
+	}
+	registered := <-registerDone
+	if registered.err != nil || !registered.ref.Created {
+		t.Fatalf("concurrent registration = %#v, %v", registered.ref, registered.err)
+	}
+	if err := b.removeChordIndexesIfState(ctx, registered.ref.DeliveryKey, oldDeletingState); err != nil {
+		t.Fatal(err)
+	}
+	if scoreErr := client.ZScore(ctx, redisChordDeliveryIndexKey, registered.ref.DeliveryKey).Err(); scoreErr != nil {
+		t.Fatalf("stale abort removed new discovery index: %v", scoreErr)
+	}
+}
+
+func TestDurableChordRedisCleanupOwnerFenceSurvivesTTLAndReregistration(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	b := NewBackendRedis(client, -1).(*BackendRedis)
+	ctx := context.Background()
+	registration := issue104PaginationRegistration(t, "cleanup-ttl-owner-race")
+	oldRef, err := b.RegisterChord(ctx, registration)
+	if err != nil {
+		t.Fatal(err)
+	}
+	recordKey, err := redisChordRecordKey(oldRef.DeliveryKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	delivery, err := b.loadChordDelivery(ctx, recordKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	past := time.Now().Add(-time.Minute)
+	delivery.TerminalExpireAt = &past
+	body, err := json.Marshal(delivery)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := client.Set(ctx, recordKey, body, time.Second).Err(); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.ZAdd(ctx, redisChordTerminalIndexKey, &redis.Z{Score: float64(past.UnixMilli()), Member: oldRef.DeliveryKey}).Err(); err != nil {
+		t.Fatal(err)
+	}
+	barrier := &issue104PreDeleteBarrierHook{
+		fenced:      make(chan struct{}),
+		deleteReady: make(chan struct{}),
+		release:     make(chan struct{}),
+	}
+	client.AddHook(barrier)
+	cleanupDone := make(chan error, 1)
+	go func() {
+		_, cleanupErr := b.CleanupTerminalChordDeliveries(ctx, time.Now(), 1)
+		cleanupDone <- cleanupErr
+	}()
+	<-barrier.fenced
+	<-barrier.deleteReady
+	mr.FastForward(2 * time.Second)
+	if exists := client.Exists(ctx, recordKey).Val(); exists != 0 {
+		t.Fatalf("old terminal record still exists after TTL: %d", exists)
+	}
+	newRef, err := b.RegisterChord(ctx, registration)
+	if err != nil || !newRef.Created {
+		t.Fatalf("replacement registration = %#v, %v", newRef, err)
+	}
+	close(barrier.release)
+	if err := <-cleanupDone; err != nil {
+		t.Fatal(err)
+	}
+	current, err := b.loadChordDelivery(ctx, recordKey)
+	if err != nil {
+		t.Fatalf("old cleanup deleted replacement record: %v", err)
+	}
+	if current.RegistrationOwner != newRef.Owner {
+		t.Fatalf("replacement owner = %q, want %q", current.RegistrationOwner, newRef.Owner)
+	}
+	if scoreErr := client.ZScore(ctx, redisChordDeliveryIndexKey, newRef.DeliveryKey).Err(); scoreErr != nil {
+		t.Fatalf("replacement discovery index missing: %v", scoreErr)
+	}
+}
+
+func TestDurableChordRedisBoundedPaginationLive(t *testing.T) {
+	if addr := os.Getenv("GKIT_REDIS_ADDR"); addr != "" {
+		t.Run("standalone", func(t *testing.T) {
+			client := redis.NewClient(&redis.Options{Addr: addr})
+			t.Cleanup(func() { _ = client.Close() })
+			runDurableChordRedisBoundedPagination(t, client)
+		})
+	}
+	if raw := os.Getenv("GKIT_REDIS_CLUSTER_ADDRS"); raw != "" {
+		t.Run("cluster", func(t *testing.T) {
+			addrs := strings.Split(raw, ",")
+			if len(addrs) != 3 {
+				t.Fatalf("GKIT_REDIS_CLUSTER_ADDRS has %d nodes, want 3", len(addrs))
+			}
+			client := redis.NewClusterClient(&redis.ClusterOptions{
+				Addrs: addrs,
+				// Redis 7 adds endpoint metadata to CLUSTER SLOTS that go-redis v8
+				// predates. The test topology is fixed, so provide the authoritative
+				// slot map and still exercise real Redis 7 cluster routing/MOVED
+				// semantics for every indexed scan and record operation.
+				ClusterSlots: func(context.Context) ([]redis.ClusterSlot, error) {
+					return []redis.ClusterSlot{
+						{Start: 0, End: 5460, Nodes: []redis.ClusterNode{{Addr: addrs[0]}}},
+						{Start: 5461, End: 10922, Nodes: []redis.ClusterNode{{Addr: addrs[1]}}},
+						{Start: 10923, End: 16383, Nodes: []redis.ClusterNode{{Addr: addrs[2]}}},
+					}, nil
+				},
+			})
+			t.Cleanup(func() { _ = client.Close() })
+			runDurableChordRedisBoundedPagination(t, client)
+		})
+	}
+	if os.Getenv("GKIT_REDIS_ADDR") == "" && os.Getenv("GKIT_REDIS_CLUSTER_ADDRS") == "" {
+		t.Skip("GKIT_REDIS_ADDR or GKIT_REDIS_CLUSTER_ADDRS is required")
+	}
+}
+
+func runDurableChordRedisBoundedPagination(t *testing.T, client redis.UniversalClient) {
+	t.Helper()
+	ctx := context.Background()
+	flushIssue104Redis(t, client)
+	b := NewBackendRedis(client, -1).(*BackendRedis)
+	const records = 240
+	states := make(map[string]backend.ChordCallbackState)
+	for index := 0; index < records; index++ {
+		registration := issue104PaginationRegistration(t, fmt.Sprintf("pagination-group-%03d", index))
+		ref, err := b.RegisterChord(ctx, registration)
+		if err != nil {
+			t.Fatalf("register %d: %v", index, err)
+		}
+		switch index {
+		case 1:
+			if err := b.ReconcileChord(ctx, ref.DeliveryKey); err != nil {
+				t.Fatal(err)
+			}
+		case 2:
+			if err := b.ReconcileChord(ctx, ref.DeliveryKey); err != nil {
+				t.Fatal(err)
+			}
+			lease, claimed, err := b.ClaimMemberPublication(ctx, backend.ChordMemberClaim{DeliveryKey: ref.DeliveryKey, Ordinal: 0, Owner: "pagination", Now: time.Now()})
+			if err != nil || !claimed {
+				t.Fatalf("claim unknown fixture = %t, %v", claimed, err)
+			}
+			if err := b.RecordMemberPublishOutcome(ctx, lease, backend.ChordPublishOutcome{Kind: backend.ChordPublishOutcomeUnknown, Now: time.Now(), ConfirmationDeadline: time.Now().Add(time.Hour)}); err != nil {
+				t.Fatal(err)
+			}
+		case 3:
+			if err := b.ReconcileChord(ctx, ref.DeliveryKey); err != nil {
+				t.Fatal(err)
+			}
+			if err := b.RecordMemberTerminal(ctx, ref.DeliveryKey, 0, registration.Members[0].TaskID, backend.MemberTerminalFailure, nil); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	hook := &issue104CommandCountHook{}
+	client.AddHook(hook)
+	cursor := ""
+	totalGets := 0
+	seen := make(map[string]backend.ChordDelivery)
+	pages := 0
+	for {
+		hook.reset()
+		page, err := b.ScanChordDeliveries(ctx, backend.ChordScan{Cursor: cursor, Limit: 12, Now: time.Now()})
+		if err != nil {
+			t.Fatal(err)
+		}
+		pages++
+		pageGets := hook.count()
+		totalGets += pageGets
+		if pageGets > 13 {
+			t.Fatalf("page %d GET count = %d, want <= limit+1", pages, pageGets)
+		}
+		for _, delivery := range page.Deliveries {
+			if _, duplicate := seen[delivery.DeliveryKey]; duplicate {
+				t.Fatalf("duplicate delivery %s", delivery.DeliveryKey)
+			}
+			seen[delivery.DeliveryKey] = delivery
+			states[delivery.DeliveryKey] = delivery.CallbackState
+		}
+		if page.NextCursor == "" {
+			break
+		}
+		if strings.Contains(page.NextCursor, "chord:v1:") {
+			t.Fatalf("cursor exposes raw delivery key: %q", page.NextCursor)
+		}
+		cursor = page.NextCursor
+	}
+	if len(seen) != records {
+		t.Fatalf("scanned deliveries = %d, want %d", len(seen), records)
+	}
+	if pages < 2 {
+		t.Fatalf("pages = %d, want multiple pages", pages)
+	}
+	if totalGets > records+pages {
+		t.Fatalf("total GET count = %d, want O(N) <= %d", totalGets, records+pages)
+	}
+	selected := map[backend.ChordCallbackState]bool{}
+	for _, state := range states {
+		selected[state] = true
+	}
+	if !selected[backend.ChordWaiting] || !selected[backend.ChordSuppressed] {
+		t.Fatalf("selected states = %#v, want WAITING and SUPPRESSED", selected)
+	}
+}
+
+func issue104PaginationRegistration(t *testing.T, groupID string) backend.ChordRegistration {
+	t.Helper()
+	callbackID := "pagination-callback"
+	deliveryKey := backend.ChordDeliveryKey(groupID, callbackID)
+	callback := task.NewSignature(callbackID, "callback")
+	callback.Meta.Set(backend.DurableChordDeliveryKeyMeta, deliveryKey)
+	callbackPayload, err := json.Marshal(callback)
+	if err != nil {
+		t.Fatal(err)
+	}
+	member := task.NewSignature(groupID+"-member", "member")
+	member.GroupID = groupID
+	member.Meta.Set(backend.DurableChordDeliveryKeyMeta, deliveryKey)
+	member.Meta.Set(backend.DurableChordMemberMeta, true)
+	member.Meta.Set(backend.DurableChordMemberOrdinal, 0)
+	memberPayload, err := json.Marshal(member)
+	if err != nil {
+		t.Fatal(err)
+	}
+	registration := backend.ChordRegistration{
+		GroupID:   groupID,
+		GroupName: groupID,
+		Retention: -1,
+		Callback:  callbackPayload,
+		Members:   []backend.ChordMemberRegistration{{Ordinal: 0, TaskID: member.ID, Payload: memberPayload}},
+	}
+	if err := backend.FinalizeChordRegistration(&registration); err != nil {
+		t.Fatal(err)
+	}
+	return registration
+}
+
+func flushIssue104Redis(t *testing.T, client redis.UniversalClient) {
+	t.Helper()
+	ctx := context.Background()
+	if cluster, ok := client.(*redis.ClusterClient); ok {
+		if err := cluster.ForEachMaster(ctx, func(ctx context.Context, master *redis.Client) error {
+			return master.FlushDB(ctx).Err()
+		}); err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+	if err := client.FlushDB(ctx).Err(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/distributed/backend/backend_redis/redis.go
+++ b/distributed/backend/backend_redis/redis.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	json "github.com/json-iterator/go"
@@ -73,6 +74,9 @@ func (b *BackendRedis) SetResultExpire(expire int64) {
 }
 
 func (b *BackendRedis) GroupTakeOver(groupID string, name string, taskIDs ...string) error {
+	if err := validateRedisUserKey("group", groupID); err != nil {
+		return err
+	}
 	group := task.InitGroupMeta(groupID, name, b.resultExpire, taskIDs...)
 	body, err := json.Marshal(group)
 	if err != nil {
@@ -149,6 +153,9 @@ func (b *BackendRedis) GroupTaskStatus(groupID string) ([]*task.Status, error) {
 }
 
 func (b *BackendRedis) TriggerCompleted(groupID string) (bool, error) {
+	if err := validateRedisUserKey("group", groupID); err != nil {
+		return false, err
+	}
 	// 分布式锁
 	l := b.lock.NewMutex("TriggerCompletedMutex" + groupID)
 	if err := l.Lock(); err != nil {
@@ -226,12 +233,18 @@ func (b *BackendRedis) ResetTask(taskIDs ...string) error {
 	if len(taskIDs) == 0 {
 		return nil
 	}
+	if err := validateRedisUserKeys("task", taskIDs); err != nil {
+		return err
+	}
 	return b.client.Del(context.Background(), taskIDs...).Err()
 }
 
 func (b *BackendRedis) ResetGroup(groupIDs ...string) error {
 	if len(groupIDs) == 0 {
 		return nil
+	}
+	if err := validateRedisUserKeys("group", groupIDs); err != nil {
+		return err
 	}
 	return b.client.Del(context.Background(), groupIDs...).Err()
 }
@@ -281,6 +294,9 @@ func (b *BackendRedis) getGroup(groupID string) (*task.GroupMeta, error) {
 
 // updateStatus 更新状态
 func (b *BackendRedis) updateStatus(status *task.Status) error {
+	if err := validateRedisUserKey("task", status.TaskID); err != nil {
+		return err
+	}
 	body, err := json.Marshal(status)
 	if err != nil {
 		return err
@@ -316,4 +332,20 @@ func (b *BackendRedis) migrate(dst *task.Status) {
 		dst.CreateAt = src.CreateAt
 		dst.Name = src.Name
 	}
+}
+
+func validateRedisUserKeys(kind string, keys []string) error {
+	for _, key := range keys {
+		if err := validateRedisUserKey(kind, key); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateRedisUserKey(kind, key string) error {
+	if strings.HasPrefix(key, redisChordKeyPrefix) {
+		return fmt.Errorf("%w: redis %s id %q uses reserved key prefix %q", backend.ErrChordInvalidInput, kind, key, redisChordKeyPrefix)
+	}
+	return nil
 }

--- a/distributed/backend/chordtest/contract.go
+++ b/distributed/backend/chordtest/contract.go
@@ -1,0 +1,499 @@
+package chordtest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/songzhibin97/gkit/distributed/backend"
+	"github.com/songzhibin97/gkit/distributed/task"
+)
+
+func Run(t *testing.T, durable backend.DurableChordBackend) {
+	t.Helper()
+	ctx := context.Background()
+	prefix := fmt.Sprintf("issue104-%d", time.Now().UnixNano())
+	runConcurrentRegistrationContract(t, durable, prefix)
+	registration := newRegistration(t, prefix+"-group", "shared-callback", 2)
+
+	created, err := durable.RegisterChord(ctx, registration)
+	if err != nil || !created.Created {
+		t.Fatalf("RegisterChord created = %#v, %v", created, err)
+	}
+	attached, err := durable.RegisterChord(ctx, registration)
+	if err != nil || attached.Created || attached.DeliveryKey != created.DeliveryKey {
+		t.Fatalf("RegisterChord attached = %#v, %v", attached, err)
+	}
+	if err := durable.AbortRegistration(ctx, attached); !errors.Is(err, backend.ErrChordRegistrationOwnershipLost) {
+		t.Fatalf("noncreator AbortRegistration error = %v", err)
+	}
+	stale := created
+	stale.Owner = "not-owner"
+	if err := durable.AbortRegistration(ctx, stale); !errors.Is(err, backend.ErrChordRegistrationOwnershipLost) {
+		t.Fatalf("stale AbortRegistration error = %v", err)
+	}
+	conflict := registration
+	conflict.Members = append([]backend.ChordMemberRegistration(nil), registration.Members...)
+	conflict.Members[0].Payload = append([]byte(nil), conflict.Members[0].Payload...)
+	conflict.Members[0].Payload = append(conflict.Members[0].Payload, ' ')
+	conflict.DefinitionHash = ""
+	if err := backend.FinalizeChordRegistration(&conflict); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := durable.RegisterChord(ctx, conflict); !errors.Is(err, backend.ErrChordRegistrationConflict) {
+		t.Fatalf("conflicting RegisterChord error = %v", err)
+	}
+	if err := durable.AbortRegistration(ctx, created); err != nil {
+		t.Fatalf("creator AbortRegistration: %v", err)
+	}
+	if err := durable.AbortRegistration(ctx, created); err != nil {
+		t.Fatalf("repeat AbortRegistration: %v", err)
+	}
+
+	created, err = durable.RegisterChord(ctx, registration)
+	if err != nil || !created.Created {
+		t.Fatalf("RegisterChord after abort = %#v, %v", created, err)
+	}
+	if err := durable.ReconcileChord(ctx, created.DeliveryKey); err != nil {
+		t.Fatalf("ReconcileChord: %v", err)
+	}
+
+	now := time.Now()
+	leaseA, claimed, err := durable.ClaimMemberPublication(ctx, backend.ChordMemberClaim{DeliveryKey: created.DeliveryKey, Ordinal: 0, Owner: "member-a", Now: now, LeaseDuration: time.Second})
+	if err != nil || !claimed {
+		t.Fatalf("first member claim = %#v, %t, %v", leaseA, claimed, err)
+	}
+	if _, claimed, err := durable.ClaimMemberPublication(ctx, backend.ChordMemberClaim{DeliveryKey: created.DeliveryKey, Ordinal: 0, Owner: "member-b", Now: now, LeaseDuration: time.Second}); err != nil || claimed {
+		t.Fatalf("concurrent member claim = %t, %v", claimed, err)
+	}
+	leaseB, claimed, err := durable.ClaimMemberPublication(ctx, backend.ChordMemberClaim{DeliveryKey: created.DeliveryKey, Ordinal: 0, Owner: "member-b", Now: now.Add(2 * time.Second), LeaseDuration: time.Second})
+	if err != nil || !claimed {
+		t.Fatalf("reclaimed member = %#v, %t, %v", leaseB, claimed, err)
+	}
+	if err := durable.RecordMemberPublishOutcome(ctx, leaseA, backend.ChordPublishOutcome{Kind: backend.ChordPublishOutcomeSucceeded, Now: now}); !errors.Is(err, backend.ErrChordLeaseLost) {
+		t.Fatalf("stale member outcome error = %v", err)
+	}
+	unknownDeadline := now.Add(4 * time.Second)
+	if err := durable.RecordMemberPublishOutcome(ctx, leaseB, backend.ChordPublishOutcome{Kind: backend.ChordPublishOutcomeUnknown, Now: now.Add(2 * time.Second), ConfirmationDeadline: unknownDeadline}); err != nil {
+		t.Fatalf("record unknown member outcome: %v", err)
+	}
+	if _, claimed, err := durable.ClaimMemberPublication(ctx, backend.ChordMemberClaim{DeliveryKey: created.DeliveryKey, Ordinal: 0, Owner: "member-c", Now: unknownDeadline.Add(-time.Millisecond)}); err != nil || claimed {
+		t.Fatalf("early unknown reclaim = %t, %v", claimed, err)
+	}
+	leaseC, claimed, err := durable.ClaimMemberPublication(ctx, backend.ChordMemberClaim{DeliveryKey: created.DeliveryKey, Ordinal: 0, Owner: "member-c", Now: unknownDeadline, LeaseDuration: time.Second})
+	if err != nil || !claimed || string(leaseC.Payload) != string(leaseA.Payload) || leaseC.TaskID != leaseA.TaskID {
+		t.Fatalf("unknown reclaim = %#v, %t, %v", leaseC, claimed, err)
+	}
+	if err := durable.RecordMemberPublishOutcome(ctx, leaseC, backend.ChordPublishOutcome{Kind: backend.ChordPublishOutcomeSucceeded, Now: unknownDeadline, ConfirmationDeadline: unknownDeadline.Add(time.Second)}); err != nil {
+		t.Fatal(err)
+	}
+	if err := durable.RecordMemberTerminal(ctx, created.DeliveryKey, 0, leaseC.TaskID, backend.MemberTerminalSuccess, []*task.Result{{Type: "string", Value: "first"}}); err != nil {
+		t.Fatalf("record member 0 receipt: %v", err)
+	}
+
+	lease1, claimed, err := durable.ClaimMemberPublication(ctx, backend.ChordMemberClaim{DeliveryKey: created.DeliveryKey, Ordinal: 1, Owner: "member-d", Now: now, LeaseDuration: time.Second})
+	if err != nil || !claimed {
+		t.Fatalf("member 1 claim = %#v, %t, %v", lease1, claimed, err)
+	}
+	if err := durable.RecordMemberPublishOutcome(ctx, lease1, backend.ChordPublishOutcome{Kind: backend.ChordPublishOutcomeSucceeded, Now: now, ConfirmationDeadline: now.Add(time.Second)}); err != nil {
+		t.Fatal(err)
+	}
+	if err := durable.RecordMemberTerminal(ctx, created.DeliveryKey, 1, lease1.TaskID, backend.MemberTerminalSuccess, []*task.Result{{Type: "string", Value: "second"}}); err != nil {
+		t.Fatalf("record member 1 receipt: %v", err)
+	}
+
+	delivery := findDelivery(t, durable, created.DeliveryKey)
+	if delivery.CallbackState != backend.ChordReady {
+		t.Fatalf("callback state = %s, want READY", delivery.CallbackState)
+	}
+	var callback task.Signature
+	if err := json.Unmarshal(delivery.CallbackPayload, &callback); err != nil {
+		t.Fatal(err)
+	}
+	if len(callback.Args) != 2 || callback.Args[0].Value != "first" || callback.Args[1].Value != "second" {
+		t.Fatalf("callback args = %#v", callback.Args)
+	}
+
+	callbackLeaseA, claimed, err := durable.ClaimCallbackPublication(ctx, backend.ChordCallbackClaim{DeliveryKey: created.DeliveryKey, Owner: "callback-a", Now: now, LeaseDuration: time.Second})
+	if err != nil || !claimed {
+		t.Fatalf("callback claim = %#v, %t, %v", callbackLeaseA, claimed, err)
+	}
+	callbackLeaseB, claimed, err := durable.ClaimCallbackPublication(ctx, backend.ChordCallbackClaim{DeliveryKey: created.DeliveryKey, Owner: "callback-b", Now: now.Add(2 * time.Second), LeaseDuration: time.Second})
+	if err != nil || !claimed {
+		t.Fatalf("callback reclaim = %#v, %t, %v", callbackLeaseB, claimed, err)
+	}
+	if err := durable.RecordCallbackPublishOutcome(ctx, callbackLeaseA, backend.ChordPublishOutcome{Kind: backend.ChordPublishOutcomeSucceeded, Now: now}); !errors.Is(err, backend.ErrChordLeaseLost) {
+		t.Fatalf("stale callback outcome error = %v", err)
+	}
+	if err := durable.RecordCallbackPublishOutcome(ctx, callbackLeaseB, backend.ChordPublishOutcome{Kind: backend.ChordPublishOutcomeSucceeded, Now: now.Add(2 * time.Second), ConfirmationDeadline: now.Add(3 * time.Second)}); err != nil {
+		t.Fatal(err)
+	}
+	if err := durable.RecordCallbackTerminal(ctx, created.DeliveryKey, backend.CallbackTerminalSuccess); err != nil {
+		t.Fatal(err)
+	}
+	delivery = findDelivery(t, durable, created.DeliveryKey)
+	if delivery.CallbackState != backend.ChordDelivered || delivery.TerminalExpireAt == nil || !delivery.TerminalExpireAt.After(delivery.TerminalAt) {
+		t.Fatalf("terminal delivery = %#v", delivery)
+	}
+
+	other := newRegistration(t, prefix+"-other-group", "shared-callback", 1)
+	otherRef, err := durable.RegisterChord(ctx, other)
+	if err != nil || otherRef.DeliveryKey == created.DeliveryKey {
+		t.Fatalf("shared callback registration = %#v, %v", otherRef, err)
+	}
+	if err := durable.ReconcileChord(ctx, otherRef.DeliveryKey); err != nil {
+		t.Fatal(err)
+	}
+	if err := durable.RecordMemberTerminal(ctx, otherRef.DeliveryKey, 0, other.Members[0].TaskID, backend.MemberTerminalSuccess, []*task.Result{{Type: "string", Value: "other"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := durable.RecordCallbackTerminal(ctx, otherRef.DeliveryKey, backend.CallbackTerminalFailure); err != nil {
+		t.Fatal(err)
+	}
+	if got := findDelivery(t, durable, created.DeliveryKey); got.CallbackState != backend.ChordDelivered || got.TerminalOutcome != backend.CallbackTerminalSuccess {
+		t.Fatalf("shared callback ID changed first delivery = %#v", got)
+	}
+	if got := findDelivery(t, durable, otherRef.DeliveryKey); got.CallbackState != backend.ChordDelivered || got.TerminalOutcome != backend.CallbackTerminalFailure {
+		t.Fatalf("shared callback ID second delivery = %#v", got)
+	}
+
+	runSuppressionAndRetentionContract(t, durable, prefix)
+	runConcurrentClaimContract(t, durable, prefix)
+}
+
+func runConcurrentRegistrationContract(t *testing.T, durable backend.DurableChordBackend, prefix string) {
+	t.Helper()
+	registration := newRegistration(t, prefix+"-registration-race", "registration-callback", 2)
+	start := make(chan struct{})
+	refs := make(chan backend.ChordRegistrationRef, 2)
+	errs := make(chan error, 2)
+	var wg sync.WaitGroup
+	for index := 0; index < 2; index++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for attempt := 0; attempt < 10; attempt++ {
+				ref, err := durable.RegisterChord(context.Background(), registration)
+				if err == nil {
+					refs <- ref
+					return
+				}
+				if attempt == 9 {
+					errs <- err
+					return
+				}
+				time.Sleep(2 * time.Millisecond)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(refs)
+	close(errs)
+	for err := range errs {
+		t.Fatalf("concurrent identical registration: %v", err)
+	}
+	created := 0
+	attached := 0
+	deliveryKey := ""
+	for ref := range refs {
+		if deliveryKey == "" {
+			deliveryKey = ref.DeliveryKey
+		} else if ref.DeliveryKey != deliveryKey {
+			t.Fatalf("concurrent registrations produced keys %q and %q", deliveryKey, ref.DeliveryKey)
+		}
+		if ref.Created {
+			created++
+		} else {
+			attached++
+		}
+	}
+	if created != 1 || attached != 1 {
+		t.Fatalf("concurrent identical registration created=%d attached=%d, want 1/1", created, attached)
+	}
+	delivery := findDelivery(t, durable, deliveryKey)
+	for ordinal, member := range delivery.Members {
+		if member.TaskID != registration.Members[ordinal].TaskID || string(member.Payload) != string(registration.Members[ordinal].Payload) {
+			t.Fatalf("stored member %d identity/payload changed", ordinal)
+		}
+	}
+}
+
+func runSuppressionAndRetentionContract(t *testing.T, durable backend.DurableChordBackend, prefix string) {
+	t.Helper()
+	ctx := context.Background()
+	for _, tc := range []struct {
+		name          string
+		retention     int64
+		failureFirst  bool
+		wantRetention time.Duration
+		wantNoExpiry  bool
+	}{
+		{name: "zero", retention: 0, wantRetention: time.Hour},
+		{name: "negative", retention: -1, wantNoExpiry: true, failureFirst: true},
+		{name: "positive", retention: 3, wantRetention: 3 * time.Second},
+	} {
+		t.Run("retention_"+tc.name, func(t *testing.T) {
+			registration := newRegistration(t, prefix+"-retention-"+tc.name, "retention-callback", 2)
+			registration.Retention = tc.retention
+			registration.DefinitionHash = ""
+			if err := backend.FinalizeChordRegistration(&registration); err != nil {
+				t.Fatal(err)
+			}
+			ref, err := durable.RegisterChord(ctx, registration)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := durable.ReconcileChord(ctx, ref.DeliveryKey); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := durable.CleanupTerminalChordDeliveries(ctx, time.Now().Add(24*time.Hour), 10000); err != nil {
+				t.Fatal(err)
+			}
+			if !deliveryExists(t, durable, ref.DeliveryKey) {
+				t.Fatal("active durable delivery expired before terminal transition")
+			}
+			failureOrdinal := 1
+			if tc.failureFirst {
+				failureOrdinal = 0
+			}
+			for ordinal := range registration.Members {
+				outcome := backend.MemberTerminalSuccess
+				if ordinal == failureOrdinal {
+					outcome = backend.MemberTerminalFailure
+				}
+				if err := durable.RecordMemberTerminal(ctx, ref.DeliveryKey, ordinal, registration.Members[ordinal].TaskID, outcome, nil); err != nil {
+					t.Fatal(err)
+				}
+			}
+			// Exact repeats are idempotent and must not create a second terminal transition.
+			if err := durable.RecordMemberTerminal(ctx, ref.DeliveryKey, failureOrdinal, registration.Members[failureOrdinal].TaskID, backend.MemberTerminalFailure, nil); err != nil {
+				t.Fatal(err)
+			}
+			delivery := findDelivery(t, durable, ref.DeliveryKey)
+			if delivery.CallbackState != backend.ChordSuppressed || delivery.TerminalOutcome != backend.CallbackTerminalFailure {
+				t.Fatalf("failure receipts produced delivery = %#v", delivery)
+			}
+			if _, claimed, err := durable.ClaimCallbackPublication(ctx, backend.ChordCallbackClaim{DeliveryKey: ref.DeliveryKey, Owner: "suppressed", Now: time.Now()}); err != nil || claimed {
+				t.Fatalf("suppressed callback claim = %t, %v", claimed, err)
+			}
+			if tc.wantNoExpiry {
+				if delivery.TerminalExpireAt != nil {
+					t.Fatalf("negative retention expiry = %s, want nil", delivery.TerminalExpireAt)
+				}
+				if _, err := durable.CleanupTerminalChordDeliveries(ctx, time.Now().Add(365*24*time.Hour), 10000); err != nil {
+					t.Fatal(err)
+				}
+				if !deliveryExists(t, durable, ref.DeliveryKey) {
+					t.Fatal("negative-retention terminal delivery was removed")
+				}
+				return
+			}
+			if delivery.TerminalExpireAt == nil {
+				t.Fatal("terminal delivery has no expiry")
+			}
+			if delta := delivery.TerminalExpireAt.Sub(delivery.TerminalAt); delta != tc.wantRetention {
+				t.Fatalf("terminal retention = %s, want %s", delta, tc.wantRetention)
+			}
+			// SQL backends may persist timestamps at millisecond precision, so use
+			// a one-second margin on either side of the semantic boundary.
+			if _, err := durable.CleanupTerminalChordDeliveries(ctx, delivery.TerminalExpireAt.Add(-time.Second), 10000); err != nil {
+				t.Fatal(err)
+			}
+			if !deliveryExists(t, durable, ref.DeliveryKey) {
+				t.Fatal("terminal delivery removed before retention boundary")
+			}
+			if _, err := durable.CleanupTerminalChordDeliveries(ctx, delivery.TerminalExpireAt.Add(time.Second), 10000); err != nil {
+				t.Fatal(err)
+			}
+			if deliveryExists(t, durable, ref.DeliveryKey) {
+				t.Fatal("terminal delivery survived retention boundary")
+			}
+		})
+	}
+}
+
+func runConcurrentClaimContract(t *testing.T, durable backend.DurableChordBackend, prefix string) {
+	t.Helper()
+	ctx := context.Background()
+	registration := newRegistration(t, prefix+"-concurrent-claims", "concurrent-callback", 1)
+	ref, err := durable.RegisterChord(ctx, registration)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := durable.ReconcileChord(ctx, ref.DeliveryKey); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	memberLeases := make(chan backend.ChordMemberLease, 8)
+	memberErrs := make(chan error, 8)
+	var memberWG sync.WaitGroup
+	for index := 0; index < 8; index++ {
+		memberWG.Add(1)
+		go func(index int) {
+			defer memberWG.Done()
+			for attempt := 0; attempt < 10; attempt++ {
+				lease, claimed, claimErr := durable.ClaimMemberPublication(ctx, backend.ChordMemberClaim{DeliveryKey: ref.DeliveryKey, Ordinal: 0, Owner: fmt.Sprintf("member-%d", index), Now: now, LeaseDuration: time.Second})
+				if claimErr != nil {
+					if attempt == 9 {
+						memberErrs <- claimErr
+						return
+					}
+					time.Sleep(2 * time.Millisecond)
+					continue
+				}
+				if claimed {
+					memberLeases <- lease
+				}
+				return
+			}
+		}(index)
+	}
+	memberWG.Wait()
+	close(memberLeases)
+	close(memberErrs)
+	for claimErr := range memberErrs {
+		t.Fatalf("concurrent member claim: %v", claimErr)
+	}
+	var firstMember backend.ChordMemberLease
+	memberWinners := 0
+	for lease := range memberLeases {
+		firstMember = lease
+		memberWinners++
+	}
+	if memberWinners != 1 {
+		t.Fatalf("concurrent member claim winners = %d, want 1", memberWinners)
+	}
+	secondMember, claimed, err := durable.ClaimMemberPublication(ctx, backend.ChordMemberClaim{DeliveryKey: ref.DeliveryKey, Ordinal: 0, Owner: "member-recovery", Now: now.Add(2 * time.Second), LeaseDuration: time.Second})
+	if err != nil || !claimed {
+		t.Fatalf("expired member recovery = %#v, %t, %v", secondMember, claimed, err)
+	}
+	if err := durable.RecordMemberPublishOutcome(ctx, firstMember, backend.ChordPublishOutcome{Kind: backend.ChordPublishOutcomeSucceeded, Now: now}); !errors.Is(err, backend.ErrChordLeaseLost) {
+		t.Fatalf("stale concurrent member owner error = %v", err)
+	}
+	if err := durable.RecordMemberTerminal(ctx, ref.DeliveryKey, 0, registration.Members[0].TaskID, backend.MemberTerminalSuccess, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	callbackLeases := make(chan backend.ChordCallbackLease, 8)
+	callbackErrs := make(chan error, 8)
+	var callbackWG sync.WaitGroup
+	for index := 0; index < 8; index++ {
+		callbackWG.Add(1)
+		go func(index int) {
+			defer callbackWG.Done()
+			for attempt := 0; attempt < 10; attempt++ {
+				lease, callbackClaimed, claimErr := durable.ClaimCallbackPublication(ctx, backend.ChordCallbackClaim{DeliveryKey: ref.DeliveryKey, Owner: fmt.Sprintf("callback-%d", index), Now: now, LeaseDuration: time.Second})
+				if claimErr != nil {
+					if attempt == 9 {
+						callbackErrs <- claimErr
+						return
+					}
+					time.Sleep(2 * time.Millisecond)
+					continue
+				}
+				if callbackClaimed {
+					callbackLeases <- lease
+				}
+				return
+			}
+		}(index)
+	}
+	callbackWG.Wait()
+	close(callbackLeases)
+	close(callbackErrs)
+	for claimErr := range callbackErrs {
+		t.Fatalf("concurrent callback claim: %v", claimErr)
+	}
+	var firstCallback backend.ChordCallbackLease
+	callbackWinners := 0
+	for lease := range callbackLeases {
+		firstCallback = lease
+		callbackWinners++
+	}
+	if callbackWinners != 1 {
+		t.Fatalf("concurrent callback claim winners = %d, want 1", callbackWinners)
+	}
+	secondCallback, claimed, err := durable.ClaimCallbackPublication(ctx, backend.ChordCallbackClaim{DeliveryKey: ref.DeliveryKey, Owner: "callback-recovery", Now: now.Add(2 * time.Second), LeaseDuration: time.Second})
+	if err != nil || !claimed {
+		t.Fatalf("expired callback recovery = %#v, %t, %v", secondCallback, claimed, err)
+	}
+	if err := durable.RecordCallbackPublishOutcome(ctx, firstCallback, backend.ChordPublishOutcome{Kind: backend.ChordPublishOutcomeSucceeded, Now: now}); !errors.Is(err, backend.ErrChordLeaseLost) {
+		t.Fatalf("stale concurrent callback owner error = %v", err)
+	}
+}
+
+func newRegistration(t *testing.T, groupID, callbackID string, members int) backend.ChordRegistration {
+	t.Helper()
+	callback := task.NewSignature(callbackID, "callback")
+	callback.Meta.Set(backend.DurableChordDeliveryKeyMeta, backend.ChordDeliveryKey(groupID, callbackID))
+	callbackPayload, err := json.Marshal(callback)
+	if err != nil {
+		t.Fatal(err)
+	}
+	registration := backend.ChordRegistration{GroupID: groupID, GroupName: "group", Retention: 2, Callback: callbackPayload}
+	for ordinal := 0; ordinal < members; ordinal++ {
+		member := task.NewSignature(fmt.Sprintf("%s-member-%d", groupID, ordinal), "member")
+		member.GroupID = groupID
+		member.CallbackChord = nil
+		member.Meta.Set(backend.DurableChordDeliveryKeyMeta, backend.ChordDeliveryKey(groupID, callbackID))
+		member.Meta.Set(backend.DurableChordMemberMeta, true)
+		member.Meta.Set(backend.DurableChordMemberOrdinal, ordinal)
+		payload, err := json.Marshal(member)
+		if err != nil {
+			t.Fatal(err)
+		}
+		registration.Members = append(registration.Members, backend.ChordMemberRegistration{Ordinal: ordinal, TaskID: member.ID, Payload: payload})
+	}
+	if err := backend.FinalizeChordRegistration(&registration); err != nil {
+		t.Fatal(err)
+	}
+	return registration
+}
+
+func findDelivery(t *testing.T, durable backend.DurableChordBackend, deliveryKey string) backend.ChordDelivery {
+	t.Helper()
+	cursor := ""
+	for {
+		page, err := durable.ScanChordDeliveries(context.Background(), backend.ChordScan{Cursor: cursor, Limit: 10, Now: time.Now()})
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, delivery := range page.Deliveries {
+			if delivery.DeliveryKey == deliveryKey {
+				return delivery
+			}
+		}
+		if page.NextCursor == "" {
+			break
+		}
+		cursor = page.NextCursor
+	}
+	t.Fatalf("delivery %s not found", deliveryKey)
+	return backend.ChordDelivery{}
+}
+
+func deliveryExists(t *testing.T, durable backend.DurableChordBackend, deliveryKey string) bool {
+	t.Helper()
+	cursor := ""
+	for {
+		page, err := durable.ScanChordDeliveries(context.Background(), backend.ChordScan{Cursor: cursor, Limit: 10, Now: time.Now()})
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, delivery := range page.Deliveries {
+			if delivery.DeliveryKey == deliveryKey {
+				return true
+			}
+		}
+		if page.NextCursor == "" {
+			return false
+		}
+		cursor = page.NextCursor
+	}
+}

--- a/distributed/backend/durable_chord.go
+++ b/distributed/backend/durable_chord.go
@@ -1,0 +1,621 @@
+package backend
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/songzhibin97/gkit/distributed/task"
+)
+
+const (
+	DurableChordDeliveryKeyMeta = "gkit.chord_delivery_key"
+	DurableChordMemberMeta      = "gkit.chord_member"
+	DurableChordMemberOrdinal   = "gkit.chord_member_ordinal"
+
+	DefaultChordRetentionSeconds int64 = 3600
+)
+
+var (
+	ErrDurableChordUnsupported        = errors.New("durable chord backend unsupported")
+	ErrChordInvalidInput              = errors.New("invalid group callback")
+	ErrChordRegistrationConflict      = errors.New("chord registration conflict")
+	ErrChordRegistrationAborted       = errors.New("chord registration aborted")
+	ErrChordRegistrationOwnershipLost = errors.New("chord registration ownership lost")
+	ErrChordPublicationStarted        = errors.New("chord publication started")
+	ErrChordLeaseLost                 = errors.New("chord publication lease lost")
+	ErrChordReceiptConflict           = errors.New("chord member receipt conflict")
+	ErrChordTerminalConflict          = errors.New("chord terminal outcome conflict")
+	ErrChordNotFound                  = errors.New("chord delivery not found")
+)
+
+type ChordMemberState string
+
+const (
+	ChordMemberSetup          ChordMemberState = "MEMBER_SETUP"
+	ChordMemberReady          ChordMemberState = "MEMBER_READY"
+	ChordMemberLeased         ChordMemberState = "MEMBER_LEASED"
+	ChordMemberPublished      ChordMemberState = "MEMBER_PUBLISHED"
+	ChordMemberPublishUnknown ChordMemberState = "MEMBER_PUBLISH_UNKNOWN"
+	ChordMemberTerminal       ChordMemberState = "MEMBER_TERMINAL"
+)
+
+type ChordCallbackState string
+
+const (
+	ChordWaiting        ChordCallbackState = "WAITING"
+	ChordReady          ChordCallbackState = "READY"
+	ChordLeased         ChordCallbackState = "LEASED"
+	ChordPublished      ChordCallbackState = "PUBLISHED"
+	ChordPublishUnknown ChordCallbackState = "PUBLISH_UNKNOWN"
+	ChordDelivered      ChordCallbackState = "DELIVERED"
+	ChordSuppressed     ChordCallbackState = "SUPPRESSED"
+)
+
+type MemberTerminalOutcome string
+
+const (
+	MemberTerminalSuccess MemberTerminalOutcome = "SUCCESS"
+	MemberTerminalFailure MemberTerminalOutcome = "FAILURE"
+)
+
+type CallbackTerminalOutcome string
+
+const (
+	CallbackTerminalSuccess CallbackTerminalOutcome = "SUCCESS"
+	CallbackTerminalFailure CallbackTerminalOutcome = "FAILURE"
+)
+
+type ChordPublishOutcomeKind string
+
+const (
+	ChordPublishOutcomeSucceeded ChordPublishOutcomeKind = "PUBLISHED"
+	ChordPublishOutcomeUnknown   ChordPublishOutcomeKind = "UNKNOWN"
+	ChordPublishOutcomeRejected  ChordPublishOutcomeKind = "REJECTED"
+)
+
+type ChordMemberRegistration struct {
+	Ordinal int    `json:"ordinal" bson:"ordinal"`
+	TaskID  string `json:"task_id" bson:"task_id"`
+	Payload []byte `json:"payload" bson:"payload"`
+}
+
+type ChordRegistration struct {
+	DeliveryKey    string                    `json:"delivery_key" bson:"delivery_key"`
+	DefinitionHash string                    `json:"definition_hash" bson:"definition_hash"`
+	GroupID        string                    `json:"group_id" bson:"group_id"`
+	GroupName      string                    `json:"group_name" bson:"group_name"`
+	Retention      int64                     `json:"retention" bson:"retention"`
+	Callback       []byte                    `json:"callback" bson:"callback"`
+	Members        []ChordMemberRegistration `json:"members" bson:"members"`
+}
+
+type ChordRegistrationRef struct {
+	DeliveryKey string `json:"delivery_key" bson:"delivery_key"`
+	Owner       string `json:"owner" bson:"owner"`
+	Version     int64  `json:"version" bson:"version"`
+	Created     bool   `json:"created" bson:"created"`
+}
+
+type ChordMemberReceipt struct {
+	TaskID  string                `json:"task_id" bson:"task_id"`
+	Outcome MemberTerminalOutcome `json:"outcome" bson:"outcome"`
+	Results []*task.Result        `json:"results" bson:"results"`
+}
+
+type ChordMemberPublication struct {
+	Ordinal              int                 `json:"ordinal" bson:"ordinal"`
+	TaskID               string              `json:"task_id" bson:"task_id"`
+	Payload              []byte              `json:"payload" bson:"payload"`
+	State                ChordMemberState    `json:"state" bson:"state"`
+	Version              int64               `json:"version" bson:"version"`
+	LeaseOwner           string              `json:"lease_owner,omitempty" bson:"lease_owner,omitempty"`
+	LeaseExpiresAt       time.Time           `json:"lease_expires_at,omitempty" bson:"lease_expires_at,omitempty"`
+	Attempts             int                 `json:"attempts" bson:"attempts"`
+	NextAttemptAt        time.Time           `json:"next_attempt_at,omitempty" bson:"next_attempt_at,omitempty"`
+	ConfirmationDeadline time.Time           `json:"confirmation_deadline,omitempty" bson:"confirmation_deadline,omitempty"`
+	LastError            string              `json:"last_error,omitempty" bson:"last_error,omitempty"`
+	Receipt              *ChordMemberReceipt `json:"receipt,omitempty" bson:"receipt,omitempty"`
+}
+
+type ChordDelivery struct {
+	DeliveryKey              string                   `json:"delivery_key" bson:"delivery_key"`
+	DefinitionHash           string                   `json:"definition_hash" bson:"definition_hash"`
+	GroupID                  string                   `json:"group_id" bson:"group_id"`
+	GroupName                string                   `json:"group_name" bson:"group_name"`
+	Retention                int64                    `json:"retention" bson:"retention"`
+	RegistrationOwner        string                   `json:"registration_owner" bson:"registration_owner"`
+	RegistrationVersion      int64                    `json:"registration_version" bson:"registration_version"`
+	Version                  int64                    `json:"version" bson:"version"`
+	MemberPublicationStarted bool                     `json:"member_publication_started" bson:"member_publication_started"`
+	CallbackTemplate         []byte                   `json:"callback_template" bson:"callback_template"`
+	CallbackPayload          []byte                   `json:"callback_payload,omitempty" bson:"callback_payload,omitempty"`
+	Members                  []ChordMemberPublication `json:"members" bson:"members"`
+	CallbackState            ChordCallbackState       `json:"callback_state" bson:"callback_state"`
+	CallbackVersion          int64                    `json:"callback_version" bson:"callback_version"`
+	CallbackLeaseOwner       string                   `json:"callback_lease_owner,omitempty" bson:"callback_lease_owner,omitempty"`
+	CallbackLeaseExpiresAt   time.Time                `json:"callback_lease_expires_at,omitempty" bson:"callback_lease_expires_at,omitempty"`
+	CallbackAttempts         int                      `json:"callback_attempts" bson:"callback_attempts"`
+	CallbackNextAttemptAt    time.Time                `json:"callback_next_attempt_at,omitempty" bson:"callback_next_attempt_at,omitempty"`
+	CallbackConfirmationAt   time.Time                `json:"callback_confirmation_at,omitempty" bson:"callback_confirmation_at,omitempty"`
+	CallbackLastError        string                   `json:"callback_last_error,omitempty" bson:"callback_last_error,omitempty"`
+	TerminalOutcome          CallbackTerminalOutcome  `json:"terminal_outcome,omitempty" bson:"terminal_outcome,omitempty"`
+	TerminalAt               time.Time                `json:"terminal_at,omitempty" bson:"terminal_at,omitempty"`
+	TerminalExpireAt         *time.Time               `json:"terminal_expire_at,omitempty" bson:"terminal_expire_at,omitempty"`
+	CreatedAt                time.Time                `json:"created_at" bson:"created_at"`
+	UpdatedAt                time.Time                `json:"updated_at" bson:"updated_at"`
+}
+
+type ChordMemberClaim struct {
+	DeliveryKey   string
+	Ordinal       int
+	Owner         string
+	Now           time.Time
+	LeaseDuration time.Duration
+}
+
+type ChordMemberLease struct {
+	DeliveryKey string
+	Ordinal     int
+	TaskID      string
+	Payload     []byte
+	Owner       string
+	Version     int64
+	ExpiresAt   time.Time
+}
+
+type ChordCallbackClaim struct {
+	DeliveryKey   string
+	Owner         string
+	Now           time.Time
+	LeaseDuration time.Duration
+}
+
+type ChordCallbackLease struct {
+	DeliveryKey string
+	Payload     []byte
+	Owner       string
+	Version     int64
+	ExpiresAt   time.Time
+}
+
+type ChordPublishOutcome struct {
+	Kind                 ChordPublishOutcomeKind
+	Now                  time.Time
+	ConfirmationDeadline time.Time
+	NextAttemptAt        time.Time
+	Error                string
+}
+
+type ChordScan struct {
+	Cursor string
+	Limit  int
+	Now    time.Time
+}
+
+type ChordDeliveryPage struct {
+	Deliveries []ChordDelivery
+	NextCursor string
+}
+
+type DurableChordBackend interface {
+	RegisterChord(context.Context, ChordRegistration) (ChordRegistrationRef, error)
+	AbortRegistration(context.Context, ChordRegistrationRef) error
+	ClaimMemberPublication(context.Context, ChordMemberClaim) (ChordMemberLease, bool, error)
+	RecordMemberPublishOutcome(context.Context, ChordMemberLease, ChordPublishOutcome) error
+	RecordMemberTerminal(context.Context, string, int, string, MemberTerminalOutcome, []*task.Result) error
+	ScanChordDeliveries(context.Context, ChordScan) (ChordDeliveryPage, error)
+	ReconcileChord(context.Context, string) error
+	ClaimCallbackPublication(context.Context, ChordCallbackClaim) (ChordCallbackLease, bool, error)
+	RecordCallbackPublishOutcome(context.Context, ChordCallbackLease, ChordPublishOutcome) error
+	RecordCallbackTerminal(context.Context, string, CallbackTerminalOutcome) error
+	CleanupTerminalChordDeliveries(context.Context, time.Time, int) (int, error)
+}
+
+func NormalizeChordRetention(value int64) int64 {
+	if value == 0 {
+		return DefaultChordRetentionSeconds
+	}
+	return value
+}
+
+func ChordDeliveryKey(groupID, callbackID string) string {
+	groupSum := sha256.Sum256([]byte(groupID))
+	deliverySum := sha256.Sum256([]byte("gkit-chord-v1\x00" + groupID + "\x00" + callbackID))
+	return "chord:v1:" + hex.EncodeToString(groupSum[:]) + ":" + hex.EncodeToString(deliverySum[:])
+}
+
+func NewChordOwner() (string, error) {
+	value := make([]byte, 16)
+	if _, err := rand.Read(value); err != nil {
+		return "", fmt.Errorf("generate chord owner: %w", err)
+	}
+	return hex.EncodeToString(value), nil
+}
+
+func FinalizeChordRegistration(reg *ChordRegistration) error {
+	if reg == nil {
+		return fmt.Errorf("%w: nil registration", ErrChordInvalidInput)
+	}
+	reg.Retention = NormalizeChordRetention(reg.Retention)
+	if reg.DeliveryKey == "" {
+		var callback task.Signature
+		if err := json.Unmarshal(reg.Callback, &callback); err != nil {
+			return fmt.Errorf("decode callback registration: %w", err)
+		}
+		reg.DeliveryKey = ChordDeliveryKey(reg.GroupID, callback.ID)
+	}
+	definition := *reg
+	definition.DefinitionHash = ""
+	body, err := json.Marshal(definition)
+	if err != nil {
+		return fmt.Errorf("marshal chord definition: %w", err)
+	}
+	sum := sha256.Sum256(body)
+	reg.DefinitionHash = hex.EncodeToString(sum[:])
+	return nil
+}
+
+func NewChordDelivery(reg ChordRegistration, owner string, now time.Time) ChordDelivery {
+	members := make([]ChordMemberPublication, len(reg.Members))
+	for index, member := range reg.Members {
+		members[index] = ChordMemberPublication{
+			Ordinal: member.Ordinal,
+			TaskID:  member.TaskID,
+			Payload: append([]byte(nil), member.Payload...),
+			State:   ChordMemberSetup,
+			Version: 1,
+		}
+	}
+	return ChordDelivery{
+		DeliveryKey:         reg.DeliveryKey,
+		DefinitionHash:      reg.DefinitionHash,
+		GroupID:             reg.GroupID,
+		GroupName:           reg.GroupName,
+		Retention:           NormalizeChordRetention(reg.Retention),
+		RegistrationOwner:   owner,
+		RegistrationVersion: 1,
+		Version:             1,
+		CallbackTemplate:    append([]byte(nil), reg.Callback...),
+		Members:             members,
+		CallbackState:       ChordWaiting,
+		CallbackVersion:     1,
+		CreatedAt:           now,
+		UpdatedAt:           now,
+	}
+}
+
+func ChordRegistrationMatches(delivery *ChordDelivery, reg ChordRegistration) bool {
+	return delivery != nil && delivery.GroupID == reg.GroupID && delivery.DefinitionHash == reg.DefinitionHash
+}
+
+func PrepareChordMembers(delivery *ChordDelivery, now time.Time) {
+	for index := range delivery.Members {
+		if delivery.Members[index].State == ChordMemberSetup {
+			delivery.Members[index].State = ChordMemberReady
+			delivery.Members[index].Version++
+		}
+	}
+	delivery.Version++
+	delivery.UpdatedAt = now
+}
+
+func ClaimChordMember(delivery *ChordDelivery, claim ChordMemberClaim) (ChordMemberLease, bool, error) {
+	if delivery == nil || claim.Ordinal < 0 || claim.Ordinal >= len(delivery.Members) {
+		return ChordMemberLease{}, false, ErrChordNotFound
+	}
+	now := claim.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+	member := &delivery.Members[claim.Ordinal]
+	switch member.State {
+	case ChordMemberLeased:
+		if member.LeaseExpiresAt.After(now) {
+			return ChordMemberLease{}, false, nil
+		}
+		member.State = ChordMemberReady
+	case ChordMemberPublished, ChordMemberPublishUnknown:
+		if member.ConfirmationDeadline.After(now) {
+			return ChordMemberLease{}, false, nil
+		}
+		member.State = ChordMemberReady
+	case ChordMemberReady:
+	case ChordMemberSetup, ChordMemberTerminal:
+		return ChordMemberLease{}, false, nil
+	default:
+		return ChordMemberLease{}, false, fmt.Errorf("unknown member state %q", member.State)
+	}
+	if member.NextAttemptAt.After(now) {
+		return ChordMemberLease{}, false, nil
+	}
+	duration := claim.LeaseDuration
+	if duration <= 0 {
+		duration = 30 * time.Second
+	}
+	member.State = ChordMemberLeased
+	member.LeaseOwner = claim.Owner
+	member.LeaseExpiresAt = now.Add(duration)
+	member.Version++
+	member.Attempts++
+	delivery.MemberPublicationStarted = true
+	delivery.Version++
+	delivery.UpdatedAt = now
+	return ChordMemberLease{
+		DeliveryKey: delivery.DeliveryKey,
+		Ordinal:     member.Ordinal,
+		TaskID:      member.TaskID,
+		Payload:     append([]byte(nil), member.Payload...),
+		Owner:       claim.Owner,
+		Version:     member.Version,
+		ExpiresAt:   member.LeaseExpiresAt,
+	}, true, nil
+}
+
+func ApplyChordMemberPublishOutcome(delivery *ChordDelivery, lease ChordMemberLease, outcome ChordPublishOutcome) error {
+	if delivery == nil || lease.Ordinal < 0 || lease.Ordinal >= len(delivery.Members) {
+		return ErrChordNotFound
+	}
+	member := &delivery.Members[lease.Ordinal]
+	if member.State != ChordMemberLeased || member.LeaseOwner != lease.Owner || member.Version != lease.Version {
+		return ErrChordLeaseLost
+	}
+	now := outcome.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+	member.LeaseOwner = ""
+	member.LeaseExpiresAt = time.Time{}
+	member.LastError = boundedChordError(outcome.Error)
+	switch outcome.Kind {
+	case ChordPublishOutcomeSucceeded:
+		member.State = ChordMemberPublished
+		member.ConfirmationDeadline = deadlineOrDefault(outcome.ConfirmationDeadline, now.Add(30*time.Second))
+	case ChordPublishOutcomeUnknown:
+		member.State = ChordMemberPublishUnknown
+		member.ConfirmationDeadline = deadlineOrDefault(outcome.ConfirmationDeadline, now.Add(30*time.Second))
+	case ChordPublishOutcomeRejected:
+		member.State = ChordMemberTerminal
+		member.Receipt = &ChordMemberReceipt{TaskID: member.TaskID, Outcome: MemberTerminalFailure}
+		setChordSuppressed(delivery, now)
+	default:
+		return fmt.Errorf("unknown publish outcome %q", outcome.Kind)
+	}
+	if !outcome.NextAttemptAt.IsZero() {
+		member.NextAttemptAt = outcome.NextAttemptAt
+	}
+	member.Version++
+	delivery.Version++
+	delivery.UpdatedAt = now
+	return nil
+}
+
+func ApplyChordMemberTerminal(delivery *ChordDelivery, ordinal int, taskID string, outcome MemberTerminalOutcome, results []*task.Result, now time.Time) error {
+	if delivery == nil || ordinal < 0 || ordinal >= len(delivery.Members) {
+		return ErrChordNotFound
+	}
+	member := &delivery.Members[ordinal]
+	if member.TaskID != taskID {
+		return ErrChordReceiptConflict
+	}
+	copyResults, err := cloneChordResults(results)
+	if err != nil {
+		return err
+	}
+	if member.Receipt != nil {
+		candidate := ChordMemberReceipt{TaskID: taskID, Outcome: outcome, Results: copyResults}
+		existing, _ := json.Marshal(member.Receipt)
+		wanted, _ := json.Marshal(candidate)
+		if bytes.Equal(existing, wanted) {
+			return nil
+		}
+		return ErrChordReceiptConflict
+	}
+	member.State = ChordMemberTerminal
+	member.LeaseOwner = ""
+	member.LeaseExpiresAt = time.Time{}
+	member.Receipt = &ChordMemberReceipt{TaskID: taskID, Outcome: outcome, Results: copyResults}
+	member.Version++
+	delivery.Version++
+	delivery.UpdatedAt = now
+	if outcome == MemberTerminalFailure {
+		setChordSuppressed(delivery, now)
+		return nil
+	}
+	for index := range delivery.Members {
+		if delivery.Members[index].Receipt == nil {
+			return nil
+		}
+		if delivery.Members[index].Receipt.Outcome == MemberTerminalFailure {
+			setChordSuppressed(delivery, now)
+			return nil
+		}
+	}
+	payload, err := buildChordCallbackPayload(delivery)
+	if err != nil {
+		return err
+	}
+	if len(delivery.CallbackPayload) == 0 {
+		delivery.CallbackPayload = payload
+	}
+	delivery.CallbackState = ChordReady
+	delivery.CallbackVersion++
+	return nil
+}
+
+func ClaimChordCallback(delivery *ChordDelivery, claim ChordCallbackClaim) (ChordCallbackLease, bool, error) {
+	if delivery == nil {
+		return ChordCallbackLease{}, false, ErrChordNotFound
+	}
+	now := claim.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+	switch delivery.CallbackState {
+	case ChordLeased:
+		if delivery.CallbackLeaseExpiresAt.After(now) {
+			return ChordCallbackLease{}, false, nil
+		}
+		delivery.CallbackState = ChordReady
+	case ChordPublished, ChordPublishUnknown:
+		if delivery.CallbackConfirmationAt.After(now) {
+			return ChordCallbackLease{}, false, nil
+		}
+		delivery.CallbackState = ChordReady
+	case ChordReady:
+	case ChordWaiting, ChordDelivered, ChordSuppressed:
+		return ChordCallbackLease{}, false, nil
+	default:
+		return ChordCallbackLease{}, false, fmt.Errorf("unknown callback state %q", delivery.CallbackState)
+	}
+	if delivery.CallbackNextAttemptAt.After(now) {
+		return ChordCallbackLease{}, false, nil
+	}
+	duration := claim.LeaseDuration
+	if duration <= 0 {
+		duration = 30 * time.Second
+	}
+	delivery.CallbackState = ChordLeased
+	delivery.CallbackLeaseOwner = claim.Owner
+	delivery.CallbackLeaseExpiresAt = now.Add(duration)
+	delivery.CallbackVersion++
+	delivery.CallbackAttempts++
+	delivery.Version++
+	delivery.UpdatedAt = now
+	return ChordCallbackLease{
+		DeliveryKey: delivery.DeliveryKey,
+		Payload:     append([]byte(nil), delivery.CallbackPayload...),
+		Owner:       claim.Owner,
+		Version:     delivery.CallbackVersion,
+		ExpiresAt:   delivery.CallbackLeaseExpiresAt,
+	}, true, nil
+}
+
+func ApplyChordCallbackPublishOutcome(delivery *ChordDelivery, lease ChordCallbackLease, outcome ChordPublishOutcome) error {
+	if delivery == nil {
+		return ErrChordNotFound
+	}
+	if delivery.CallbackState != ChordLeased || delivery.CallbackLeaseOwner != lease.Owner || delivery.CallbackVersion != lease.Version {
+		return ErrChordLeaseLost
+	}
+	now := outcome.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+	delivery.CallbackLeaseOwner = ""
+	delivery.CallbackLeaseExpiresAt = time.Time{}
+	delivery.CallbackLastError = boundedChordError(outcome.Error)
+	switch outcome.Kind {
+	case ChordPublishOutcomeSucceeded:
+		delivery.CallbackState = ChordPublished
+		delivery.CallbackConfirmationAt = deadlineOrDefault(outcome.ConfirmationDeadline, now.Add(30*time.Second))
+	case ChordPublishOutcomeUnknown:
+		delivery.CallbackState = ChordPublishUnknown
+		delivery.CallbackConfirmationAt = deadlineOrDefault(outcome.ConfirmationDeadline, now.Add(30*time.Second))
+	case ChordPublishOutcomeRejected:
+		delivery.CallbackState = ChordReady
+		delivery.CallbackNextAttemptAt = deadlineOrDefault(outcome.NextAttemptAt, now.Add(time.Second))
+	default:
+		return fmt.Errorf("unknown publish outcome %q", outcome.Kind)
+	}
+	delivery.CallbackVersion++
+	delivery.Version++
+	delivery.UpdatedAt = now
+	return nil
+}
+
+func ApplyChordCallbackTerminal(delivery *ChordDelivery, outcome CallbackTerminalOutcome, now time.Time) error {
+	if delivery == nil {
+		return ErrChordNotFound
+	}
+	if delivery.CallbackState == ChordDelivered {
+		if delivery.TerminalOutcome == outcome {
+			return nil
+		}
+		return ErrChordTerminalConflict
+	}
+	if delivery.CallbackState == ChordSuppressed {
+		return ErrChordTerminalConflict
+	}
+	delivery.CallbackState = ChordDelivered
+	delivery.TerminalOutcome = outcome
+	setChordTerminalTime(delivery, now)
+	delivery.CallbackVersion++
+	delivery.Version++
+	delivery.UpdatedAt = now
+	return nil
+}
+
+func SortChordDeliveries(deliveries []ChordDelivery) {
+	sort.Slice(deliveries, func(i, j int) bool { return deliveries[i].DeliveryKey < deliveries[j].DeliveryKey })
+}
+
+func boundedChordError(value string) string {
+	const max = 512
+	if len(value) <= max {
+		return value
+	}
+	return value[:max]
+}
+
+func deadlineOrDefault(value, fallback time.Time) time.Time {
+	if value.IsZero() {
+		return fallback
+	}
+	return value
+}
+
+func cloneChordResults(results []*task.Result) ([]*task.Result, error) {
+	body, err := json.Marshal(results)
+	if err != nil {
+		return nil, fmt.Errorf("serialize chord member results: %w", err)
+	}
+	var copyResults []*task.Result
+	if err := json.Unmarshal(body, &copyResults); err != nil {
+		return nil, fmt.Errorf("deserialize chord member results: %w", err)
+	}
+	return copyResults, nil
+}
+
+func buildChordCallbackPayload(delivery *ChordDelivery) ([]byte, error) {
+	var callback task.Signature
+	if err := json.Unmarshal(delivery.CallbackTemplate, &callback); err != nil {
+		return nil, fmt.Errorf("decode chord callback template: %w", err)
+	}
+	for ordinal := range delivery.Members {
+		for _, result := range delivery.Members[ordinal].Receipt.Results {
+			callback.Args = append(callback.Args, task.Arg{Type: result.Type, Value: result.Value})
+		}
+	}
+	return json.Marshal(&callback)
+}
+
+func setChordSuppressed(delivery *ChordDelivery, now time.Time) {
+	if delivery.CallbackState == ChordDelivered || delivery.CallbackState == ChordSuppressed {
+		return
+	}
+	delivery.CallbackState = ChordSuppressed
+	delivery.TerminalOutcome = CallbackTerminalFailure
+	setChordTerminalTime(delivery, now)
+	delivery.CallbackVersion++
+}
+
+func setChordTerminalTime(delivery *ChordDelivery, now time.Time) {
+	if now.IsZero() {
+		now = time.Now()
+	}
+	delivery.TerminalAt = now
+	if delivery.Retention < 0 {
+		delivery.TerminalExpireAt = nil
+		return
+	}
+	expires := now.Add(time.Duration(NormalizeChordRetention(delivery.Retention)) * time.Second)
+	delivery.TerminalExpireAt = &expires
+}

--- a/distributed/backend/durable_chord.go
+++ b/distributed/backend/durable_chord.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/songzhibin97/gkit/distributed/task"
@@ -373,7 +374,7 @@ func ApplyChordMemberPublishOutcome(delivery *ChordDelivery, lease ChordMemberLe
 	}
 	member.LeaseOwner = ""
 	member.LeaseExpiresAt = time.Time{}
-	member.LastError = boundedChordError(outcome.Error)
+	member.LastError = chordErrorSummary("member_publish", outcome)
 	switch outcome.Kind {
 	case ChordPublishOutcomeSucceeded:
 		member.State = ChordMemberPublished
@@ -511,7 +512,7 @@ func ApplyChordCallbackPublishOutcome(delivery *ChordDelivery, lease ChordCallba
 	}
 	delivery.CallbackLeaseOwner = ""
 	delivery.CallbackLeaseExpiresAt = time.Time{}
-	delivery.CallbackLastError = boundedChordError(outcome.Error)
+	delivery.CallbackLastError = chordErrorSummary("callback_publish", outcome)
 	switch outcome.Kind {
 	case ChordPublishOutcomeSucceeded:
 		delivery.CallbackState = ChordPublished
@@ -557,12 +558,12 @@ func SortChordDeliveries(deliveries []ChordDelivery) {
 	sort.Slice(deliveries, func(i, j int) bool { return deliveries[i].DeliveryKey < deliveries[j].DeliveryKey })
 }
 
-func boundedChordError(value string) string {
-	const max = 512
-	if len(value) <= max {
-		return value
+func chordErrorSummary(operation string, outcome ChordPublishOutcome) string {
+	if outcome.Error == "" {
+		return ""
 	}
-	return value[:max]
+	category := strings.ToLower(string(outcome.Kind))
+	return "operation=" + operation + " category=" + category
 }
 
 func deadlineOrDefault(value, fallback time.Time) time.Time {

--- a/distributed/backend/durable_chord_redaction_regression_test.go
+++ b/distributed/backend/durable_chord_redaction_regression_test.go
@@ -1,0 +1,53 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDurableChordStoredErrorsAreStructuredAndRedacted(t *testing.T) {
+	secret := "synthetic-secret-token payload={credit_card:4111111111111111}"
+	now := time.Now()
+	delivery := ChordDelivery{
+		DeliveryKey: "delivery",
+		Members: []ChordMemberPublication{{
+			Ordinal: 0,
+			TaskID:  "member",
+			Payload: []byte(`{"args":["private-payload"],"meta":{"token":"private-meta"}}`),
+			State:   ChordMemberReady,
+			Version: 1,
+		}},
+		CallbackState:   ChordReady,
+		CallbackPayload: []byte(`{"args":["private-callback-payload"]}`),
+		CallbackVersion: 1,
+	}
+	memberLease, claimed, err := ClaimChordMember(&delivery, ChordMemberClaim{DeliveryKey: delivery.DeliveryKey, Ordinal: 0, Owner: "member-owner", Now: now})
+	if err != nil || !claimed {
+		t.Fatalf("member claim = %t, %v", claimed, err)
+	}
+	if err := ApplyChordMemberPublishOutcome(&delivery, memberLease, ChordPublishOutcome{Kind: ChordPublishOutcomeUnknown, Now: now, Error: secret}); err != nil {
+		t.Fatal(err)
+	}
+	if got := delivery.Members[0].LastError; got != "operation=member_publish category=unknown" {
+		t.Fatalf("member stored error = %q", got)
+	}
+
+	callbackLease, claimed, err := ClaimChordCallback(&delivery, ChordCallbackClaim{DeliveryKey: delivery.DeliveryKey, Owner: "callback-owner", Now: now})
+	if err != nil || !claimed {
+		t.Fatalf("callback claim = %t, %v", claimed, err)
+	}
+	if err := ApplyChordCallbackPublishOutcome(&delivery, callbackLease, ChordPublishOutcome{Kind: ChordPublishOutcomeRejected, Now: now, Error: secret}); err != nil {
+		t.Fatal(err)
+	}
+	if got := delivery.CallbackLastError; got != "operation=callback_publish category=rejected" {
+		t.Fatalf("callback stored error = %q", got)
+	}
+
+	body := string(delivery.Members[0].Payload) + string(delivery.CallbackPayload)
+	for _, forbidden := range []string{secret, "synthetic-secret-token", "credit_card", body} {
+		if strings.Contains(delivery.Members[0].LastError, forbidden) || strings.Contains(delivery.CallbackLastError, forbidden) {
+			t.Fatalf("stored error leaked %q", forbidden)
+		}
+	}
+}

--- a/distributed/durable_chord.go
+++ b/distributed/durable_chord.go
@@ -1,0 +1,463 @@
+package distributed
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/robfig/cron/v3"
+	"github.com/songzhibin97/gkit/distributed/backend"
+	"github.com/songzhibin97/gkit/distributed/backend/result"
+	"github.com/songzhibin97/gkit/distributed/locker"
+	"github.com/songzhibin97/gkit/distributed/task"
+	"github.com/songzhibin97/gkit/tools/rand_string"
+)
+
+var ErrDurableTimedChordLockerUnsupported = errors.New("durable timed chord requires context-aware locker")
+
+type DefinitePublishRejection interface {
+	error
+	RejectedWithoutBrokerSideEffect() bool
+}
+
+const (
+	chordDispatchInterval    = 250 * time.Millisecond
+	chordOperationTimeout    = 5 * time.Second
+	chordPublicationLease    = 30 * time.Second
+	chordConfirmationTimeout = 30 * time.Second
+	chordScanLimit           = 100
+)
+
+func (s *Server) sendDurableGroupCallback(ctx context.Context, groupCallback *task.GroupCallback, concurrency int) (*result.GroupCallbackAsyncResult, error) {
+	s.lifecycleMu.Lock()
+	if s.closing {
+		s.lifecycleMu.Unlock()
+		return nil, context.Canceled
+	}
+	startupErr := s.startupErr
+	s.lifecycleMu.Unlock()
+	if startupErr != nil {
+		return nil, startupErr
+	}
+
+	group := &task.Group{GroupID: groupCallback.Group.GroupID, Name: groupCallback.Group.Name, Tasks: task.CopySignatures(groupCallback.Group.Tasks...)}
+	callback := task.CopySignature(groupCallback.Callback)
+	if s.prePublishHandler != nil {
+		s.prePublishHandler(callback)
+	}
+	if callback.ID == "" {
+		return nil, fmt.Errorf("%w: pre-publish hook cleared callback id", backend.ErrChordInvalidInput)
+	}
+	s.bindDefaultRouter(callback)
+	deliveryKey := backend.ChordDeliveryKey(group.GroupID, callback.ID)
+	if callback.Meta == nil {
+		callback.Meta = task.NewMeta(callback.MetaSafe)
+	}
+	callback.Meta.Set(backend.DurableChordDeliveryKeyMeta, deliveryKey)
+	callbackPayload, err := json.Marshal(callback)
+	if err != nil {
+		return nil, fmt.Errorf("serialize durable chord callback: %w", err)
+	}
+	registration := backend.ChordRegistration{
+		DeliveryKey: deliveryKey,
+		GroupID:     group.GroupID,
+		GroupName:   group.Name,
+		Retention:   s.config.ResultExpire,
+		Callback:    callbackPayload,
+	}
+	memberIDs := make(map[string]struct{}, len(group.Tasks))
+	for ordinal, member := range group.Tasks {
+		if s.prePublishHandler != nil {
+			s.prePublishHandler(member)
+		}
+		member.GroupID = group.GroupID
+		member.GroupTaskCount = len(group.Tasks)
+		member.CallbackChord = nil
+		if member.Meta == nil {
+			member.Meta = task.NewMeta(member.MetaSafe)
+		}
+		member.Meta.Set(backend.DurableChordDeliveryKeyMeta, deliveryKey)
+		member.Meta.Set(backend.DurableChordMemberMeta, true)
+		member.Meta.Set(backend.DurableChordMemberOrdinal, ordinal)
+		if member.ID == "" {
+			return nil, fmt.Errorf("%w: pre-publish hook cleared member id at ordinal %d", backend.ErrChordInvalidInput, ordinal)
+		}
+		if _, exists := memberIDs[member.ID]; exists {
+			return nil, fmt.Errorf("%w: pre-publish hook created duplicate member id %q", backend.ErrChordInvalidInput, member.ID)
+		}
+		memberIDs[member.ID] = struct{}{}
+		s.bindDefaultRouter(member)
+		payload, marshalErr := json.Marshal(member)
+		if marshalErr != nil {
+			return nil, fmt.Errorf("serialize durable chord member %d: %w", ordinal, marshalErr)
+		}
+		registration.Members = append(registration.Members, backend.ChordMemberRegistration{Ordinal: ordinal, TaskID: member.ID, Payload: payload})
+	}
+	if err := backend.FinalizeChordRegistration(&registration); err != nil {
+		return nil, err
+	}
+	ref, err := s.durableBackend.RegisterChord(ctx, registration)
+	if err != nil {
+		return nil, err
+	}
+	if ref.Created {
+		if err := s.durableBackend.ReconcileChord(ctx, ref.DeliveryKey); err != nil {
+			abortErr := s.durableBackend.AbortRegistration(ctx, ref)
+			// Reconcile uses create-if-absent writes. Without ownership markers on
+			// legacy group/task rows, deleting them here could erase state owned by
+			// another caller. A later identical registration safely reuses them.
+			return nil, errors.Join(err, abortErr)
+		}
+	} else {
+		if err := s.waitForChordRegistration(ctx, ref); err != nil {
+			return nil, err
+		}
+		return result.NewGroupCallbackAsyncResult(group.Tasks, callback, s.backend), nil
+	}
+
+	if concurrency < 1 {
+		concurrency = 1
+	}
+	var publishErrs []error
+	var publishErrsMu sync.Mutex
+	semaphore := make(chan struct{}, concurrency)
+	var wg sync.WaitGroup
+	for ordinal := range group.Tasks {
+		if err := ctx.Err(); err != nil {
+			publishErrsMu.Lock()
+			publishErrs = append(publishErrs, err)
+			publishErrsMu.Unlock()
+			break
+		}
+		select {
+		case semaphore <- struct{}{}:
+		case <-ctx.Done():
+			publishErrsMu.Lock()
+			publishErrs = append(publishErrs, ctx.Err())
+			publishErrsMu.Unlock()
+			break
+		}
+		if ctx.Err() != nil {
+			break
+		}
+		wg.Add(1)
+		go func(ordinal int) {
+			defer wg.Done()
+			defer func() { <-semaphore }()
+			if err := s.publishChordMember(ctx, ref.DeliveryKey, ordinal); err != nil {
+				publishErrsMu.Lock()
+				publishErrs = append(publishErrs, err)
+				publishErrsMu.Unlock()
+			}
+		}(ordinal)
+	}
+	wg.Wait()
+	async := result.NewGroupCallbackAsyncResult(group.Tasks, callback, s.backend)
+	return async, errors.Join(publishErrs...)
+}
+
+func (s *Server) waitForChordRegistration(ctx context.Context, ref backend.ChordRegistrationRef) error {
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		cursor := ""
+		found := false
+		for {
+			page, err := s.durableBackend.ScanChordDeliveries(ctx, backend.ChordScan{Cursor: cursor, Limit: chordScanLimit, Now: time.Now()})
+			if err != nil {
+				return err
+			}
+			for _, delivery := range page.Deliveries {
+				if delivery.DeliveryKey != ref.DeliveryKey {
+					continue
+				}
+				found = true
+				if delivery.RegistrationOwner != ref.Owner || delivery.RegistrationVersion != ref.Version {
+					return backend.ErrChordRegistrationAborted
+				}
+				ready := true
+				for _, member := range delivery.Members {
+					if member.State == backend.ChordMemberSetup {
+						ready = false
+						break
+					}
+				}
+				if ready {
+					return nil
+				}
+				break
+			}
+			if found || page.NextCursor == "" {
+				break
+			}
+			cursor = page.NextCursor
+		}
+		if !found {
+			return backend.ErrChordRegistrationAborted
+		}
+		select {
+		case <-ticker.C:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+func (s *Server) startChordDispatcher() error {
+	if err := s.runChordPass(s.chordCtx); err != nil {
+		return fmt.Errorf("durable chord startup scan: %w", err)
+	}
+	s.chordWG.Add(1)
+	go func() {
+		defer s.chordWG.Done()
+		ticker := time.NewTicker(chordDispatchInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-s.chordCtx.Done():
+				return
+			case <-ticker.C:
+				if err := s.runChordPass(s.chordCtx); err != nil {
+					s.recordLifecycleError(fmt.Errorf("durable chord dispatcher: %w", err))
+				}
+			}
+		}
+	}()
+	return nil
+}
+
+func (s *Server) runChordPass(ctx context.Context) error {
+	owner, err := backend.NewChordOwner()
+	if err != nil {
+		return err
+	}
+	cursor := ""
+	for {
+		operationCtx, cancel := context.WithTimeout(ctx, chordOperationTimeout)
+		page, scanErr := s.durableBackend.ScanChordDeliveries(operationCtx, backend.ChordScan{Cursor: cursor, Limit: chordScanLimit, Now: time.Now()})
+		cancel()
+		if scanErr != nil {
+			return scanErr
+		}
+		for index := range page.Deliveries {
+			delivery := &page.Deliveries[index]
+			operationCtx, cancel = context.WithTimeout(ctx, chordOperationTimeout)
+			reconcileErr := s.durableBackend.ReconcileChord(operationCtx, delivery.DeliveryKey)
+			cancel()
+			if reconcileErr != nil {
+				return reconcileErr
+			}
+			for ordinal := range delivery.Members {
+				operationCtx, cancel = context.WithTimeout(ctx, chordOperationTimeout)
+				publishErr := s.publishChordMemberWithOwner(operationCtx, delivery.DeliveryKey, ordinal, owner)
+				cancel()
+				if publishErr != nil && !errors.Is(publishErr, context.Canceled) {
+					s.recordLifecycleError(publishErr)
+				}
+			}
+			operationCtx, cancel = context.WithTimeout(ctx, chordOperationTimeout)
+			publishErr := s.publishChordCallbackWithOwner(operationCtx, delivery.DeliveryKey, owner)
+			cancel()
+			if publishErr != nil && !errors.Is(publishErr, context.Canceled) {
+				s.recordLifecycleError(publishErr)
+			}
+		}
+		if page.NextCursor == "" {
+			break
+		}
+		cursor = page.NextCursor
+	}
+	operationCtx, cancel := context.WithTimeout(ctx, chordOperationTimeout)
+	_, cleanupErr := s.durableBackend.CleanupTerminalChordDeliveries(operationCtx, time.Now(), chordScanLimit)
+	cancel()
+	return cleanupErr
+}
+
+func (s *Server) publishChordMember(ctx context.Context, deliveryKey string, ordinal int) error {
+	owner, err := backend.NewChordOwner()
+	if err != nil {
+		return err
+	}
+	return s.publishChordMemberWithOwner(ctx, deliveryKey, ordinal, owner)
+}
+
+func (s *Server) publishChordMemberWithOwner(ctx context.Context, deliveryKey string, ordinal int, owner string) error {
+	now := time.Now()
+	lease, claimed, err := s.durableBackend.ClaimMemberPublication(ctx, backend.ChordMemberClaim{DeliveryKey: deliveryKey, Ordinal: ordinal, Owner: owner, Now: now, LeaseDuration: chordPublicationLease})
+	if err != nil || !claimed {
+		return err
+	}
+	var signature task.Signature
+	if err := json.Unmarshal(lease.Payload, &signature); err != nil {
+		recordCtx, cancel := s.newChordOutcomeContext()
+		defer cancel()
+		return s.durableBackend.RecordMemberPublishOutcome(recordCtx, lease, backend.ChordPublishOutcome{Kind: backend.ChordPublishOutcomeRejected, Now: time.Now(), Error: err.Error()})
+	}
+	publishErr := s.controller.Publish(ctx, &signature)
+	outcome := classifyChordPublishOutcome(publishErr, time.Now())
+	recordCtx, cancel := s.newChordOutcomeContext()
+	recordErr := s.durableBackend.RecordMemberPublishOutcome(recordCtx, lease, outcome)
+	cancel()
+	return errors.Join(publishErr, recordErr)
+}
+
+func (s *Server) publishChordCallbackWithOwner(ctx context.Context, deliveryKey, owner string) error {
+	now := time.Now()
+	lease, claimed, err := s.durableBackend.ClaimCallbackPublication(ctx, backend.ChordCallbackClaim{DeliveryKey: deliveryKey, Owner: owner, Now: now, LeaseDuration: chordPublicationLease})
+	if err != nil || !claimed {
+		return err
+	}
+	var signature task.Signature
+	if err := json.Unmarshal(lease.Payload, &signature); err != nil {
+		recordCtx, cancel := s.newChordOutcomeContext()
+		defer cancel()
+		return s.durableBackend.RecordCallbackPublishOutcome(recordCtx, lease, backend.ChordPublishOutcome{Kind: backend.ChordPublishOutcomeRejected, Now: time.Now(), Error: err.Error(), NextAttemptAt: time.Now().Add(time.Second)})
+	}
+	publishErr := s.controller.Publish(ctx, &signature)
+	outcome := classifyChordPublishOutcome(publishErr, time.Now())
+	recordCtx, cancel := s.newChordOutcomeContext()
+	recordErr := s.durableBackend.RecordCallbackPublishOutcome(recordCtx, lease, outcome)
+	cancel()
+	return errors.Join(publishErr, recordErr)
+}
+
+func (s *Server) newChordOutcomeContext() (context.Context, context.CancelFunc) {
+	root := s.chordOutcomeCtx
+	if root == nil {
+		root = context.Background()
+	}
+	return context.WithTimeout(root, chordOperationTimeout)
+}
+
+func classifyChordPublishOutcome(err error, now time.Time) backend.ChordPublishOutcome {
+	if err == nil {
+		return backend.ChordPublishOutcome{Kind: backend.ChordPublishOutcomeSucceeded, Now: now, ConfirmationDeadline: now.Add(chordConfirmationTimeout)}
+	}
+	var rejection DefinitePublishRejection
+	if errors.As(err, &rejection) && rejection.RejectedWithoutBrokerSideEffect() {
+		return backend.ChordPublishOutcome{Kind: backend.ChordPublishOutcomeRejected, Now: now, NextAttemptAt: now.Add(time.Second), Error: err.Error()}
+	}
+	return backend.ChordPublishOutcome{Kind: backend.ChordPublishOutcomeUnknown, Now: now, ConfirmationDeadline: now.Add(chordConfirmationTimeout), Error: err.Error()}
+}
+
+func (s *Server) recordLifecycleError(err error) {
+	if err == nil {
+		return
+	}
+	s.lifecycleMu.Lock()
+	s.lifecycleErrs = append(s.lifecycleErrs, err)
+	s.lifecycleMu.Unlock()
+}
+
+func (s *Server) shutdown(ctx context.Context) error {
+	s.lifecycleMu.Lock()
+	s.closing = true
+	s.lifecycleMu.Unlock()
+	if s.registrationCancel != nil {
+		s.registrationCancel()
+	}
+	if s.cleanupRootCancel != nil {
+		s.cleanupRootCancel()
+	}
+	stopCtx := s.scheduler.Stop()
+	if err := waitForContext(ctx, stopCtx); err != nil {
+		s.recordLifecycleError(err)
+	}
+	if err := waitForGroup(ctx, &s.registrationWG); err != nil {
+		s.recordLifecycleError(err)
+	}
+	if s.chordCancel != nil {
+		s.chordCancel()
+	}
+	if err := waitForGroup(ctx, &s.chordWG); err != nil {
+		s.recordLifecycleError(err)
+	}
+	if s.chordOutcomeCancel != nil {
+		s.chordOutcomeCancel()
+	}
+	s.lifecycleMu.Lock()
+	errs := append([]error(nil), s.lifecycleErrs...)
+	s.lifecycleMu.Unlock()
+	if ctx.Err() != nil {
+		errs = append(errs, ctx.Err())
+	}
+	return errors.Join(errs...)
+}
+
+func waitForContext(ctx context.Context, target context.Context) error {
+	select {
+	case <-target.Done():
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func waitForGroup(ctx context.Context, group *sync.WaitGroup) error {
+	done := make(chan struct{})
+	go func() {
+		group.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (s *Server) contextLocker() (locker.ContextLocker, bool) {
+	value, ok := s.lock.(locker.ContextLocker)
+	return value, ok
+}
+
+func (s *Server) runDurableTimedGroupCallback(contextLock locker.ContextLocker, schedule cron.Schedule, spec, name, groupID string, concurrency int, callback *task.Signature, signatures ...*task.Signature) (returnErr error) {
+	s.lifecycleMu.Lock()
+	if s.closing {
+		s.lifecycleMu.Unlock()
+		return context.Canceled
+	}
+	s.registrationWG.Add(1)
+	s.lifecycleMu.Unlock()
+	defer s.registrationWG.Done()
+
+	ctx, cancel := context.WithTimeout(s.registrationCtx, s.config.DurableChordRegistrationTimeout)
+	defer cancel()
+	runSuffix := rand_string.RandomLetter(timedRunSuffixLength)
+	groupCallback := newTimedGroupCallbackRun(groupID, name, runSuffix, callback, signatures...)
+	key := getLockName(name, spec)
+	mark := rand_string.RandomLetter(16)
+	ttl := timedTaskLockTTL(time.Until(schedule.Next(time.Now())))
+	if err := contextLock.LockContext(ctx, key, ttl, mark); err != nil {
+		return fmt.Errorf("lock durable timed chord %q: %w", name, err)
+	}
+	lockExpiresAt := time.Now().Add(time.Duration(ttl) * time.Millisecond)
+	defer func() {
+		remaining := time.Until(lockExpiresAt)
+		if remaining <= 0 {
+			unlockErr := fmt.Errorf("unlock durable timed chord %q: lock expired", name)
+			s.recordLifecycleError(unlockErr)
+			returnErr = errors.Join(returnErr, unlockErr)
+			return
+		}
+		cleanupTimeout := 5 * time.Second
+		if remaining < cleanupTimeout {
+			cleanupTimeout = remaining
+		}
+		cleanupCtx, cleanupCancel := context.WithTimeout(s.cleanupRootCtx, cleanupTimeout)
+		defer cleanupCancel()
+		if err := contextLock.UnlockContext(cleanupCtx, key, mark); err != nil {
+			unlockErr := fmt.Errorf("unlock durable timed chord %q: %w", name, err)
+			s.recordLifecycleError(unlockErr)
+			returnErr = errors.Join(returnErr, unlockErr)
+		}
+	}()
+	if _, err := s.SendGroupCallbackWithContext(ctx, groupCallback, concurrency); err != nil {
+		return fmt.Errorf("send durable timed chord %q: %w", name, err)
+	}
+	return nil
+}

--- a/distributed/durable_chord_namespace_regression_test.go
+++ b/distributed/durable_chord_namespace_regression_test.go
@@ -1,0 +1,149 @@
+package distributed
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/go-redis/redis/v8"
+	"github.com/songzhibin97/gkit/distributed/backend"
+	backendredis "github.com/songzhibin97/gkit/distributed/backend/backend_redis"
+	"github.com/songzhibin97/gkit/distributed/task"
+	"github.com/songzhibin97/gkit/log"
+)
+
+func TestRedisDurableChordNamespaceIsolatedAcrossSendWorkerAndRestart(t *testing.T) {
+	t.Run("public send", func(t *testing.T) {
+		mr := miniredis.RunT(t)
+		client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+		t.Cleanup(func() { _ = client.Close() })
+		server, controller := startNamespaceServer(t, client)
+		t.Cleanup(func() { shutdownNamespaceServer(t, server) })
+
+		for _, tt := range []struct {
+			name        string
+			groupID     string
+			memberID    string
+			callbackID  string
+			wantContext string
+		}{
+			{name: "group id", groupID: "gkit:chord:{public-group}:record", memberID: "member-a", callbackID: "callback-a", wantContext: "group"},
+			{name: "member id", groupID: "group-b", memberID: "gkit:chord:{public-member}:record", callbackID: "callback-b", wantContext: "member"},
+			{name: "callback id", groupID: "group-c", memberID: "member-c", callbackID: "gkit:chord:{public-callback}:record", wantContext: "callback"},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				groupCallback := namespaceGroupCallback(tt.groupID, tt.memberID, tt.callbackID)
+				if _, err := server.SendGroupCallbackWithContext(context.Background(), groupCallback, 1); !errors.Is(err, backend.ErrChordInvalidInput) || !strings.Contains(err.Error(), tt.wantContext) {
+					t.Fatalf("SendGroupCallback error = %v, want typed %s context", err, tt.wantContext)
+				}
+				if got := controller.publishCount.Load(); got != 0 {
+					t.Fatalf("reserved identifier published %d tasks", got)
+				}
+			})
+		}
+	})
+
+	t.Run("worker status", func(t *testing.T) {
+		mr := miniredis.RunT(t)
+		client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+		t.Cleanup(func() { _ = client.Close() })
+		server, _ := startNamespaceServer(t, client)
+		t.Cleanup(func() { shutdownNamespaceServer(t, server) })
+		var handlerCalls atomic.Int32
+		if err := server.RegisteredTask("namespace-worker", func() (string, error) {
+			handlerCalls.Add(1)
+			return "ok", nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+		const taskID = "gkit:chord:{worker-status}:record"
+		const legacyValue = "legacy-worker-value"
+		if err := client.Set(context.Background(), taskID, legacyValue, 0).Err(); err != nil {
+			t.Fatal(err)
+		}
+		worker := server.NewWorker("namespace", 1, "queue")
+		err := worker.Process(&task.Signature{ID: taskID, Name: "namespace-worker"})
+		if !errors.Is(err, backend.ErrChordInvalidInput) || !strings.Contains(err.Error(), "task") {
+			t.Fatalf("worker error = %v, want typed reserved task error", err)
+		}
+		if handlerCalls.Load() != 0 {
+			t.Fatal("worker invoked handler after reserved status-key rejection")
+		}
+		if got := client.Get(context.Background(), taskID).Val(); got != legacyValue {
+			t.Fatalf("worker changed legacy value to %q", got)
+		}
+	})
+
+	t.Run("legacy collision restart", func(t *testing.T) {
+		mr := miniredis.RunT(t)
+		client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+		t.Cleanup(func() { _ = client.Close() })
+		groupCallback := namespaceGroupCallback("restart-group", "restart-member", "restart-callback")
+		recordKey := namespaceRecordKey(groupCallback.Group.GroupID, groupCallback.Callback.ID)
+		const legacyValue = "legacy-non-json-value"
+		if err := client.Set(context.Background(), recordKey, legacyValue, 0).Err(); err != nil {
+			t.Fatal(err)
+		}
+
+		first, firstController := startNamespaceServer(t, client)
+		if _, err := first.SendGroupCallbackWithContext(context.Background(), groupCallback, 1); !errors.Is(err, backend.ErrChordRegistrationConflict) {
+			t.Fatalf("first send error = %v, want ErrChordRegistrationConflict", err)
+		}
+		if firstController.publishCount.Load() != 0 || client.Get(context.Background(), recordKey).Val() != legacyValue {
+			t.Fatal("first send published work or overwrote legacy record")
+		}
+		shutdownNamespaceServer(t, first)
+
+		second, secondController := startNamespaceServer(t, client)
+		t.Cleanup(func() { shutdownNamespaceServer(t, second) })
+		if _, err := second.SendGroupCallbackWithContext(context.Background(), groupCallback, 1); !errors.Is(err, backend.ErrChordRegistrationConflict) {
+			t.Fatalf("send after restart error = %v, want ErrChordRegistrationConflict", err)
+		}
+		if secondController.publishCount.Load() != 0 || client.Get(context.Background(), recordKey).Val() != legacyValue {
+			t.Fatal("restart published work or overwrote legacy record")
+		}
+	})
+}
+
+func startNamespaceServer(t *testing.T, client redis.UniversalClient) (*Server, *groupTestController) {
+	t.Helper()
+	controller := &groupTestController{}
+	server, err := NewServerE(
+		controller,
+		backendredis.NewBackendRedis(client, -1),
+		timedGroupTestLocker{},
+		log.NewHelper(log.DefaultLogger),
+		nil,
+		SetEnableDurableChordRegistration(true),
+		SetConsumeQueue("namespace-queue"),
+	)
+	if err != nil {
+		t.Fatalf("NewServerE: %v", err)
+	}
+	return server, controller
+}
+
+func shutdownNamespaceServer(t *testing.T, server *Server) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := server.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+}
+
+func namespaceGroupCallback(groupID, memberID, callbackID string) *task.GroupCallback {
+	return &task.GroupCallback{
+		Group:    &task.Group{GroupID: groupID, Name: "namespace", Tasks: []*task.Signature{{ID: memberID, Name: "member"}}},
+		Callback: &task.Signature{ID: callbackID, Name: "callback"},
+	}
+}
+
+func namespaceRecordKey(groupID, callbackID string) string {
+	parts := strings.Split(backend.ChordDeliveryKey(groupID, callbackID), ":")
+	return "gkit:chord:{" + parts[2] + "}:record"
+}

--- a/distributed/durable_chord_service_regression_test.go
+++ b/distributed/durable_chord_service_regression_test.go
@@ -1,0 +1,1058 @@
+package distributed
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/robfig/cron/v3"
+	"github.com/songzhibin97/gkit/distributed/backend"
+	"github.com/songzhibin97/gkit/distributed/task"
+	"github.com/songzhibin97/gkit/log"
+)
+
+var _ backend.Backend = (*groupTestBackend)(nil)
+
+type issue104DefiniteRejection struct{ definite bool }
+
+func (e issue104DefiniteRejection) Error() string { return "publish rejected" }
+func (e issue104DefiniteRejection) RejectedWithoutBrokerSideEffect() bool {
+	return e.definite
+}
+
+type issue104FailingScanBackend struct {
+	backend.Backend
+	backend.DurableChordBackend
+	err error
+}
+
+type issue104FailOnceBackend struct {
+	backend.Backend
+	backend.DurableChordBackend
+	mu                    sync.Mutex
+	memberOutcomeFails    int
+	memberTerminalFails   int
+	callbackTerminalFails int
+	forceLease            time.Duration
+	forceConfirmation     time.Duration
+}
+
+func (b *issue104FailOnceBackend) consume(counter *int) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if *counter <= 0 {
+		return false
+	}
+	*counter--
+	return true
+}
+
+func (b *issue104FailOnceBackend) ClaimMemberPublication(ctx context.Context, claim backend.ChordMemberClaim) (backend.ChordMemberLease, bool, error) {
+	if b.forceLease > 0 {
+		claim.LeaseDuration = b.forceLease
+	}
+	return b.DurableChordBackend.ClaimMemberPublication(ctx, claim)
+}
+
+func (b *issue104FailOnceBackend) RecordMemberPublishOutcome(ctx context.Context, lease backend.ChordMemberLease, outcome backend.ChordPublishOutcome) error {
+	if b.consume(&b.memberOutcomeFails) {
+		return errors.New("injected member outcome write failure")
+	}
+	if b.forceConfirmation > 0 && (outcome.Kind == backend.ChordPublishOutcomeSucceeded || outcome.Kind == backend.ChordPublishOutcomeUnknown) {
+		outcome.ConfirmationDeadline = outcome.Now.Add(b.forceConfirmation)
+	}
+	return b.DurableChordBackend.RecordMemberPublishOutcome(ctx, lease, outcome)
+}
+
+func (b *issue104FailOnceBackend) RecordCallbackPublishOutcome(ctx context.Context, lease backend.ChordCallbackLease, outcome backend.ChordPublishOutcome) error {
+	if b.forceConfirmation > 0 && (outcome.Kind == backend.ChordPublishOutcomeSucceeded || outcome.Kind == backend.ChordPublishOutcomeUnknown) {
+		outcome.ConfirmationDeadline = outcome.Now.Add(b.forceConfirmation)
+	}
+	return b.DurableChordBackend.RecordCallbackPublishOutcome(ctx, lease, outcome)
+}
+
+func (b *issue104FailOnceBackend) RecordMemberTerminal(ctx context.Context, key string, ordinal int, taskID string, outcome backend.MemberTerminalOutcome, results []*task.Result) error {
+	if b.consume(&b.memberTerminalFails) {
+		return errors.New("injected member receipt write failure")
+	}
+	return b.DurableChordBackend.RecordMemberTerminal(ctx, key, ordinal, taskID, outcome, results)
+}
+
+func (b *issue104FailOnceBackend) RecordCallbackTerminal(ctx context.Context, key string, outcome backend.CallbackTerminalOutcome) error {
+	if b.consume(&b.callbackTerminalFails) {
+		return errors.New("injected callback terminal write failure")
+	}
+	return b.DurableChordBackend.RecordCallbackTerminal(ctx, key, outcome)
+}
+
+func (b *issue104FailingScanBackend) ScanChordDeliveries(context.Context, backend.ChordScan) (backend.ChordDeliveryPage, error) {
+	return backend.ChordDeliveryPage{}, b.err
+}
+
+type issue104BlockingContextLocker struct {
+	unlockEntered chan struct{}
+	ttl           int
+}
+
+func (l *issue104BlockingContextLocker) Lock(string, int, string) error  { return nil }
+func (l *issue104BlockingContextLocker) UnLock(string, string) error     { return nil }
+func (l *issue104BlockingContextLocker) Renew(string, int, string) error { return nil }
+func (l *issue104BlockingContextLocker) LockContext(_ context.Context, _ string, ttl int, _ string) error {
+	l.ttl = ttl
+	return nil
+}
+func (l *issue104BlockingContextLocker) UnlockContext(ctx context.Context, _, _ string) error {
+	select {
+	case l.unlockEntered <- struct{}{}:
+	default:
+	}
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func TestDurableChordEndToEndUsesReceiptsAndDeliveryKey(t *testing.T) {
+	backendValue := newGroupConvergenceRedisBackend(t)
+	durable := backendValue.(backend.DurableChordBackend)
+	published := make(chan *task.Signature, 16)
+	prePublishCalls := make(map[string]int)
+	var prePublishMu sync.Mutex
+	controller := &groupTestController{publishFn: func(_ context.Context, signature *task.Signature) error {
+		published <- task.CopySignature(signature)
+		return nil
+	}}
+	server, err := NewServerE(
+		controller,
+		backendValue,
+		timedGroupTestLocker{},
+		log.NewHelper(log.DefaultLogger),
+		func(signature *task.Signature) {
+			prePublishMu.Lock()
+			prePublishCalls[signature.ID]++
+			prePublishMu.Unlock()
+			signature.Meta = nil
+			if signature.Name == "member" {
+				signature.CallbackChord = task.NewSignature("legacy-callback", "callback")
+				signature.GroupID = "hook-overwrite"
+			}
+			signature.Router = "durable-route"
+		},
+		SetEnableDurableChordRegistration(true),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = server.Shutdown(ctx)
+	})
+
+	if err := server.RegisteredTask("member", func() (string, error) { return "member-result", nil }); err != nil {
+		t.Fatal(err)
+	}
+	if err := server.RegisteredTask("callback", func(string, string) (string, error) { return "callback-result", nil }); err != nil {
+		t.Fatal(err)
+	}
+	memberA := task.NewSignature("member-a", "member")
+	memberB := task.NewSignature("member-b", "member")
+	group, _ := task.NewGroup("durable-group", "durable-group", memberA, memberB)
+	callback := task.NewSignature("shared-callback", "callback")
+	groupCallback, _ := task.NewGroupCallback(group, "durable-group", callback)
+
+	if _, err := server.SendGroupCallbackWithContext(context.Background(), groupCallback, 2); err != nil {
+		t.Fatalf("SendGroupCallbackWithContext: %v", err)
+	}
+	if memberA.CallbackChord != callback || memberB.CallbackChord != callback {
+		t.Fatal("durable send mutated caller member templates")
+	}
+	if memberA.Router != "" || memberB.Router != "" || callback.Router != "" {
+		t.Fatal("durable send mutated caller routing templates")
+	}
+
+	worker := server.NewWorker("issue104", 1, "queue")
+	seenMembers := map[string]bool{}
+	for len(seenMembers) < 2 {
+		select {
+		case signature := <-published:
+			if signature.Name != "member" {
+				continue
+			}
+			if signature.CallbackChord != nil {
+				t.Fatal("durable member retained legacy CallbackChord")
+			}
+			if signature.GroupID != group.GroupID {
+				t.Fatalf("durable member group = %q, want %q", signature.GroupID, group.GroupID)
+			}
+			if marker, ok := signature.Meta.Get(backend.DurableChordMemberMeta); !ok || !metadataBool(marker) {
+				t.Fatal("durable member hook overwrote reserved marker")
+			}
+			if key, ok := signature.Meta.Get(backend.DurableChordDeliveryKeyMeta); !ok || key == "" {
+				t.Fatal("durable member hook overwrote delivery key")
+			}
+			if signature.Router != "durable-route" {
+				t.Fatalf("durable member route = %q", signature.Router)
+			}
+			if err := worker.Process(signature); err != nil {
+				t.Fatalf("process durable member %s: %v", signature.ID, err)
+			}
+			seenMembers[signature.ID] = true
+		case <-time.After(2 * time.Second):
+			t.Fatal("durable members were not published")
+		}
+	}
+
+	var callbackSignature *task.Signature
+	select {
+	case callbackSignature = <-published:
+		for callbackSignature.Name != "callback" {
+			select {
+			case callbackSignature = <-published:
+			case <-time.After(2 * time.Second):
+				t.Fatal("durable callback was not published")
+			}
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("durable callback was not published")
+	}
+	value, ok := callbackSignature.Meta.Get(backend.DurableChordDeliveryKeyMeta)
+	if !ok || value == "" {
+		t.Fatal("durable callback lacks delivery key metadata")
+	}
+	if callbackSignature.Router != "durable-route" {
+		t.Fatalf("durable callback route = %q", callbackSignature.Router)
+	}
+	if err := worker.Process(callbackSignature); err != nil {
+		t.Fatalf("process durable callback: %v", err)
+	}
+
+	deliveryKey := value.(string)
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		page, err := durable.ScanChordDeliveries(context.Background(), backend.ChordScan{Limit: 10})
+		if err != nil {
+			t.Fatal(err)
+		}
+		found := false
+		for _, delivery := range page.Deliveries {
+			if delivery.DeliveryKey == deliveryKey {
+				found = true
+				if delivery.CallbackState == backend.ChordDelivered {
+					prePublishMu.Lock()
+					defer prePublishMu.Unlock()
+					for _, id := range []string{memberA.ID, memberB.ID, callback.ID} {
+						if prePublishCalls[id] != 1 {
+							t.Fatalf("pre-publish calls for %s = %d, want exactly once", id, prePublishCalls[id])
+						}
+					}
+					return
+				}
+			}
+		}
+		if !found {
+			t.Fatal("durable delivery disappeared")
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("callback terminal outcome was not recorded by delivery key")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestDurableTimedChordRejectsLegacyLocker(t *testing.T) {
+	backendValue := newGroupConvergenceRedisBackend(t)
+	server, err := NewServerE(
+		&groupTestController{},
+		backendValue,
+		timedGroupTestLocker{},
+		log.NewHelper(log.DefaultLogger),
+		nil,
+		SetEnableDurableChordRegistration(true),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	t.Cleanup(func() { _ = server.Shutdown(ctx) })
+	err = server.RegisteredTimedGroupCallback("* * * * *", "durable", "group", 1, task.NewSignature("callback", "callback"), task.NewSignature("member", "member"))
+	if !errors.Is(err, ErrDurableTimedChordLockerUnsupported) {
+		t.Fatalf("RegisteredTimedGroupCallback error = %v", err)
+	}
+}
+
+func TestShutdownCancelsUnlockAlreadyInProgress(t *testing.T) {
+	backendValue := newGroupConvergenceRedisBackend(t)
+	contextLock := &issue104BlockingContextLocker{unlockEntered: make(chan struct{}, 1)}
+	server, err := NewServerE(
+		&groupTestController{},
+		backendValue,
+		contextLock,
+		log.NewHelper(log.DefaultLogger),
+		nil,
+		SetEnableDurableChordRegistration(true),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	schedule, err := cron.ParseStandard("* * * * *")
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- server.runDurableTimedGroupCallback(
+			contextLock,
+			schedule,
+			"* * * * *",
+			"durable",
+			"group",
+			1,
+			task.NewSignature("callback", "callback"),
+			task.NewSignature("member", "member"),
+		)
+	}()
+	select {
+	case <-contextLock.unlockEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("UnlockContext did not start")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	shutdownErr := server.Shutdown(ctx)
+	if !errors.Is(shutdownErr, context.Canceled) {
+		t.Fatalf("Shutdown error = %v, want retained unlock cancellation", shutdownErr)
+	}
+	select {
+	case runErr := <-done:
+		if !errors.Is(runErr, context.Canceled) {
+			t.Fatalf("scheduled run error = %v, want context cancellation", runErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("scheduled run survived Shutdown")
+	}
+	if contextLock.ttl <= 0 {
+		t.Fatalf("lock TTL = %d, want finite positive fallback", contextLock.ttl)
+	}
+}
+
+func TestDurableChordPublishOutcomeClassification(t *testing.T) {
+	now := time.Now()
+	for _, tc := range []struct {
+		name string
+		err  error
+		want backend.ChordPublishOutcomeKind
+	}{
+		{name: "nil", want: backend.ChordPublishOutcomeSucceeded},
+		{name: "ordinary", err: errors.New("enqueue then error"), want: backend.ChordPublishOutcomeUnknown},
+		{name: "canceled", err: context.Canceled, want: backend.ChordPublishOutcomeUnknown},
+		{name: "typed false", err: issue104DefiniteRejection{}, want: backend.ChordPublishOutcomeUnknown},
+		{name: "typed true", err: issue104DefiniteRejection{definite: true}, want: backend.ChordPublishOutcomeRejected},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			outcome := classifyChordPublishOutcome(tc.err, now)
+			if outcome.Kind != tc.want {
+				t.Fatalf("outcome = %s, want %s", outcome.Kind, tc.want)
+			}
+			if tc.err != nil && tc.want != backend.ChordPublishOutcomeRejected && outcome.ConfirmationDeadline.IsZero() {
+				t.Fatal("unknown outcome has no confirmation deadline")
+			}
+		})
+	}
+}
+
+func TestDurableChordCompatibilityMatrix(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		enable  bool
+		strict  bool
+		wantErr error
+	}{
+		{name: "disabled compatible", enable: false, strict: false},
+		{name: "disabled strict", enable: false, strict: true},
+		{name: "enabled compatible", enable: true, strict: false},
+		{name: "enabled strict", enable: true, strict: true, wantErr: backend.ErrDurableChordUnsupported},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			backendValue := &groupTestBackend{}
+			controller := &groupTestController{}
+			server, err := NewServerE(
+				controller,
+				backendValue,
+				timedGroupTestLocker{},
+				log.NewHelper(log.DefaultLogger),
+				nil,
+				SetEnableDurableChordRegistration(tc.enable),
+				SetRequireDurableChordBackend(tc.strict),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() {
+				ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+				defer cancel()
+				_ = server.Shutdown(ctx)
+			})
+			group, _ := task.NewGroup("compatibility-"+tc.name, "group", task.NewSignature("member-"+tc.name, "member"))
+			groupCallback, _ := task.NewGroupCallback(group, "group", task.NewSignature("callback-"+tc.name, "callback"))
+			_, sendErr := server.SendGroupCallbackWithContext(context.Background(), groupCallback, 1)
+			if !errors.Is(sendErr, tc.wantErr) {
+				t.Fatalf("send error = %v, want %v", sendErr, tc.wantErr)
+			}
+			wantPublishes := int64(1)
+			if tc.wantErr != nil {
+				wantPublishes = 0
+			}
+			if got := controller.publishCount.Load(); got != wantPublishes {
+				t.Fatalf("publish count = %d, want %d", got, wantPublishes)
+			}
+			timedErr := server.RegisteredTimedGroupCallback("* * * * *", "compatibility-"+tc.name, "timed-group", 1, task.NewSignature("timed-callback", "callback"), task.NewSignature("timed-member", "member"))
+			if !errors.Is(timedErr, tc.wantErr) {
+				t.Fatalf("timed registration error = %v, want %v", timedErr, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestNonDurableTimedChordAcceptsLegacyLocker(t *testing.T) {
+	server, err := NewServerE(
+		&groupTestController{},
+		&groupTestBackend{},
+		timedGroupTestLocker{},
+		log.NewHelper(log.DefaultLogger),
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	t.Cleanup(func() { _ = server.Shutdown(ctx) })
+	if err := server.RegisteredTimedGroupCallback("* * * * *", "legacy", "group", 1, task.NewSignature("callback", "callback"), task.NewSignature("member", "member")); err != nil {
+		t.Fatalf("legacy timed chord registration: %v", err)
+	}
+}
+
+func TestDurableChordStartupRecoversEveryScanPageWhenRegistrationDisabled(t *testing.T) {
+	backendValue := newGroupConvergenceRedisBackend(t)
+	durable := backendValue.(backend.DurableChordBackend)
+	const registrations = chordScanLimit + 1
+	stale := time.Now().Add(-time.Minute)
+	for index := 0; index < registrations; index++ {
+		registration, _ := issue104Registration(t, fmt.Sprintf("startup-group-%03d", index), "shared-startup-callback", "member")
+		ref, err := durable.RegisterChord(context.Background(), registration)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if index == 0 || index > 10 {
+			continue // MEMBER_SETUP / WAITING fixtures span both scan pages.
+		}
+		if err := durable.ReconcileChord(context.Background(), ref.DeliveryKey); err != nil {
+			t.Fatal(err)
+		}
+		switch index {
+		case 1: // MEMBER_READY
+		case 2: // expired MEMBER_LEASED
+			if _, claimed, err := durable.ClaimMemberPublication(context.Background(), backend.ChordMemberClaim{DeliveryKey: ref.DeliveryKey, Ordinal: 0, Owner: "stale-member", Now: stale, LeaseDuration: time.Second}); err != nil || !claimed {
+				t.Fatalf("member leased fixture = %t, %v", claimed, err)
+			}
+		case 3, 4: // overdue MEMBER_PUBLISHED / MEMBER_PUBLISH_UNKNOWN
+			lease, claimed, err := durable.ClaimMemberPublication(context.Background(), backend.ChordMemberClaim{DeliveryKey: ref.DeliveryKey, Ordinal: 0, Owner: "member-outcome", Now: stale, LeaseDuration: time.Second})
+			if err != nil || !claimed {
+				t.Fatalf("member outcome fixture = %t, %v", claimed, err)
+			}
+			kind := backend.ChordPublishOutcomeSucceeded
+			if index == 4 {
+				kind = backend.ChordPublishOutcomeUnknown
+			}
+			if err := durable.RecordMemberPublishOutcome(context.Background(), lease, backend.ChordPublishOutcome{Kind: kind, Now: stale, ConfirmationDeadline: stale.Add(time.Second)}); err != nil {
+				t.Fatal(err)
+			}
+		case 5, 6, 7, 8, 9: // callback READY/LEASED/PUBLISHED/UNKNOWN/DELIVERED
+			if err := durable.RecordMemberTerminal(context.Background(), ref.DeliveryKey, 0, registration.Members[0].TaskID, backend.MemberTerminalSuccess, nil); err != nil {
+				t.Fatal(err)
+			}
+			if index == 5 {
+				break
+			}
+			if index == 9 {
+				if err := durable.RecordCallbackTerminal(context.Background(), ref.DeliveryKey, backend.CallbackTerminalSuccess); err != nil {
+					t.Fatal(err)
+				}
+				break
+			}
+			lease, claimed, err := durable.ClaimCallbackPublication(context.Background(), backend.ChordCallbackClaim{DeliveryKey: ref.DeliveryKey, Owner: "stale-callback", Now: stale, LeaseDuration: time.Second})
+			if err != nil || !claimed {
+				t.Fatalf("callback fixture = %t, %v", claimed, err)
+			}
+			if index == 6 {
+				break
+			}
+			kind := backend.ChordPublishOutcomeSucceeded
+			if index == 8 {
+				kind = backend.ChordPublishOutcomeUnknown
+			}
+			if err := durable.RecordCallbackPublishOutcome(context.Background(), lease, backend.ChordPublishOutcome{Kind: kind, Now: stale, ConfirmationDeadline: stale.Add(time.Second)}); err != nil {
+				t.Fatal(err)
+			}
+		case 10: // SUPPRESSED
+			if err := durable.RecordMemberTerminal(context.Background(), ref.DeliveryKey, 0, registration.Members[0].TaskID, backend.MemberTerminalFailure, nil); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	controller := &groupTestController{}
+	server, err := NewServerE(
+		controller,
+		backendValue,
+		timedGroupTestLocker{},
+		log.NewHelper(log.DefaultLogger),
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	t.Cleanup(func() { _ = server.Shutdown(ctx) })
+	const expectedPublications = 99 // 95 recoverable members + 4 recoverable callbacks.
+	if got := controller.publishCount.Load(); got != expectedPublications {
+		t.Fatalf("startup published %d items, want %d across every state and scan page", got, expectedPublications)
+	}
+}
+
+func TestDurableChordStartupFailureIsReturnedAndStored(t *testing.T) {
+	startupErr := errors.New("scan unavailable")
+	newFailing := func(t *testing.T) *issue104FailingScanBackend {
+		t.Helper()
+		base := newGroupConvergenceRedisBackend(t)
+		return &issue104FailingScanBackend{Backend: base, DurableChordBackend: base.(backend.DurableChordBackend), err: startupErr}
+	}
+	server, err := NewServerE(
+		&groupTestController{},
+		newFailing(t),
+		timedGroupTestLocker{},
+		log.NewHelper(log.DefaultLogger),
+		nil,
+		SetEnableDurableChordRegistration(true),
+	)
+	if !errors.Is(err, startupErr) {
+		t.Fatalf("NewServerE error = %v, want startup scan failure", err)
+	}
+	if server != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		_ = server.Shutdown(ctx)
+		cancel()
+	}
+
+	compatibilityServer := NewServer(
+		&groupTestController{},
+		newFailing(t),
+		timedGroupTestLocker{},
+		log.NewHelper(log.DefaultLogger),
+		nil,
+		SetEnableDurableChordRegistration(true),
+	)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	t.Cleanup(func() { _ = compatibilityServer.Shutdown(ctx) })
+	registration, callback := issue104Registration(t, "stored-error-group", "callback", "member")
+	var member task.Signature
+	if err := json.Unmarshal(registration.Members[0].Payload, &member); err != nil {
+		t.Fatal(err)
+	}
+	group, _ := task.NewGroup(registration.GroupID, registration.GroupName, &member)
+	groupCallback, _ := task.NewGroupCallback(group, registration.GroupName, callback)
+	if _, err := compatibilityServer.SendGroupCallbackWithContext(context.Background(), groupCallback, 1); !errors.Is(err, startupErr) {
+		t.Fatalf("compatibility NewServer durable send error = %v, want stored startup error", err)
+	}
+	if err := compatibilityServer.RegisteredTimedGroupCallback("* * * * *", "stored-error", "group", 1, callback, &member); !errors.Is(err, startupErr) {
+		t.Fatalf("compatibility NewServer timed registration error = %v, want stored startup error", err)
+	}
+}
+
+func TestDurableChordAttachedRegistrationObservesCreatorAbort(t *testing.T) {
+	backendValue := newGroupConvergenceRedisBackend(t)
+	durable := backendValue.(backend.DurableChordBackend)
+	registration, _ := issue104Registration(t, "attached-abort-group", "callback", "member")
+	ref, err := durable.RegisterChord(context.Background(), registration)
+	if err != nil {
+		t.Fatal(err)
+	}
+	attached, err := durable.RegisterChord(context.Background(), registration)
+	if err != nil || attached.Created {
+		t.Fatalf("attached registration = %#v, %v", attached, err)
+	}
+	server := &Server{durableBackend: durable}
+	if err := durable.AbortRegistration(context.Background(), ref); err != nil {
+		t.Fatal(err)
+	}
+	recreated, err := durable.RegisterChord(context.Background(), registration)
+	if err != nil || !recreated.Created {
+		t.Fatalf("recreated registration = %#v, %v", recreated, err)
+	}
+	if err := durable.ReconcileChord(context.Background(), recreated.DeliveryKey); err != nil {
+		t.Fatal(err)
+	}
+	if waitErr := server.waitForChordRegistration(context.Background(), attached); !errors.Is(waitErr, backend.ErrChordRegistrationAborted) {
+		t.Fatalf("attached registration error = %v, want creator generation abort", waitErr)
+	}
+}
+
+func TestShutdownCancelsAndJoinsDirectDurablePublication(t *testing.T) {
+	backendValue := newGroupConvergenceRedisBackend(t)
+	publishEntered := make(chan struct{}, 1)
+	controller := &groupTestController{publishFn: func(ctx context.Context, _ *task.Signature) error {
+		publishEntered <- struct{}{}
+		<-ctx.Done()
+		return ctx.Err()
+	}}
+	server, err := NewServerE(
+		controller,
+		backendValue,
+		timedGroupTestLocker{},
+		log.NewHelper(log.DefaultLogger),
+		nil,
+		SetEnableDurableChordRegistration(true),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	group, _ := task.NewGroup("shutdown-publish-group", "group", task.NewSignature("shutdown-member", "member"))
+	groupCallback, _ := task.NewGroupCallback(group, "group", task.NewSignature("shutdown-callback", "callback"))
+	sendDone := make(chan error, 1)
+	go func() {
+		_, sendErr := server.SendGroupCallbackWithContext(context.Background(), groupCallback, 1)
+		sendDone <- sendErr
+	}()
+	select {
+	case <-publishEntered:
+	case <-time.After(time.Second):
+		t.Fatal("durable member Publish did not start")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := server.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	select {
+	case sendErr := <-sendDone:
+		if !errors.Is(sendErr, context.Canceled) {
+			t.Fatalf("durable send error = %v, want shutdown cancellation", sendErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("durable publication goroutine survived Shutdown")
+	}
+	if active := controller.active.Load(); active != 0 {
+		t.Fatalf("active publishers after Shutdown = %d", active)
+	}
+	deliveryKey := backend.ChordDeliveryKey(group.GroupID, groupCallback.Callback.ID)
+	delivery := issue104FindDelivery(t, backendValue.(backend.DurableChordBackend), deliveryKey)
+	if delivery.Members[0].State != backend.ChordMemberPublishUnknown {
+		t.Fatalf("shutdown publication outcome = %s, want MEMBER_PUBLISH_UNKNOWN", delivery.Members[0].State)
+	}
+}
+
+func TestDurableChordRestartRecoversOutcomeWriteFailureWithStablePayload(t *testing.T) {
+	base := newGroupConvergenceRedisBackend(t)
+	wrapped := &issue104FailOnceBackend{
+		Backend:             base,
+		DurableChordBackend: base.(backend.DurableChordBackend),
+		memberOutcomeFails:  1,
+		forceLease:          10 * time.Millisecond,
+	}
+	firstPublished := make(chan *task.Signature, 2)
+	firstServer, err := NewServerE(
+		&groupTestController{publishFn: func(_ context.Context, signature *task.Signature) error {
+			firstPublished <- task.CopySignature(signature)
+			return nil
+		}},
+		wrapped,
+		timedGroupTestLocker{},
+		log.NewHelper(log.DefaultLogger),
+		nil,
+		SetEnableDurableChordRegistration(true),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	member := task.NewSignature("outcome-failure-member", "member")
+	group, _ := task.NewGroup("outcome-failure-group", "group", member)
+	groupCallback, _ := task.NewGroupCallback(group, "group", task.NewSignature("outcome-failure-callback", "callback"))
+	if _, err := firstServer.SendGroupCallbackWithContext(context.Background(), groupCallback, 1); err == nil || !strings.Contains(err.Error(), "injected member outcome") {
+		t.Fatalf("first durable send error = %v, want outcome persistence failure", err)
+	}
+	first := <-firstPublished
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), time.Second)
+	if err := firstServer.Shutdown(shutdownCtx); err != nil {
+		t.Fatal(err)
+	}
+	shutdownCancel()
+	time.Sleep(20 * time.Millisecond)
+
+	secondPublished := make(chan *task.Signature, 2)
+	secondServer, err := NewServerE(
+		&groupTestController{publishFn: func(_ context.Context, signature *task.Signature) error {
+			secondPublished <- task.CopySignature(signature)
+			return nil
+		}},
+		wrapped,
+		timedGroupTestLocker{},
+		log.NewHelper(log.DefaultLogger),
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = secondServer.Shutdown(ctx)
+	})
+	second := <-secondPublished
+	firstBody, _ := json.Marshal(first)
+	secondBody, _ := json.Marshal(second)
+	if first.ID != second.ID || string(firstBody) != string(secondBody) {
+		t.Fatalf("recovered publication changed identity/payload: first=%s second=%s", first.ID, second.ID)
+	}
+}
+
+func TestDurableChordRestartRecoversEnqueueThenErrorWithStablePayload(t *testing.T) {
+	base := newGroupConvergenceRedisBackend(t)
+	wrapped := &issue104FailOnceBackend{
+		Backend:             base,
+		DurableChordBackend: base.(backend.DurableChordBackend),
+		forceConfirmation:   10 * time.Millisecond,
+	}
+	firstPublished := make(chan *task.Signature, 2)
+	firstServer, err := NewServerE(
+		&groupTestController{publishFn: func(_ context.Context, signature *task.Signature) error {
+			firstPublished <- task.CopySignature(signature)
+			return errors.New("broker accepted but response was lost")
+		}},
+		wrapped,
+		timedGroupTestLocker{},
+		log.NewHelper(log.DefaultLogger),
+		nil,
+		SetEnableDurableChordRegistration(true),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	group, _ := task.NewGroup("enqueue-error-group", "group", task.NewSignature("enqueue-error-member", "member"))
+	groupCallback, _ := task.NewGroupCallback(group, "group", task.NewSignature("enqueue-error-callback", "callback"))
+	if _, err := firstServer.SendGroupCallbackWithContext(context.Background(), groupCallback, 1); err == nil || !strings.Contains(err.Error(), "broker accepted") {
+		t.Fatalf("first durable send error = %v, want enqueue-then-error", err)
+	}
+	first := <-firstPublished
+	deliveryKey := backend.ChordDeliveryKey(group.GroupID, groupCallback.Callback.ID)
+	if delivery := issue104FindDelivery(t, wrapped, deliveryKey); delivery.Members[0].State != backend.ChordMemberPublishUnknown {
+		t.Fatalf("enqueue-then-error state = %s, want MEMBER_PUBLISH_UNKNOWN", delivery.Members[0].State)
+	}
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), time.Second)
+	if err := firstServer.Shutdown(shutdownCtx); err != nil {
+		t.Fatal(err)
+	}
+	shutdownCancel()
+	time.Sleep(20 * time.Millisecond)
+
+	secondPublished := make(chan *task.Signature, 2)
+	secondServer, err := NewServerE(
+		&groupTestController{publishFn: func(_ context.Context, signature *task.Signature) error {
+			secondPublished <- task.CopySignature(signature)
+			return nil
+		}},
+		wrapped,
+		timedGroupTestLocker{},
+		log.NewHelper(log.DefaultLogger),
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = secondServer.Shutdown(ctx)
+	})
+	second := <-secondPublished
+	firstBody, _ := json.Marshal(first)
+	secondBody, _ := json.Marshal(second)
+	if first.ID != second.ID || string(firstBody) != string(secondBody) {
+		t.Fatalf("enqueue-then-error recovery changed identity/payload: first=%s second=%s", first.ID, second.ID)
+	}
+}
+
+func TestDurableChordRetriesReceiptAndCallbackTerminalWriteFailures(t *testing.T) {
+	base := newGroupConvergenceRedisBackend(t)
+	wrapped := &issue104FailOnceBackend{
+		Backend:               base,
+		DurableChordBackend:   base.(backend.DurableChordBackend),
+		memberTerminalFails:   1,
+		callbackTerminalFails: 1,
+		forceConfirmation:     10 * time.Millisecond,
+	}
+	published := make(chan *task.Signature, 8)
+	server, err := NewServerE(
+		&groupTestController{publishFn: func(_ context.Context, signature *task.Signature) error {
+			published <- task.CopySignature(signature)
+			return nil
+		}},
+		wrapped,
+		timedGroupTestLocker{},
+		log.NewHelper(log.DefaultLogger),
+		nil,
+		SetEnableDurableChordRegistration(true),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = server.Shutdown(ctx)
+	})
+	memberExecutions := 0
+	callbackExecutions := 0
+	if err := server.RegisteredTask("member-fail-once", func() (string, error) {
+		memberExecutions++
+		return "member-result", nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := server.RegisteredTask("callback-fail-once", func(string) (string, error) {
+		callbackExecutions++
+		return "callback-result", nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	group, _ := task.NewGroup("terminal-write-group", "group", task.NewSignature("terminal-write-member", "member-fail-once"))
+	groupCallback, _ := task.NewGroupCallback(group, "group", task.NewSignature("terminal-write-callback", "callback-fail-once"))
+	if _, err := server.SendGroupCallbackWithContext(context.Background(), groupCallback, 1); err != nil {
+		t.Fatal(err)
+	}
+	memberSignature := <-published
+	worker := server.NewWorker("fail-once", 1, "queue")
+	if err := worker.Process(memberSignature); err == nil || !strings.Contains(err.Error(), "injected member receipt") {
+		t.Fatalf("first member execution error = %v, want receipt persistence failure", err)
+	}
+	deliveryKey := backend.ChordDeliveryKey(group.GroupID, groupCallback.Callback.ID)
+	if delivery := issue104FindDelivery(t, wrapped, deliveryKey); delivery.CallbackState != backend.ChordWaiting || delivery.Members[0].Receipt != nil {
+		t.Fatalf("failed receipt changed readiness = %#v", delivery)
+	}
+	var recoveredMember *task.Signature
+	select {
+	case recoveredMember = <-published:
+	case <-time.After(time.Second):
+		t.Fatal("dispatcher did not republish member after receipt write failure")
+	}
+	if recoveredMember.ID != memberSignature.ID {
+		t.Fatalf("recovered member id = %s, want %s", recoveredMember.ID, memberSignature.ID)
+	}
+	if err := worker.Process(recoveredMember); err != nil {
+		t.Fatal(err)
+	}
+	var callbackSignature *task.Signature
+	select {
+	case callbackSignature = <-published:
+	case <-time.After(time.Second):
+		t.Fatal("callback was not recovered after receipt retry")
+	}
+	if err := worker.Process(callbackSignature); err == nil || !strings.Contains(err.Error(), "injected callback terminal") {
+		t.Fatalf("first callback execution error = %v, want terminal persistence failure", err)
+	}
+	if delivery := issue104FindDelivery(t, wrapped, deliveryKey); delivery.CallbackState == backend.ChordDelivered {
+		t.Fatal("failed callback terminal write finalized delivery")
+	}
+	var recoveredCallback *task.Signature
+	select {
+	case recoveredCallback = <-published:
+	case <-time.After(time.Second):
+		t.Fatal("dispatcher did not republish callback after terminal write failure")
+	}
+	if recoveredCallback.ID != callbackSignature.ID {
+		t.Fatalf("recovered callback id = %s, want %s", recoveredCallback.ID, callbackSignature.ID)
+	}
+	if err := worker.Process(recoveredCallback); err != nil {
+		t.Fatal(err)
+	}
+	if delivery := issue104FindDelivery(t, wrapped, deliveryKey); delivery.CallbackState != backend.ChordDelivered {
+		t.Fatalf("callback terminal retry state = %s", delivery.CallbackState)
+	}
+	if memberExecutions != 2 || callbackExecutions != 2 {
+		t.Fatalf("duplicate execution evidence member=%d callback=%d, want 2/2", memberExecutions, callbackExecutions)
+	}
+}
+
+func TestDurableChordOldWorkerStatusDoesNotSatisfyReceipt(t *testing.T) {
+	backendValue := newGroupConvergenceRedisBackend(t)
+	durable := backendValue.(backend.DurableChordBackend)
+	registration, _ := issue104Registration(t, "rollout-group", "rollout-callback", "member")
+	ref, err := durable.RegisterChord(context.Background(), registration)
+	if err != nil {
+		t.Fatal(err)
+	}
+	published := make(chan *task.Signature, 8)
+	controller := &groupTestController{publishFn: func(_ context.Context, signature *task.Signature) error {
+		published <- task.CopySignature(signature)
+		return nil
+	}}
+	server, err := NewServerE(controller, backendValue, timedGroupTestLocker{}, log.NewHelper(log.DefaultLogger), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	t.Cleanup(func() { _ = server.Shutdown(ctx) })
+	if err := server.RegisteredTask("member", func() (string, error) { return "upgraded", nil }); err != nil {
+		t.Fatal(err)
+	}
+	member := <-published
+	if member.CallbackChord != nil {
+		t.Fatal("durable member can enter legacy TriggerCompleted path")
+	}
+	if err := backendValue.SetStateSuccess(member, []*task.Result{{Type: "string", Value: "old-worker"}}); err != nil {
+		t.Fatal(err)
+	}
+	delivery := issue104FindDelivery(t, durable, ref.DeliveryKey)
+	if delivery.CallbackState != backend.ChordWaiting || delivery.Members[0].Receipt != nil {
+		t.Fatalf("generic old-worker status changed durable readiness = %#v", delivery)
+	}
+	worker := server.NewWorker("upgraded", 1, "queue")
+	if err := worker.Process(member); err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.Now().Add(time.Second)
+	for {
+		delivery = issue104FindDelivery(t, durable, ref.DeliveryKey)
+		if delivery.CallbackState != backend.ChordWaiting {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("upgraded worker did not record durable receipt")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestDurableCallbackWorkerUsesDeliveryKeyAndRetriesRemainNonterminal(t *testing.T) {
+	backendValue := newGroupConvergenceRedisBackend(t)
+	durable := backendValue.(backend.DurableChordBackend)
+	registrationA, callbackA := issue104Registration(t, "callback-worker-a", "shared-callback-worker", "member")
+	registrationB, callbackB := issue104Registration(t, "callback-worker-b", "shared-callback-worker", "member")
+	refA := issue104ReadyRegistration(t, durable, registrationA)
+	refB := issue104ReadyRegistration(t, durable, registrationB)
+	server := &Server{
+		config:          &Config{ConsumeQueue: "queue"},
+		backend:         backendValue,
+		durableBackend:  durable,
+		controller:      &groupTestController{},
+		registeredTasks: &sync.Map{},
+		helper:          log.NewHelper(log.DefaultLogger),
+	}
+	if err := server.RegisteredTask("success-callback", func() (string, error) { return "ok", nil }); err != nil {
+		t.Fatal(err)
+	}
+	if err := server.RegisteredTask("retry-callback", func() (string, error) { return "", errors.New("retry") }); err != nil {
+		t.Fatal(err)
+	}
+	callbackA.Name = "success-callback"
+	callbackB.Name = "retry-callback"
+	worker := server.NewWorker("callback-worker", 1, "queue")
+	if err := worker.Process(callbackA); err != nil {
+		t.Fatal(err)
+	}
+	callbackB.RetryCount = 1
+	if err := worker.Process(callbackB); err != nil {
+		t.Fatal(err)
+	}
+	if got := issue104FindDelivery(t, durable, refA.DeliveryKey); got.CallbackState != backend.ChordDelivered || got.TerminalOutcome != backend.CallbackTerminalSuccess {
+		t.Fatalf("success callback terminal = %#v", got)
+	}
+	if got := issue104FindDelivery(t, durable, refB.DeliveryKey); got.CallbackState != backend.ChordReady {
+		t.Fatalf("retryable callback finalized delivery = %#v", got)
+	}
+	callbackB.RetryCount = 0
+	if err := worker.Process(callbackB); err != nil {
+		t.Fatal(err)
+	}
+	if got := issue104FindDelivery(t, durable, refB.DeliveryKey); got.CallbackState != backend.ChordDelivered || got.TerminalOutcome != backend.CallbackTerminalFailure {
+		t.Fatalf("final callback failure terminal = %#v", got)
+	}
+	if got := issue104FindDelivery(t, durable, refA.DeliveryKey); got.TerminalOutcome != backend.CallbackTerminalSuccess {
+		t.Fatalf("colliding callback ID changed other delivery = %#v", got)
+	}
+}
+
+func issue104Registration(t *testing.T, groupID, callbackID, memberName string) (backend.ChordRegistration, *task.Signature) {
+	t.Helper()
+	deliveryKey := backend.ChordDeliveryKey(groupID, callbackID)
+	callback := task.NewSignature(callbackID, "callback")
+	callback.Meta.Set(backend.DurableChordDeliveryKeyMeta, deliveryKey)
+	callbackPayload, err := json.Marshal(callback)
+	if err != nil {
+		t.Fatal(err)
+	}
+	member := task.NewSignature(groupID+"-member", memberName)
+	member.GroupID = groupID
+	member.CallbackChord = nil
+	member.Meta.Set(backend.DurableChordDeliveryKeyMeta, deliveryKey)
+	member.Meta.Set(backend.DurableChordMemberMeta, true)
+	member.Meta.Set(backend.DurableChordMemberOrdinal, 0)
+	memberPayload, err := json.Marshal(member)
+	if err != nil {
+		t.Fatal(err)
+	}
+	registration := backend.ChordRegistration{
+		GroupID:   groupID,
+		GroupName: groupID,
+		Retention: -1,
+		Callback:  callbackPayload,
+		Members:   []backend.ChordMemberRegistration{{Ordinal: 0, TaskID: member.ID, Payload: memberPayload}},
+	}
+	if err := backend.FinalizeChordRegistration(&registration); err != nil {
+		t.Fatal(err)
+	}
+	return registration, callback
+}
+
+func issue104ReadyRegistration(t *testing.T, durable backend.DurableChordBackend, registration backend.ChordRegistration) backend.ChordRegistrationRef {
+	t.Helper()
+	ref, err := durable.RegisterChord(context.Background(), registration)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := durable.ReconcileChord(context.Background(), ref.DeliveryKey); err != nil {
+		t.Fatal(err)
+	}
+	if err := durable.RecordMemberTerminal(context.Background(), ref.DeliveryKey, 0, registration.Members[0].TaskID, backend.MemberTerminalSuccess, nil); err != nil {
+		t.Fatal(err)
+	}
+	return ref
+}
+
+func issue104FindDelivery(t *testing.T, durable backend.DurableChordBackend, key string) backend.ChordDelivery {
+	t.Helper()
+	cursor := ""
+	for {
+		page, err := durable.ScanChordDeliveries(context.Background(), backend.ChordScan{Cursor: cursor, Limit: 10, Now: time.Now()})
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, delivery := range page.Deliveries {
+			if delivery.DeliveryKey == key {
+				return delivery
+			}
+		}
+		if page.NextCursor == "" {
+			break
+		}
+		cursor = page.NextCursor
+	}
+	t.Fatalf("delivery %s not found", key)
+	return backend.ChordDelivery{}
+}

--- a/distributed/durable_chord_validation_regression_test.go
+++ b/distributed/durable_chord_validation_regression_test.go
@@ -2,8 +2,11 @@ package distributed
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 
+	backendapi "github.com/songzhibin97/gkit/distributed/backend"
 	"github.com/songzhibin97/gkit/distributed/task"
 )
 
@@ -17,7 +20,7 @@ func (b *issue104ValidationBackend) GroupTakeOver(string, string, ...string) err
 	return nil
 }
 
-func TestDurableChordValidationHasZeroSideEffects(t *testing.T) {
+func TestDurableChordValidationHasTypedFieldErrorsAndZeroSideEffects(t *testing.T) {
 	validMember := func(id string) *task.Signature {
 		return &task.Signature{ID: id, Name: "member"}
 	}
@@ -29,18 +32,19 @@ func TestDurableChordValidationHasZeroSideEffects(t *testing.T) {
 	}
 
 	tests := []struct {
-		name  string
-		value *task.GroupCallback
+		name        string
+		value       *task.GroupCallback
+		wantContext string
 	}{
-		{name: "nil group callback"},
-		{name: "nil group", value: &task.GroupCallback{Callback: validCallback()}},
-		{name: "nil callback", value: &task.GroupCallback{Group: validGroup(validMember("m1"))}},
-		{name: "empty group", value: &task.GroupCallback{Group: validGroup(), Callback: validCallback()}},
-		{name: "nil member", value: &task.GroupCallback{Group: validGroup(nil), Callback: validCallback()}},
-		{name: "empty group id", value: &task.GroupCallback{Group: &task.Group{Tasks: []*task.Signature{validMember("m1")}}, Callback: validCallback()}},
-		{name: "empty callback id", value: &task.GroupCallback{Group: validGroup(validMember("m1")), Callback: &task.Signature{Name: "callback"}}},
-		{name: "empty member id", value: &task.GroupCallback{Group: validGroup(validMember("")), Callback: validCallback()}},
-		{name: "duplicate member id", value: &task.GroupCallback{Group: validGroup(validMember("m1"), validMember("m1")), Callback: validCallback()}},
+		{name: "nil group callback", wantContext: "group callback"},
+		{name: "nil group", value: &task.GroupCallback{Callback: validCallback()}, wantContext: "group"},
+		{name: "nil callback", value: &task.GroupCallback{Group: validGroup(validMember("m1"))}, wantContext: "callback"},
+		{name: "empty group", value: &task.GroupCallback{Group: validGroup(), Callback: validCallback()}, wantContext: "group"},
+		{name: "nil member", value: &task.GroupCallback{Group: validGroup(nil), Callback: validCallback()}, wantContext: "member"},
+		{name: "empty group id", value: &task.GroupCallback{Group: &task.Group{Tasks: []*task.Signature{validMember("m1")}}, Callback: validCallback()}, wantContext: "group id"},
+		{name: "empty callback id", value: &task.GroupCallback{Group: validGroup(validMember("m1")), Callback: &task.Signature{Name: "callback"}}, wantContext: "callback id"},
+		{name: "empty member id", value: &task.GroupCallback{Group: validGroup(validMember("")), Callback: validCallback()}, wantContext: "member id"},
+		{name: "duplicate member id", value: &task.GroupCallback{Group: validGroup(validMember("m1"), validMember("m1")), Callback: validCallback()}, wantContext: "member id"},
 	}
 
 	for _, tt := range tests {
@@ -49,16 +53,21 @@ func TestDurableChordValidationHasZeroSideEffects(t *testing.T) {
 			controller := &groupTestController{}
 			server := &Server{backend: backend, controller: controller}
 
+			var validationErr error
 			func() {
 				defer func() {
 					if recovered := recover(); recovered != nil {
 						t.Fatalf("SendGroupCallbackWithContext panicked: %v", recovered)
 					}
 				}()
-				if _, err := server.SendGroupCallbackWithContext(context.Background(), tt.value, 1); err == nil {
-					t.Fatal("SendGroupCallbackWithContext returned nil error")
-				}
+				_, validationErr = server.SendGroupCallbackWithContext(context.Background(), tt.value, 1)
 			}()
+			if !errors.Is(validationErr, backendapi.ErrChordInvalidInput) {
+				t.Fatalf("validation error = %v, want ErrChordInvalidInput", validationErr)
+			}
+			if !strings.Contains(validationErr.Error(), tt.wantContext) {
+				t.Fatalf("validation error = %q, want %q field context", validationErr, tt.wantContext)
+			}
 
 			if backend.takeovers != 0 || len(backend.pendingIDs) != 0 || controller.publishCount.Load() != 0 {
 				t.Fatalf("invalid input caused side effects: takeovers=%d pending=%v publishes=%d", backend.takeovers, backend.pendingIDs, controller.publishCount.Load())

--- a/distributed/durable_chord_validation_regression_test.go
+++ b/distributed/durable_chord_validation_regression_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/robfig/cron/v3"
 	backendapi "github.com/songzhibin97/gkit/distributed/backend"
 	"github.com/songzhibin97/gkit/distributed/task"
 )
@@ -32,26 +33,31 @@ func TestDurableChordValidationHasTypedFieldErrorsAndZeroSideEffects(t *testing.
 	}
 
 	tests := []struct {
-		name        string
-		value       *task.GroupCallback
-		wantContext string
+		name         string
+		value        *task.GroupCallback
+		wantContext  string
+		wantWorkflow bool
 	}{
-		{name: "nil group callback", wantContext: "group callback"},
-		{name: "nil group", value: &task.GroupCallback{Callback: validCallback()}, wantContext: "group"},
-		{name: "nil callback", value: &task.GroupCallback{Group: validGroup(validMember("m1"))}, wantContext: "callback"},
-		{name: "empty group", value: &task.GroupCallback{Group: validGroup(), Callback: validCallback()}, wantContext: "group"},
-		{name: "nil member", value: &task.GroupCallback{Group: validGroup(nil), Callback: validCallback()}, wantContext: "member"},
+		{name: "nil group callback", wantContext: "group callback", wantWorkflow: true},
+		{name: "nil group", value: &task.GroupCallback{Callback: validCallback()}, wantContext: "group", wantWorkflow: true},
+		{name: "nil callback", value: &task.GroupCallback{Group: validGroup(validMember("m1"))}, wantContext: "callback", wantWorkflow: true},
+		{name: "empty group", value: &task.GroupCallback{Group: validGroup(), Callback: validCallback()}, wantContext: "group", wantWorkflow: true},
+		{name: "nil member", value: &task.GroupCallback{Group: validGroup(nil), Callback: validCallback()}, wantContext: "member", wantWorkflow: true},
 		{name: "empty group id", value: &task.GroupCallback{Group: &task.Group{Tasks: []*task.Signature{validMember("m1")}}, Callback: validCallback()}, wantContext: "group id"},
 		{name: "empty callback id", value: &task.GroupCallback{Group: validGroup(validMember("m1")), Callback: &task.Signature{Name: "callback"}}, wantContext: "callback id"},
 		{name: "empty member id", value: &task.GroupCallback{Group: validGroup(validMember("")), Callback: validCallback()}, wantContext: "member id"},
-		{name: "duplicate member id", value: &task.GroupCallback{Group: validGroup(validMember("m1"), validMember("m1")), Callback: validCallback()}, wantContext: "member id"},
+		{name: "duplicate member id", value: &task.GroupCallback{Group: validGroup(validMember("m1"), validMember("m1")), Callback: validCallback()}, wantContext: "duplicate member id"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			backend := &issue104ValidationBackend{}
 			controller := &groupTestController{}
-			server := &Server{backend: backend, controller: controller}
+			server := &Server{
+				config:     &Config{EnableDurableChordRegistration: true},
+				backend:    backend,
+				controller: controller,
+			}
 
 			var validationErr error
 			func() {
@@ -65,12 +71,88 @@ func TestDurableChordValidationHasTypedFieldErrorsAndZeroSideEffects(t *testing.
 			if !errors.Is(validationErr, backendapi.ErrChordInvalidInput) {
 				t.Fatalf("validation error = %v, want ErrChordInvalidInput", validationErr)
 			}
+			if tt.wantWorkflow && !errors.Is(validationErr, task.ErrInvalidWorkflow) {
+				t.Fatalf("validation error = %v, want ErrInvalidWorkflow joined with ErrChordInvalidInput", validationErr)
+			}
 			if !strings.Contains(validationErr.Error(), tt.wantContext) {
 				t.Fatalf("validation error = %q, want %q field context", validationErr, tt.wantContext)
 			}
 
 			if backend.takeovers != 0 || len(backend.pendingIDs) != 0 || controller.publishCount.Load() != 0 {
 				t.Fatalf("invalid input caused side effects: takeovers=%d pending=%v publishes=%d", backend.takeovers, backend.pendingIDs, controller.publishCount.Load())
+			}
+		})
+	}
+}
+
+func TestDurableTimedChordValidationHasTypedFieldErrorsAndZeroSideEffects(t *testing.T) {
+	validMember := func(id string) *task.Signature {
+		return &task.Signature{ID: id, Name: "member"}
+	}
+	validCallback := func() *task.Signature {
+		return &task.Signature{ID: "callback", Name: "callback"}
+	}
+
+	tests := []struct {
+		name         string
+		groupID      string
+		callback     *task.Signature
+		members      []*task.Signature
+		wantContext  string
+		wantWorkflow bool
+	}{
+		{name: "empty group id", callback: validCallback(), members: []*task.Signature{validMember("m1")}, wantContext: "group id"},
+		{name: "empty callback id", groupID: "group", callback: &task.Signature{Name: "callback"}, members: []*task.Signature{validMember("m1")}, wantContext: "callback id"},
+		{name: "empty member id", groupID: "group", callback: validCallback(), members: []*task.Signature{validMember("")}, wantContext: "member id"},
+		{name: "duplicate member id", groupID: "group", callback: validCallback(), members: []*task.Signature{validMember("m1"), validMember("m1")}, wantContext: "duplicate member id"},
+		{name: "empty group", groupID: "group", callback: validCallback(), wantContext: "empty group", wantWorkflow: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			backend := &issue104ValidationBackend{}
+			controller := &groupTestController{}
+			server := &Server{
+				config:     &Config{EnableDurableChordRegistration: true},
+				backend:    backend,
+				controller: controller,
+				scheduler:  cron.New(),
+			}
+
+			var validationErr error
+			func() {
+				defer func() {
+					if recovered := recover(); recovered != nil {
+						t.Fatalf("RegisteredTimedGroupCallback panicked: %v", recovered)
+					}
+				}()
+				validationErr = server.RegisteredTimedGroupCallback(
+					"* * * * *",
+					"timed-chord",
+					tt.groupID,
+					1,
+					tt.callback,
+					tt.members...,
+				)
+			}()
+			if !errors.Is(validationErr, backendapi.ErrChordInvalidInput) {
+				t.Fatalf("validation error = %v, want ErrChordInvalidInput", validationErr)
+			}
+			if tt.wantWorkflow && !errors.Is(validationErr, task.ErrInvalidWorkflow) {
+				t.Fatalf("validation error = %v, want ErrInvalidWorkflow joined with ErrChordInvalidInput", validationErr)
+			}
+			if !strings.Contains(validationErr.Error(), tt.wantContext) {
+				t.Fatalf("validation error = %q, want %q field context", validationErr, tt.wantContext)
+			}
+
+			if backend.takeovers != 0 || len(backend.pendingIDs) != 0 || controller.publishCount.Load() != 0 || len(server.scheduler.Entries()) != 0 {
+				t.Fatalf(
+					"invalid input caused side effects: takeovers=%d pending=%v publishes=%d scheduled=%d",
+					backend.takeovers,
+					backend.pendingIDs,
+					controller.publishCount.Load(),
+					len(server.scheduler.Entries()),
+				)
 			}
 		})
 	}

--- a/distributed/durable_chord_validation_regression_test.go
+++ b/distributed/durable_chord_validation_regression_test.go
@@ -1,0 +1,68 @@
+package distributed
+
+import (
+	"context"
+	"testing"
+
+	"github.com/songzhibin97/gkit/distributed/task"
+)
+
+type issue104ValidationBackend struct {
+	groupTestBackend
+	takeovers int
+}
+
+func (b *issue104ValidationBackend) GroupTakeOver(string, string, ...string) error {
+	b.takeovers++
+	return nil
+}
+
+func TestDurableChordValidationHasZeroSideEffects(t *testing.T) {
+	validMember := func(id string) *task.Signature {
+		return &task.Signature{ID: id, Name: "member"}
+	}
+	validCallback := func() *task.Signature {
+		return &task.Signature{ID: "callback", Name: "callback"}
+	}
+	validGroup := func(members ...*task.Signature) *task.Group {
+		return &task.Group{GroupID: "group", Name: "group", Tasks: members}
+	}
+
+	tests := []struct {
+		name  string
+		value *task.GroupCallback
+	}{
+		{name: "nil group callback"},
+		{name: "nil group", value: &task.GroupCallback{Callback: validCallback()}},
+		{name: "nil callback", value: &task.GroupCallback{Group: validGroup(validMember("m1"))}},
+		{name: "empty group", value: &task.GroupCallback{Group: validGroup(), Callback: validCallback()}},
+		{name: "nil member", value: &task.GroupCallback{Group: validGroup(nil), Callback: validCallback()}},
+		{name: "empty group id", value: &task.GroupCallback{Group: &task.Group{Tasks: []*task.Signature{validMember("m1")}}, Callback: validCallback()}},
+		{name: "empty callback id", value: &task.GroupCallback{Group: validGroup(validMember("m1")), Callback: &task.Signature{Name: "callback"}}},
+		{name: "empty member id", value: &task.GroupCallback{Group: validGroup(validMember("")), Callback: validCallback()}},
+		{name: "duplicate member id", value: &task.GroupCallback{Group: validGroup(validMember("m1"), validMember("m1")), Callback: validCallback()}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			backend := &issue104ValidationBackend{}
+			controller := &groupTestController{}
+			server := &Server{backend: backend, controller: controller}
+
+			func() {
+				defer func() {
+					if recovered := recover(); recovered != nil {
+						t.Fatalf("SendGroupCallbackWithContext panicked: %v", recovered)
+					}
+				}()
+				if _, err := server.SendGroupCallbackWithContext(context.Background(), tt.value, 1); err == nil {
+					t.Fatal("SendGroupCallbackWithContext returned nil error")
+				}
+			}()
+
+			if backend.takeovers != 0 || len(backend.pendingIDs) != 0 || controller.publishCount.Load() != 0 {
+				t.Fatalf("invalid input caused side effects: takeovers=%d pending=%v publishes=%d", backend.takeovers, backend.pendingIDs, controller.publishCount.Load())
+			}
+		})
+	}
+}

--- a/distributed/locker/lock_redis/context_regression_test.go
+++ b/distributed/locker/lock_redis/context_regression_test.go
@@ -1,0 +1,111 @@
+package lock_redis
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/go-redis/redis/v8"
+)
+
+type issue104BlockingEvalHook struct {
+	entered chan struct{}
+}
+
+func (h *issue104BlockingEvalHook) BeforeProcess(ctx context.Context, cmd redis.Cmder) (context.Context, error) {
+	if cmd.Name() != "eval" {
+		return ctx, nil
+	}
+	select {
+	case h.entered <- struct{}{}:
+	default:
+	}
+	<-ctx.Done()
+	return ctx, ctx.Err()
+}
+
+func (*issue104BlockingEvalHook) AfterProcess(context.Context, redis.Cmder) error { return nil }
+func (*issue104BlockingEvalHook) BeforeProcessPipeline(ctx context.Context, _ []redis.Cmder) (context.Context, error) {
+	return ctx, nil
+}
+func (*issue104BlockingEvalHook) AfterProcessPipeline(context.Context, []redis.Cmder) error {
+	return nil
+}
+
+type issue104ContextLocker interface {
+	LockContext(context.Context, string, int, string) error
+	UnlockContext(context.Context, string, string) error
+}
+
+func TestRedisLockerContextCancelsBlockedEval(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		call func(issue104ContextLocker, context.Context) error
+	}{
+		{name: "lock", call: func(lock issue104ContextLocker, ctx context.Context) error {
+			return lock.LockContext(ctx, "key", 1000, "mark")
+		}},
+		{name: "unlock", call: func(lock issue104ContextLocker, ctx context.Context) error {
+			return lock.UnlockContext(ctx, "key", "mark")
+		}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			mr := miniredis.RunT(t)
+			client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+			t.Cleanup(func() { _ = client.Close() })
+			entered := make(chan struct{}, 1)
+			client.AddHook(&issue104BlockingEvalHook{entered: entered})
+			lock := NewRedisLock(client).(issue104ContextLocker)
+			ctx, cancel := context.WithCancel(context.Background())
+			done := make(chan error, 1)
+			go func() { done <- tt.call(lock, ctx) }()
+			select {
+			case <-entered:
+			case <-time.After(time.Second):
+				t.Fatal("Eval did not start")
+			}
+			cancel()
+			select {
+			case err := <-done:
+				if !errors.Is(err, context.Canceled) {
+					t.Fatalf("operation error = %v, want context.Canceled", err)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("context cancellation did not stop Eval")
+			}
+		})
+	}
+}
+
+func TestRedisLockerContextCancelsRetryWait(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	if err := client.Set(context.Background(), "key", "other", time.Minute).Err(); err != nil {
+		t.Fatal(err)
+	}
+	lock := NewRedisLock(client, SetRetries(10), SetInterval(time.Second)).(issue104ContextLocker)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	err := lock.LockContext(ctx, "key", 1000, "mark")
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("LockContext error = %v, want context deadline", err)
+	}
+	if elapsed := time.Since(started); elapsed > 250*time.Millisecond {
+		t.Fatalf("retry wait ignored context: %s", elapsed)
+	}
+}
+
+func TestRedisLockerAdvertisesContextCapability(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+
+	lock := NewRedisLock(client)
+	if _, ok := lock.(issue104ContextLocker); !ok {
+		t.Fatalf("NewRedisLock returned %T, want context-aware lock capability", lock)
+	}
+}

--- a/distributed/locker/lock_redis/redis.go
+++ b/distributed/locker/lock_redis/redis.go
@@ -1,6 +1,7 @@
 package lock_redis
 
 import (
+	"context"
 	"errors"
 	"strconv"
 	"time"
@@ -32,8 +33,7 @@ type Lock struct {
 	client redis.UniversalClient
 }
 
-func (l *Lock) lock(key string, expire int, mark string) error {
-	ctx := l.client.Context()
+func (l *Lock) lock(ctx context.Context, key string, expire int, mark string) error {
 	resp, err := l.client.Eval(ctx, CMDLock, []string{key}, []string{mark, strconv.Itoa(expire)}).Result()
 	if err != nil && !errors.Is(err, redis.Nil) {
 		return err
@@ -49,21 +49,42 @@ func (l *Lock) lock(key string, expire int, mark string) error {
 }
 
 func (l *Lock) Lock(key string, expire int, mark string) error {
+	return l.LockContext(l.client.Context(), key, expire, mark)
+}
+
+func (l *Lock) LockContext(ctx context.Context, key string, expire int, mark string) error {
 	var err error
 	for i := 0; i < l.retries+1; i++ {
-		err = l.lock(key, expire, mark)
-		if err == nil {
-			break
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
 		}
-		if l.interval > 0 {
-			time.Sleep(l.interval)
+		err = l.lock(ctx, key, expire, mark)
+		if err == nil {
+			return nil
+		}
+		if l.interval > 0 && i < l.retries {
+			timer := time.NewTimer(l.interval)
+			select {
+			case <-timer.C:
+			case <-ctx.Done():
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				return ctx.Err()
+			}
 		}
 	}
 	return err
 }
 
 func (l *Lock) UnLock(key string, mark string) error {
-	ctx := l.client.Context()
+	return l.UnlockContext(l.client.Context(), key, mark)
+}
+
+func (l *Lock) UnlockContext(ctx context.Context, key string, mark string) error {
 	resp, err := l.client.Eval(ctx, CMDUnlock, []string{key}, []string{mark}).Result()
 	if err != nil && !errors.Is(err, redis.Nil) {
 		return err

--- a/distributed/locker/locker.go
+++ b/distributed/locker/locker.go
@@ -1,5 +1,7 @@
 package locker
 
+import "context"
+
 // 分布式锁
 
 type Locker interface {
@@ -20,4 +22,12 @@ type Locker interface {
 	// expire 新的过期时间,以Millisecond为单位 1000 = 1s
 	// 返回 error 如果续约失败(锁不存在或mark不匹配)
 	Renew(key string, expire int, mark string) error
+}
+
+// ContextLocker is an optional capability for operations that must be joined
+// during server shutdown. Locker remains unchanged for third-party source
+// compatibility.
+type ContextLocker interface {
+	LockContext(ctx context.Context, key string, expire int, mark string) error
+	UnlockContext(ctx context.Context, key string, mark string) error
 }

--- a/distributed/option.go
+++ b/distributed/option.go
@@ -1,6 +1,10 @@
 package distributed
 
-import "github.com/songzhibin97/gkit/options"
+import (
+	"time"
+
+	"github.com/songzhibin97/gkit/options"
+)
 
 // SetNoUnixSignals 设置是否优雅关闭
 func SetNoUnixSignals(noUnixSignals bool) options.Option {
@@ -34,5 +38,23 @@ func SetConsumeQueue(consumeQueue string) options.Option {
 func SetDelayedQueue(delayedQueue string) options.Option {
 	return func(o interface{}) {
 		o.(*Config).DelayedQueue = delayedQueue
+	}
+}
+
+func SetEnableDurableChordRegistration(enabled bool) options.Option {
+	return func(o interface{}) {
+		o.(*Config).EnableDurableChordRegistration = enabled
+	}
+}
+
+func SetRequireDurableChordBackend(required bool) options.Option {
+	return func(o interface{}) {
+		o.(*Config).RequireDurableChordBackend = required
+	}
+}
+
+func SetDurableChordRegistrationTimeout(timeout time.Duration) options.Option {
+	return func(o interface{}) {
+		o.(*Config).DurableChordRegistrationTimeout = timeout
 	}
 }

--- a/distributed/service.go
+++ b/distributed/service.go
@@ -47,22 +47,40 @@ func timedTaskLockTTL(d time.Duration) int {
 
 // Config distributed service配置文件
 type Config struct {
-	NoUnixSignals bool   `json:"no_unix_signals"`
-	ResultExpire  int64  `json:"result_expire"`
-	Concurrency   int64  `json:"concurrency"`
-	ConsumeQueue  string `json:"consume_queue"`
-	DelayedQueue  string `json:"delayed_queue"`
+	NoUnixSignals                   bool          `json:"no_unix_signals"`
+	ResultExpire                    int64         `json:"result_expire"`
+	Concurrency                     int64         `json:"concurrency"`
+	ConsumeQueue                    string        `json:"consume_queue"`
+	DelayedQueue                    string        `json:"delayed_queue"`
+	EnableDurableChordRegistration  bool          `json:"enable_durable_chord_registration"`
+	RequireDurableChordBackend      bool          `json:"require_durable_chord_backend"`
+	DurableChordRegistrationTimeout time.Duration `json:"durable_chord_registration_timeout"`
 }
 
 type Server struct {
-	config            *Config
-	registeredTasks   *sync.Map                  // registeredTasks 注册任务处理函数
-	controller        controller.Controller      // controller 控制器
-	backend           backend.Backend            // backend 后端引擎
-	lock              locker.Locker              // lock 锁
-	scheduler         *cron.Cron                 // scheduler 调度器
-	prePublishHandler func(task *task.Signature) // prePublishHandler 预处理器
-	helper            *log.Helper
+	config             *Config
+	registeredTasks    *sync.Map                  // registeredTasks 注册任务处理函数
+	controller         controller.Controller      // controller 控制器
+	backend            backend.Backend            // backend 后端引擎
+	lock               locker.Locker              // lock 锁
+	scheduler          *cron.Cron                 // scheduler 调度器
+	prePublishHandler  func(task *task.Signature) // prePublishHandler 预处理器
+	helper             *log.Helper
+	durableBackend     backend.DurableChordBackend
+	registrationCtx    context.Context
+	registrationCancel context.CancelFunc
+	cleanupRootCtx     context.Context
+	cleanupRootCancel  context.CancelFunc
+	chordCtx           context.Context
+	chordCancel        context.CancelFunc
+	chordOutcomeCtx    context.Context
+	chordOutcomeCancel context.CancelFunc
+	registrationWG     sync.WaitGroup
+	chordWG            sync.WaitGroup
+	lifecycleMu        sync.Mutex
+	closing            bool
+	startupErr         error
+	lifecycleErrs      []error
 }
 
 // GetConfig 获取配置文件
@@ -313,11 +331,80 @@ func (s *Server) SendGroup(group *task.Group, concurrency int) ([]*result.AsyncR
 
 // SendGroupCallbackWithContext 发送具有回调任务的任务组
 func (s *Server) SendGroupCallbackWithContext(ctx context.Context, groupCallback *task.GroupCallback, concurrency int) (*result.GroupCallbackAsyncResult, error) {
+	if err := validateGroupCallback(groupCallback); err != nil {
+		return nil, err
+	}
+	if s.config != nil && s.config.EnableDurableChordRegistration {
+		if s.durableBackend == nil {
+			if s.config.RequireDurableChordBackend {
+				return nil, backend.ErrDurableChordUnsupported
+			}
+		} else {
+			s.lifecycleMu.Lock()
+			if s.closing {
+				s.lifecycleMu.Unlock()
+				return nil, context.Canceled
+			}
+			s.registrationWG.Add(1)
+			s.lifecycleMu.Unlock()
+			defer s.registrationWG.Done()
+			registrationCtx, cancel := contextWithCancellation(ctx, s.registrationCtx)
+			defer cancel()
+			return s.sendDurableGroupCallback(registrationCtx, groupCallback, concurrency)
+		}
+	}
 	_, err := s.SendGroupWithContext(ctx, groupCallback.Group, concurrency)
 	if err != nil {
 		return nil, err
 	}
 	return result.NewGroupCallbackAsyncResult(groupCallback.Group.Tasks, groupCallback.Callback, s.backend), nil
+}
+
+func contextWithCancellation(parent, shutdown context.Context) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(parent)
+	go func() {
+		select {
+		case <-shutdown.Done():
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+	return ctx, cancel
+}
+
+func validateGroupCallback(groupCallback *task.GroupCallback) error {
+	if groupCallback == nil {
+		return fmt.Errorf("%w: nil group callback", backend.ErrChordInvalidInput)
+	}
+	if groupCallback.Group == nil {
+		return fmt.Errorf("%w: nil group", backend.ErrChordInvalidInput)
+	}
+	if groupCallback.Callback == nil {
+		return fmt.Errorf("%w: nil callback", backend.ErrChordInvalidInput)
+	}
+	if groupCallback.Group.GroupID == "" {
+		return fmt.Errorf("%w: empty group id", backend.ErrChordInvalidInput)
+	}
+	if groupCallback.Callback.ID == "" {
+		return fmt.Errorf("%w: empty callback id", backend.ErrChordInvalidInput)
+	}
+	if len(groupCallback.Group.Tasks) == 0 {
+		return fmt.Errorf("%w: empty group", backend.ErrChordInvalidInput)
+	}
+	seen := make(map[string]struct{}, len(groupCallback.Group.Tasks))
+	for ordinal, member := range groupCallback.Group.Tasks {
+		if member == nil {
+			return fmt.Errorf("%w: nil member at ordinal %d", backend.ErrChordInvalidInput, ordinal)
+		}
+		if member.ID == "" {
+			return fmt.Errorf("%w: empty member id at ordinal %d", backend.ErrChordInvalidInput, ordinal)
+		}
+		if _, exists := seen[member.ID]; exists {
+			return fmt.Errorf("%w: duplicate member id %q", backend.ErrChordInvalidInput, member.ID)
+		}
+		seen[member.ID] = struct{}{}
+	}
+	return nil
 }
 
 // SendGroupCallback 发送具有回调任务的任务组
@@ -423,6 +510,28 @@ func (s *Server) RegisteredTimedGroupCallback(spec, name string, groupID string,
 	if err != nil {
 		return err
 	}
+	if s.config != nil && s.config.EnableDurableChordRegistration {
+		if s.startupErr != nil {
+			return s.startupErr
+		}
+		if s.durableBackend == nil {
+			if s.config.RequireDurableChordBackend {
+				return backend.ErrDurableChordUnsupported
+			}
+		} else {
+			contextLock, ok := s.contextLocker()
+			if !ok {
+				return ErrDurableTimedChordLockerUnsupported
+			}
+			f := func() {
+				if err := s.runDurableTimedGroupCallback(contextLock, schedule, spec, name, groupID, concurrency, callback, signatures...); err != nil {
+					s.recordLifecycleError(err)
+				}
+			}
+			_, err = s.scheduler.AddFunc(spec, f)
+			return err
+		}
+	}
 	f := func() {
 		runSuffix := rand_string.RandomLetter(timedRunSuffixLength)
 		c := newTimedGroupCallbackRun(groupID, name, runSuffix, callback, signatures...)
@@ -488,29 +597,56 @@ func getLockName(name, spec string) string {
 }
 
 // NewServer 创建服务
-func NewServer(controller controller.Controller, backend backend.Backend, lock locker.Locker, helper *log.Helper, prePublishHandler func(task *task.Signature), options ...options.Option) *Server {
+func NewServer(controller controller.Controller, backendEngine backend.Backend, lock locker.Locker, helper *log.Helper, prePublishHandler func(task *task.Signature), options ...options.Option) *Server {
+	server, _ := newServer(controller, backendEngine, lock, helper, prePublishHandler, options...)
+	return server
+}
+
+func NewServerE(controller controller.Controller, backendEngine backend.Backend, lock locker.Locker, helper *log.Helper, prePublishHandler func(task *task.Signature), options ...options.Option) (*Server, error) {
+	return newServer(controller, backendEngine, lock, helper, prePublishHandler, options...)
+}
+
+func newServer(controller controller.Controller, backendEngine backend.Backend, lock locker.Locker, helper *log.Helper, prePublishHandler func(task *task.Signature), optionList ...options.Option) (*Server, error) {
 	server := &Server{
 		config: &Config{
-			NoUnixSignals: false,
-			ResultExpire:  0,
-			Concurrency:   1,
-			ConsumeQueue:  "consume_queue",
-			DelayedQueue:  "delayed_queue",
+			NoUnixSignals:                   false,
+			ResultExpire:                    0,
+			Concurrency:                     1,
+			ConsumeQueue:                    "consume_queue",
+			DelayedQueue:                    "delayed_queue",
+			DurableChordRegistrationTimeout: 5 * time.Minute,
 		},
 		registeredTasks:   &sync.Map{},
 		controller:        controller,
-		backend:           backend,
+		backend:           backendEngine,
 		lock:              lock,
 		scheduler:         cron.New(),
 		prePublishHandler: prePublishHandler,
 		helper:            helper,
 	}
-	for _, option := range options {
+	for _, option := range optionList {
 		option(server.config)
 	}
+	if server.config.DurableChordRegistrationTimeout <= 0 {
+		server.config.DurableChordRegistrationTimeout = 5 * time.Minute
+	}
+	server.durableBackend, _ = backendEngine.(backend.DurableChordBackend)
+	server.registrationCtx, server.registrationCancel = context.WithCancel(context.Background())
+	server.cleanupRootCtx, server.cleanupRootCancel = context.WithCancel(context.Background())
+	server.chordCtx, server.chordCancel = context.WithCancel(context.Background())
+	server.chordOutcomeCtx, server.chordOutcomeCancel = context.WithCancel(context.Background())
 	server.EnforcementConf()
 	go server.scheduler.Run()
-	return server
+	if server.durableBackend != nil {
+		if err := server.startChordDispatcher(); err != nil {
+			server.startupErr = err
+			if server.helper != nil {
+				server.helper.Errorf("durable chord startup failed: %v", err)
+			}
+			return server, err
+		}
+	}
+	return server, nil
 }
 
 func (s *Server) EnforcementConf() {
@@ -524,13 +660,7 @@ func (s *Server) EnforcementConf() {
 // this, the goroutine launched by `go server.scheduler.Run()` survives until
 // process exit, holding timers for every registered job.
 func (s *Server) Shutdown(ctx context.Context) error {
-	stopCtx := s.scheduler.Stop()
-	select {
-	case <-stopCtx.Done():
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
-	}
+	return s.shutdown(ctx)
 }
 
 func (s *Server) NewWorker(consumerTag string, concurrency int, queue string) *Worker {

--- a/distributed/task/group.go
+++ b/distributed/task/group.go
@@ -31,9 +31,9 @@ func (s StringSlice) Value() (driver.Value, error) {
 type GroupMeta struct {
 	ID uint `json:"-" bson:"-" gorm:"column:_id;primarykey;comment:_id"`
 	// GroupID 组的唯一标识
-	GroupID string `json:"group_id" bson:"_id" gorm:"column:id;index;comment:id"`
+	GroupID string `json:"group_id" bson:"_id" gorm:"column:id;size:255;index;comment:id"`
 	// 组名称
-	Name string `json:"name" bson:"name" gorm:"column:name;comment:组名称"`
+	Name string `json:"name" bson:"name" gorm:"column:name;size:255;comment:组名称"`
 	// TaskIDs 接管的任务id
 	TaskIDs StringSlice `json:"task_ids" bson:"task_ids" gorm:"column:task_ids;comment:接管的任务id;type:text"`
 	// TriggerCompleted 是否触发完成

--- a/distributed/task/state.go
+++ b/distributed/task/state.go
@@ -132,9 +132,9 @@ func (s Results) Value() (driver.Value, error) {
 // Status 任务状态
 type Status struct {
 	ID        uint           `json:"-" bson:"-" gorm:"column:_id;primarykey;comment:_id"`
-	TaskID    string         `json:"task_id" bson:"_id" gorm:"column:id;uniqueIndex:uq_status_task_id;comment:id"`
-	GroupID   string         `json:"group_id" bson:"group_id" gorm:"column:group_id;comment:组唯一标识"`
-	Name      string         `json:"name" bson:"name" gorm:"column:name;comment:组名称"`
+	TaskID    string         `json:"task_id" bson:"_id" gorm:"column:id;size:255;uniqueIndex:uq_status_task_id;comment:id"`
+	GroupID   string         `json:"group_id" bson:"group_id" gorm:"column:group_id;size:255;comment:组唯一标识"`
+	Name      string         `json:"name" bson:"name" gorm:"column:name;size:255;comment:组名称"`
 	Status    State          `json:"status" bson:"status" gorm:"column:status;comment:任务状态"`
 	TTL       int64          `json:"ttl" bson:"ttl" gorm:"column:ttl;comment:过期时间"`
 	Error     string         `json:"error" bson:"error" gorm:"column:error;comment:错误"`

--- a/distributed/worker.go
+++ b/distributed/worker.go
@@ -1,6 +1,8 @@
 package distributed
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"math"
 	"os"
@@ -9,6 +11,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/songzhibin97/gkit/distributed/backend"
 	"github.com/songzhibin97/gkit/distributed/retry"
 
 	"github.com/pkg/errors"
@@ -164,6 +167,9 @@ func (w *Worker) handlerSucceeded(signature *task.Signature, results []*task.Res
 	if err := w.bindService.GetBackend().SetStateSuccess(signature, results); err != nil {
 		return errors.Wrap(err, "worker set task state to 'succeeded' error, signature id:"+signature.ID)
 	}
+	if err := w.recordDurableTerminal(signature, backend.MemberTerminalSuccess, backend.CallbackTerminalSuccess, results); err != nil {
+		return err
+	}
 
 	// 执行任务成功回调
 	for _, success := range signature.CallbackOnSuccess {
@@ -240,6 +246,9 @@ func (w *Worker) handlerFailed(signature *task.Signature, err error) error {
 	if err := w.bindService.GetBackend().SetStateFailure(signature, err.Error()); err != nil {
 		return errors.Wrap(err, "worker set task state to 'succeeded' error, signature id:"+signature.ID)
 	}
+	if durableErr := w.recordDurableTerminal(signature, backend.MemberTerminalFailure, backend.CallbackTerminalFailure, nil); durableErr != nil {
+		return durableErr
+	}
 	if w.errorHandler != nil {
 		w.errorHandler(err)
 	} else {
@@ -253,6 +262,69 @@ func (w *Worker) handlerFailed(signature *task.Signature, err error) error {
 		return errors.New("StopTaskDeletionOnError")
 	}
 	return nil
+}
+
+func (w *Worker) recordDurableTerminal(signature *task.Signature, memberOutcome backend.MemberTerminalOutcome, callbackOutcome backend.CallbackTerminalOutcome, results []*task.Result) error {
+	durable := w.bindService.durableBackend
+	if durable == nil || signature == nil || signature.Meta == nil {
+		return nil
+	}
+	value, ok := signature.Meta.Get(backend.DurableChordDeliveryKeyMeta)
+	if !ok {
+		return nil
+	}
+	deliveryKey, ok := value.(string)
+	if !ok || deliveryKey == "" {
+		return fmt.Errorf("invalid durable chord delivery key metadata on task %s", signature.ID)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), chordOperationTimeout)
+	defer cancel()
+	memberValue, isMember := signature.Meta.Get(backend.DurableChordMemberMeta)
+	if isMember && metadataBool(memberValue) {
+		ordinalValue, ok := signature.Meta.Get(backend.DurableChordMemberOrdinal)
+		if !ok {
+			return fmt.Errorf("missing durable chord ordinal metadata on task %s", signature.ID)
+		}
+		ordinal, ok := metadataInt(ordinalValue)
+		if !ok {
+			return fmt.Errorf("invalid durable chord ordinal metadata on task %s", signature.ID)
+		}
+		if err := durable.RecordMemberTerminal(ctx, deliveryKey, ordinal, signature.ID, memberOutcome, results); err != nil {
+			return fmt.Errorf("record durable chord member terminal %s: %w", signature.ID, err)
+		}
+		return nil
+	}
+	if err := durable.RecordCallbackTerminal(ctx, deliveryKey, callbackOutcome); err != nil {
+		return fmt.Errorf("record durable chord callback terminal %s: %w", signature.ID, err)
+	}
+	return nil
+}
+
+func metadataBool(value interface{}) bool {
+	switch typed := value.(type) {
+	case bool:
+		return typed
+	case string:
+		return typed == "true"
+	default:
+		return false
+	}
+}
+
+func metadataInt(value interface{}) (int, bool) {
+	switch typed := value.(type) {
+	case int:
+		return typed, true
+	case int64:
+		return int(typed), true
+	case float64:
+		return int(typed), typed == float64(int(typed))
+	case json.Number:
+		parsed, err := typed.Int64()
+		return int(parsed), err == nil
+	default:
+		return 0, false
+	}
 }
 
 func (w *Worker) ConsumeQueue() string {

--- a/specs/104/PRODUCT.md
+++ b/specs/104/PRODUCT.md
@@ -1,0 +1,30 @@
+# Durable chord callback delivery
+
+## Summary
+
+Group callbacks remain recoverable across publication ambiguity, backend failures, concurrent workers, rolling upgrades, and process restarts. Eligible callbacks use stable group-scoped identity and immutable payloads and provide at-least-once delivery without claiming exactly-once side effects.
+
+## Behavior
+
+1. Sending a group callback rejects a nil group-callback value, nil group, nil callback, empty group, nil member, empty group/callback/member identifier, or duplicate member identifier before registering or publishing anything. The returned error is identifiable as invalid chord input and names the invalid field or member.
+2. Durable registration, including every member's stable identifier and immutable publication payload, completes before any member is published. Concurrent identical sends share one registration, and setup cleanup can affect only the registration version created and still owned by that send.
+3. Once publication ownership has been acquired, an ordinary publication error or process exit never aborts the registration. Recovery retries the same identifier and payload; only an explicit rejection that guarantees no broker side effect can become a final member failure.
+4. Group-scoped member completion receipts are the sole authority for callback readiness. A temporary receipt-write failure leaves the same member recoverable, and generic task status written by an older worker cannot make the callback ready.
+5. Durable state has a stable group-scoped identity that is isolated from user task and group state. A storage backend rejects identifiers in any namespace it reserves before changing user or durable state, and pre-existing user state occupying a durable location is never overwritten during send or restart.
+6. Concurrent workers and service instances permit at most one current publisher for each member or callback. Ownership expires and can be recovered, while a stale owner cannot finalize a newer owner's publication.
+7. Every ordinary publication error is an unknown broker outcome. Recovery may publish the same identifier and payload again; only an explicitly typed no-side-effect rejection is definite.
+8. Server startup scans and reconciles all nonterminal durable work before accepting new durable registration. Startup failure is observable, and a later healthy restart recovers registered work from backend state alone even when new registration is disabled.
+9. Scheduled durable callbacks require cancellation-aware locking. Lock acquisition, retry waiting, sending, unlock cleanup, dispatcher work, and shutdown joining are bounded by server-owned cancellation; non-durable scheduling retains legacy-locker compatibility.
+10. The group-scoped delivery identity is the authority for callback terminal state. Generic status or another group reusing the same callback task identifier cannot finalize, suppress, or move the wrong delivery backward.
+11. Retention begins at terminal delivery time: zero means 3600 seconds, negative means no expiry, and positive values are retained unchanged. Active delivery state and evidence required for readiness do not expire under this policy.
+12. Any final member failure durably suppresses the success callback; the callback is not published and does not remain indefinitely recoverable as ready work.
+13. While durable backend state remains available and the broker eventually accepts work, every registered member and eligible all-success callback receives at least one publication and execution attempt with stable identity. Duplicate attempts remain possible and handlers must make external side effects idempotent.
+14. Durable registration and strict backend enforcement are independent rollout controls. Older workers provide only the safety property that they cannot trigger the legacy callback path; upgraded workers are required for durable liveness, and disabling new registration does not stop recovery of existing records.
+15. Existing backend implementations remain source-compatible. With registration disabled the legacy path is unchanged; with registration enabled, compatibility mode falls back for a backend without durable capability and strict mode rejects before publication.
+
+## Non-goals
+
+- Exactly-once publication, execution, or application side effects.
+- Automatic idempotency for callback handlers.
+- Reconstructing results that were never durably recorded.
+- Retrofitting legacy groups that contain no recoverable callback payload.

--- a/specs/104/TECH.md
+++ b/specs/104/TECH.md
@@ -1,0 +1,71 @@
+# Durable chord callback delivery: technical design
+
+## Context
+
+[PRODUCT.md](./PRODUCT.md) defines the shipped at-least-once contract. Public validation and durable/legacy routing live in `distributed/service.go`; durable registration, dispatcher recovery, publication classification, and shutdown live in `distributed/durable_chord.go`; upgraded worker receipts and terminal recording live in `distributed/worker.go`. The optional capability and backend-independent state machine live in `distributed/backend/durable_chord.go`.
+
+Redis stores legacy task status and group metadata under raw caller identifiers in `distributed/backend/backend_redis/redis.go`, while durable records and indexes use private keys in `distributed/backend/backend_redis/durable_chord.go`. SQL initializes the current task/group schema before durable tables in `distributed/backend/backend_db/db.go` and `distributed/backend/backend_db/durable_chord.go`. MongoDB uses a separate durable collection in `distributed/backend/backend_mongodb/durable_chord.go`.
+
+This document describes the implementation that ships on the current branch, including the merged `master` schema contract; it is not a future design.
+
+## Proposed changes
+
+### Validation and immutable registration
+
+`SendGroupCallbackWithContext` validates every pointer, identifier, group member, and duplicate before backend/controller calls. All validation errors wrap `backend.ErrChordInvalidInput` and include field or ordinal context. Durable send copies caller templates, applies the pre-publish hook once, clears the legacy callback pointer on member copies, freezes routing/metadata, serializes each payload once, and registers before claiming publication.
+
+Registration ownership is an owner/version fence. Exactly one identical concurrent registration is the creator; attached callers cannot abort or reset it. Abort is idempotent only for the current created reference before any member lease. A member lease permanently closes the abort window.
+
+### Redis namespace choice, compatibility, and rollback
+
+Redis keeps the existing raw task/group key format; user keys are not encoded or migrated. Durable records and indexes retain the dedicated `gkit:chord:` key domain. Because raw identifiers could otherwise equal a private key, every Redis task/group raw-key write entry point rejects identifiers beginning with that reserved prefix before `SET`, `SETNX`, or `DEL`: group takeover/completion, all task-state updates, resets, durable registration setup, callback pending setup, and restart reconciliation all use the same check.
+
+This choice preserves reads and writes for every historical raw identifier outside the newly reserved domain. Registration still claims its record with `SETNX`. If that key already contains a legacy task/group value, malformed data, or a durable record whose delivery identity does not match the key, registration fails closed with conflict, removes only its own pending index generation, and never overwrites the value. Restart scanning therefore cannot convert an occupied legacy key into durable state.
+
+No data rewrite is required for deployment. Rollback first disables new durable registration and drains or preserves existing durable records; because ordinary user keys were never re-encoded, older readers continue to read all non-reserved historical keys. Operators must not create new `gkit:chord:` user identifiers during rollback because older binaries do not enforce the reservation. The durable record format and indexes are otherwise unchanged.
+
+### Recovery, fencing, and terminal authority
+
+The backend stores a group-scoped delivery key, definition hash, owner/version, immutable member payloads, publication leases/outcomes, receipts, frozen callback payload, terminal outcome, and terminal timestamps. Member and callback claims are compare-and-swap transitions. Nil publication records success; untyped errors, cancellation after dispatch, and outcome-write failure remain unknown; only `DefinitePublishRejection` may be final.
+
+Member receipts validate delivery key, ordinal, task ID, outcome, and results. Generic status never substitutes for a receipt. The final successful receipt freezes callback arguments in member order; any failure receipt atomically suppresses the callback. Callback terminal writes use only the reserved delivery-key metadata and never infer authority from callback task ID.
+
+Startup completes a paginated scan before durable admission. Periodic recovery handles setup, ready, leased, published, unknown, terminal, and suppressed records. Registration and recovery have independent enablement. Shutdown rejects admission, cancels scheduled registration and cleanup roots, stops scheduling, cancels dispatcher claims/publications, and joins all owned goroutines.
+
+### SQL and MongoDB storage
+
+The merged current schema keeps `GroupMeta.GroupID` at size 191 with unique index `uq_group_meta_group_id` and `Status.TaskID` at size 191 with unique index `uq_status_task_id`; the existing `StringSlice` scanner/versioned encoding remains intact. `BackendSQLDB.autoMigrate` migrates those task/group constraints before the durable chord tables. Fresh MySQL 8 and PostgreSQL 16 migrations must expose both exact lengths and unique indexes, and historical duplicate groups must fail migration without silent deletion.
+
+SQL uses local transactions and conditional owner/version updates across delivery, publication, and receipt tables. MongoDB uses one durable document with unique/due/TTL indexes and compare-and-swap update filters. Broker publication remains outside either storage transaction.
+
+## Testing and validation
+
+Each PRODUCT behavior has exactly one primary regression test:
+
+| Behavior | Primary proof | Mutation target |
+| --- | --- | --- |
+| 1 | `TestDurableChordValidationHasTypedFieldErrorsAndZeroSideEffects` | Replace a typed field error with a generic error or remove a guard. |
+| 2 | `TestDurableChordAttachedRegistrationObservesCreatorAbort` | Allow an attached/stale owner to abort or reset another registration. |
+| 3 | `TestDurableChordRestartRecoversOutcomeWriteFailureWithStablePayload` | Abort after ownership or regenerate member identity/payload on restart. |
+| 4 | `TestDurableChordRetriesReceiptAndCallbackTerminalWriteFailures` | Treat generic task status as a receipt or stop after a receipt-write failure. |
+| 5 | `TestRedisDurableChordNamespaceIsolatedAcrossSendWorkerAndRestart` | Remove the reserved-domain check or overwrite a legacy record collision. |
+| 6 | `backend_redis.TestDurableChordContract` | Remove owner/version predicates from member or callback claims/outcomes. |
+| 7 | `TestDurableChordPublishOutcomeClassification` | Classify an ordinary publication error as a definite rejection. |
+| 8 | `TestDurableChordStartupRecoversEveryScanPageWhenRegistrationDisabled` | Skip a state/page or gate recovery on registration enablement. |
+| 9 | `TestShutdownCancelsUnlockAlreadyInProgress` | Root unlock outside server cancellation or return before owned work joins. |
+| 10 | `TestDurableCallbackWorkerUsesDeliveryKeyAndRetriesRemainNonterminal` | Finalize through callback task ID or generic status. |
+| 11 | `backend_db.TestDurableChordContract/retention_zero` | Start retention at creation or interpret zero/negative incorrectly. |
+| 12 | `backend_mongodb.TestDurableChordContract/retention_negative` | Ignore a failed receipt and make the callback ready. |
+| 13 | `TestDurableChordEndToEndUsesReceiptsAndDeliveryKey` | Remove a recovery transition or regenerate an identity. |
+| 14 | `TestDurableChordOldWorkerStatusDoesNotSatisfyReceipt` | Let an old worker trigger the legacy path or satisfy durable readiness. |
+| 15 | `TestDurableChordCompatibilityMatrix` | Add methods to the base backend interface or couple strictness to registration. |
+
+Supporting blocker gates are `TestRedisRawKeyWritersRejectDurableChordNamespace`, `TestRedisChordRegistrationFailsClosedOnLegacyRecordCollision`, `TestDurableChordCurrentMasterSchemaContract`, and `TestDurableChordCurrentMasterSchemaLiveSQL`. The namespace tests cover public send, worker status writes, legacy collision, and restart; generic-error, reserved-prefix, record-overwrite, size-191, and unique-index mutations must each fail.
+
+Required execution gates:
+
+- touched and full `distributed` packages under `go test -race`;
+- `go vet ./distributed/...` and `git diff --check`;
+- live Redis 7, MongoDB 7, MySQL 8, and PostgreSQL 16 backend contracts;
+- idempotency, concurrent claim, owner/version fence, restart, and terminal-authority tests;
+- combined-tree checks with PR #120, PR #122, and the current PR #126 head.


### PR DESCRIPTION
## What

- add an optional durable chord backend contract with group-scoped delivery keys, immutable member payloads, versioned leases, receipts, callback terminal authority, and terminal retention
- implement the contract for Redis, SQL (SQLite/MySQL/PostgreSQL), and MongoDB
- add server startup recovery, periodic dispatch, rolling-upgrade flags, worker receipts, context-aware timed locking, and bounded shutdown/outcome persistence
- reserve the Redis `gkit:chord:` domain across every raw task/group writer and fail closed when a legacy value occupies a durable record key
- preserve the current master SQL identifier constraints and restore `specs/104` with 15 behavior-to-test mappings
- preserve the existing `backend.Backend` and `locker.Locker` interfaces for compatibility

## Why

The legacy chord path can permanently lose a callback after member completion or broker/backend failures. Durable registration and recovery make member and eligible callback publication at-least-once while retaining stable task and delivery identities. Redis raw user keys also needed a provable boundary from private durable keys so a crafted task/group identifier or legacy value cannot overwrite recovery state.

Fixes #104

## How

- register the full group definition before publication and fence setup/abort by owner and version
- recover every member/callback state through cursor-paginated startup and periodic scans
- treat ordinary publication failures as unknown; only typed no-side-effect rejection is definite
- record member receipts and callback terminal outcomes by the group-scoped delivery key
- keep historical Redis user keys raw, reject the private prefix before `SET`/`SETNX`/`DEL`, and use `SETNX` plus strict record validation and owned pending-index cleanup for legacy collisions
- retain `GroupMeta.GroupID`/`Status.TaskID` size 191 unique indexes and verify the live SQL migration result
- expire terminal records from terminal time, with zero/negative/positive retention semantics

## Tests

- touched packages under `go test -race`
- package-list `go test -race` for all `distributed` packages except the two unchanged fixed-endpoint baseline blockers described below
- `go vet ./distributed/...`
- live Redis 7.4.8, MongoDB 7.0.37 focused durable contract, MySQL 8.4.9, and PostgreSQL 16.13
- five new mutation checks: typed nil-callback validation, Redis reserved-prefix removal, legacy-record `SETNX` to overwrite, GroupID size 191 to 255, and unique to non-unique index
- existing durable recovery mutations for publication classification, owner/version fencing, retention, and shutdown cancellation remain covered
- synthetic merge with master `4b4d031`; PR #120 and #122 heads are tree-identical after that merge

## Known baseline

- `TestControllerRedis_StartConsuming` still returns `context canceled` after 10 seconds; the identical focused failure reproduces on master `4b4d031`.
- the legacy `backend_mongodb` full package waits on its fixed endpoint; the unchanged `mongo_test.go` blob is identical to master. The focused MongoDB 7 durable contract passes.
- PR #126 head `4646eb4` overlaps this branch in five single-hunk files and will require an explicit combined merge if it lands first; no other branch was modified.
