### PR TITLE
fix(json): reject nil unmarshal targets

### DIFF
--- a/coding/json/json.go
+++ b/coding/json/json.go
@@ -39,6 +39,9 @@ func (c code) Marshal(v interface{}) ([]byte, error) {
 
 func (c code) Unmarshal(data []byte, v interface{}) error {
 	rv := reflect.ValueOf(v)
+	if !rv.IsValid() {
+		return fmt.Errorf("json: unmarshal target is nil")
+	}
 	for rv.Kind() == reflect.Ptr {
 		if rv.IsNil() {
 			if !rv.CanSet() {

--- a/coding/json/regression_test.go
+++ b/coding/json/regression_test.go
@@ -1,6 +1,9 @@
 package json
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 type issue84Payload struct {
 	Value string `json:"value"`
@@ -8,11 +11,25 @@ type issue84Payload struct {
 
 func TestUnmarshalTypedNilTarget(t *testing.T) {
 	var target *issue84Payload
-	if err := (code{}).Unmarshal([]byte(`{"value":"decoded"}`), target); err == nil {
+	err := (code{}).Unmarshal([]byte(`{"value":"decoded"}`), target)
+	if err == nil {
 		t.Fatal("Unmarshal() error = nil, want non-nil typed target error")
+	}
+	if !strings.Contains(err.Error(), "json: unmarshal target is a nil *json.issue84Payload") {
+		t.Fatalf("Unmarshal() error = %q, want explicit typed-nil target error", err)
 	}
 	if target != nil {
 		t.Fatalf("Unmarshal() changed typed-nil target to %#v", target)
+	}
+}
+
+func TestUnmarshalUntypedNilTarget(t *testing.T) {
+	err := (code{}).Unmarshal([]byte(`{"value":"decoded"}`), nil)
+	if err == nil {
+		t.Fatal("Unmarshal() error = nil, want untyped-nil target error")
+	}
+	if !strings.Contains(err.Error(), "json: unmarshal target is nil") {
+		t.Fatalf("Unmarshal() error = %q, want explicit untyped-nil target error", err)
 	}
 }
 


### PR DESCRIPTION
## What

- reject untyped nil JSON unmarshal targets with an explicit error
- strengthen typed-nil target regression coverage
- preserve nested pointer allocation for valid targets

## Why

Passing an untyped nil target reached reflection on a zero Value and panicked instead of returning an ordinary decoding error.

## How

Validate the reflected target before pointer traversal. The existing typed-nil and nested-pointer paths remain unchanged.

## Tests

- go test -race ./coding/json -count=10
- go vet ./coding/json
- mutation: removing the invalid-Value guard fails the untyped-nil test
- mutation: removing the typed-nil CanSet guard fails the typed-nil test

## Review

Independent review: APPROVE, 0 findings.
