### PR TITLE
fix(tools): handle nil binding targets safely

### DIFF
--- a/tools/bind/form_mapping.go
+++ b/tools/bind/form_mapping.go
@@ -26,21 +26,35 @@ var emptyField = reflect.StructField{}
 
 func mapFormByTag(ptr interface{}, form map[string][]string, tag string) error {
 	ptrVal := reflect.ValueOf(ptr)
-	var pointed interface{}
-	// 如果 ptr 是指针
-	if ptrVal.Kind() == reflect.Ptr {
-		// 获取指针内下的值 并且记录一下 当前类型的 interface模式存储在 pointed 位置
-		ptrVal = ptrVal.Elem()
-		pointed = ptrVal.Interface()
+	if !ptrVal.IsValid() {
+		return errUnknownType
 	}
-	if ptrVal.Kind() == reflect.Map &&
-		ptrVal.Type().Key().Kind() == reflect.String {
-		// 如果 ptr 是map类型 && 并且 key 是 string 的情况下
-		if pointed != nil {
-			// 如果上面 pointed 不是nil 有值的情况下 ptr = pointed 赋值
-			ptr = pointed
+	rootKind := ptrVal.Kind()
+	if ptrVal.Kind() == reflect.Ptr {
+		if ptrVal.IsNil() {
+			return errUnknownType
 		}
-		return setFormMap(ptr, form)
+		ptrVal = ptrVal.Elem()
+	} else if rootKind != reflect.Map {
+		return errUnknownType
+	}
+	if ptrVal.Kind() == reflect.Map {
+		if ptrVal.Type().Key().Kind() != reflect.String {
+			return errUnknownType
+		}
+		if ptrVal.IsNil() {
+			switch ptrVal.Interface().(type) {
+			case map[string]string, map[string][]string:
+				if !ptrVal.CanSet() {
+					return errUnknownType
+				}
+				ptrVal.Set(reflect.MakeMap(ptrVal.Type()))
+			}
+		}
+		return setFormMap(ptrVal.Interface(), form)
+	}
+	if ptrVal.Kind() != reflect.Struct && ptrVal.Kind() != reflect.Ptr {
+		return errUnknownType
 	}
 
 	return mappingByPtr(ptr, formSource(form), tag)

--- a/tools/bind/nil_target_test.go
+++ b/tools/bind/nil_target_test.go
@@ -1,0 +1,107 @@
+package bind
+
+import (
+	"errors"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestFormBindingsAllocateNilMapPointers(t *testing.T) {
+	values := url.Values{"name": {"first", "last"}}
+	binders := []struct {
+		name string
+		bind func(interface{}) error
+	}{
+		{
+			name: "uri",
+			bind: func(target interface{}) error { return Uri.BindUri(values, target) },
+		},
+		{
+			name: "form",
+			bind: func(target interface{}) error {
+				request := httptest.NewRequest("POST", "/", strings.NewReader(values.Encode()))
+				request.Header.Set("Content-Type", MIMEPOSTForm)
+				return Form.Bind(request, target)
+			},
+		},
+	}
+
+	for _, binder := range binders {
+		t.Run(binder.name+"/map-string", func(t *testing.T) {
+			var target map[string]string
+			if err := binder.bind(&target); err != nil {
+				t.Fatalf("bind nil map pointer: %v", err)
+			}
+			if target == nil || target["name"] != "last" {
+				t.Fatalf("bound map = %#v, want allocated map with last value", target)
+			}
+		})
+
+		t.Run(binder.name+"/map-string-slice", func(t *testing.T) {
+			var target map[string][]string
+			if err := binder.bind(&target); err != nil {
+				t.Fatalf("bind nil map-slice pointer: %v", err)
+			}
+			if target == nil || !reflect.DeepEqual(target["name"], []string{"first", "last"}) {
+				t.Fatalf("bound map = %#v, want allocated map with all values", target)
+			}
+		})
+	}
+}
+
+func TestFormBindingsRejectInvalidOrUnsettableTargets(t *testing.T) {
+	values := url.Values{"name": {"value"}}
+	type targetStruct struct {
+		Name string `form:"name" uri:"name"`
+	}
+	var typedNil *targetStruct
+	var nilMap map[string]string
+	scalar := 1
+	nonStringKeyMap := map[int]string{}
+
+	binders := []struct {
+		name string
+		bind func(interface{}) error
+	}{
+		{name: "uri", bind: func(target interface{}) error { return Uri.BindUri(values, target) }},
+		{
+			name: "form",
+			bind: func(target interface{}) error {
+				request := httptest.NewRequest("POST", "/", strings.NewReader(values.Encode()))
+				request.Header.Set("Content-Type", MIMEPOSTForm)
+				return Form.Bind(request, target)
+			},
+		},
+	}
+	invalid := []struct {
+		name   string
+		target interface{}
+	}{
+		{name: "untyped-nil", target: nil},
+		{name: "typed-nil-pointer", target: typedNil},
+		{name: "non-pointer-struct", target: targetStruct{}},
+		{name: "unsettable-nil-map", target: nilMap},
+		{name: "pointer-to-scalar", target: &scalar},
+		{name: "non-string-map-key", target: &nonStringKeyMap},
+	}
+
+	for _, binder := range binders {
+		for _, invalidTarget := range invalid {
+			t.Run(binder.name+"/"+invalidTarget.name, func(t *testing.T) {
+				if err := binder.bind(invalidTarget.target); !errors.Is(err, errUnknownType) {
+					t.Fatalf("bind error = %v, want %v", err, errUnknownType)
+				}
+			})
+		}
+
+		t.Run(binder.name+"/unsupported-map", func(t *testing.T) {
+			var target map[string]int
+			if err := binder.bind(&target); err == nil || !strings.Contains(err.Error(), "cannot convert to map of strings") {
+				t.Fatalf("bind error = %v, want existing map conversion error", err)
+			}
+		})
+	}
+}

--- a/tools/vto/default.go
+++ b/tools/vto/default.go
@@ -7,17 +7,18 @@ import (
 )
 
 func CompletionDefault(dst interface{}) error {
-	dstT := reflect.TypeOf(dst)
-	if dstT.Kind() != reflect.Ptr {
-		return tools.ErrorMustPtr
+	dstV := reflect.ValueOf(dst)
+	if !dstV.IsValid() || dstV.Kind() != reflect.Ptr || dstV.IsNil() {
+		return tools.ErrorInvalidValue
 	}
 
+	dstT := dstV.Type()
 	dstT = dstT.Elem()
 	if dstT.Kind() != reflect.Struct {
 		return tools.ErrorMustStructPtr
 	}
 
-	dstV := reflect.ValueOf(dst).Elem()
+	dstV = dstV.Elem()
 	for i := 0; i < dstT.NumField(); i++ {
 		field := dstT.Field(i)
 		if !field.IsExported() {

--- a/tools/vto/default.go
+++ b/tools/vto/default.go
@@ -8,7 +8,13 @@ import (
 
 func CompletionDefault(dst interface{}) error {
 	dstV := reflect.ValueOf(dst)
-	if !dstV.IsValid() || dstV.Kind() != reflect.Ptr || dstV.IsNil() {
+	if !dstV.IsValid() {
+		return tools.ErrorInvalidValue
+	}
+	if dstV.Kind() != reflect.Ptr {
+		return tools.ErrorMustPtr
+	}
+	if dstV.IsNil() {
 		return tools.ErrorInvalidValue
 	}
 

--- a/tools/vto/default_nil_target_test.go
+++ b/tools/vto/default_nil_target_test.go
@@ -14,16 +14,21 @@ func TestCompletionDefaultRejectsInvalidTargets(t *testing.T) {
 	var typedNil *target
 
 	for _, tt := range []struct {
-		name   string
-		target interface{}
+		name    string
+		target  interface{}
+		wantErr error
 	}{
-		{name: "untyped-nil", target: nil},
-		{name: "typed-nil-pointer", target: typedNil},
-		{name: "non-pointer", target: target{}},
+		{name: "untyped-nil", target: nil, wantErr: tools.ErrorInvalidValue},
+		{name: "typed-nil-pointer", target: typedNil, wantErr: tools.ErrorInvalidValue},
+		{name: "non-pointer", target: target{}, wantErr: tools.ErrorMustPtr},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := CompletionDefault(tt.target); !errors.Is(err, tools.ErrorInvalidValue) {
-				t.Fatalf("CompletionDefault error = %v, want %v", err, tools.ErrorInvalidValue)
+			err := CompletionDefault(tt.target)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("CompletionDefault error = %v, want errors.Is(_, %v)", err, tt.wantErr)
+			}
+			if err != tt.wantErr {
+				t.Fatalf("CompletionDefault error = %v, want exact sentinel %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/tools/vto/default_nil_target_test.go
+++ b/tools/vto/default_nil_target_test.go
@@ -1,0 +1,52 @@
+package vto
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/songzhibin97/gkit/tools"
+)
+
+func TestCompletionDefaultRejectsInvalidTargets(t *testing.T) {
+	type target struct {
+		Name string `default:"default-name"`
+	}
+	var typedNil *target
+
+	for _, tt := range []struct {
+		name   string
+		target interface{}
+	}{
+		{name: "untyped-nil", target: nil},
+		{name: "typed-nil-pointer", target: typedNil},
+		{name: "non-pointer", target: target{}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := CompletionDefault(tt.target); !errors.Is(err, tools.ErrorInvalidValue) {
+				t.Fatalf("CompletionDefault error = %v, want %v", err, tools.ErrorInvalidValue)
+			}
+		})
+	}
+}
+
+func TestCompletionDefaultValidPointerBehaviorIsUnchanged(t *testing.T) {
+	type target struct {
+		Name string `default:"default-name"`
+	}
+
+	var empty target
+	if err := CompletionDefault(&empty); err != nil {
+		t.Fatalf("CompletionDefault empty pointer: %v", err)
+	}
+	if empty.Name != "default-name" {
+		t.Fatalf("default Name = %q, want default-name", empty.Name)
+	}
+
+	existing := target{Name: "existing"}
+	if err := CompletionDefault(&existing); err != nil {
+		t.Fatalf("CompletionDefault populated pointer: %v", err)
+	}
+	if existing.Name != "existing" {
+		t.Fatalf("existing Name = %q, want unchanged", existing.Name)
+	}
+}


### PR DESCRIPTION
## What

- allocate supported nil map targets before URI and form binding
- reject invalid or unsettable binding/default targets with existing errors
- add regression coverage for nil maps and reflection edge cases

## Why

Binding into a pointer to a nil map and completing defaults on nil targets could panic instead of returning a normal result or the established invalid-value error.

## How

Validate reflection targets before dereferencing them. Allocate only settable map[string]string and map[string][]string targets with reflect.MakeMap; unsupported targets continue through the existing explicit error paths.

## Tests

- go test -race ./tools/bind ./tools/vto -count=10
- go vet ./tools/bind ./tools/vto
- mutation: removing reflect.MakeMap fails the nil-map binding regression
- mutation: removing the typed-nil guard fails the CompletionDefault regression
