### PR TITLE
fix(log): propagate writer failures

### DIFF
--- a/log/std.go
+++ b/log/std.go
@@ -16,6 +16,18 @@ type stdLogger struct {
 	minLevel Lever
 }
 
+type shortWriteWriter struct {
+	io.Writer
+}
+
+func (w shortWriteWriter) Write(p []byte) (int, error) {
+	n, err := w.Writer.Write(p)
+	if n < len(p) && err == nil {
+		err = io.ErrShortWrite
+	}
+	return n, err
+}
+
 // NewStdLogger new a logger with writer. The minimum level filter is
 // LevelDebug (i.e. everything is emitted).
 func NewStdLogger(w io.Writer) Logger {
@@ -28,7 +40,7 @@ func NewStdLogger(w io.Writer) Logger {
 // was never invoked.
 func NewStdLoggerWithLevel(w io.Writer, min Lever) Logger {
 	return &stdLogger{
-		log: log.New(w, "", 0),
+		log: log.New(shortWriteWriter{Writer: w}, "", 0),
 		pool: &sync.Pool{
 			New: func() interface{} {
 				return new(bytes.Buffer)
@@ -54,8 +66,8 @@ func (l *stdLogger) Log(level Lever, kvs ...interface{}) error {
 	for i := 0; i < len(kvs); i += 2 {
 		fmt.Fprintf(buf, " %s=%v", kvs[i], kvs[i+1])
 	}
-	_ = l.log.Output(4, buf.String())
+	err := l.log.Output(4, buf.String())
 	buf.Reset()
 	l.pool.Put(buf)
-	return nil
+	return err
 }

--- a/log/std_writer_error_test.go
+++ b/log/std_writer_error_test.go
@@ -1,0 +1,49 @@
+package log
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+)
+
+type writerFunc func([]byte) (int, error)
+
+func (f writerFunc) Write(p []byte) (int, error) {
+	return f(p)
+}
+
+func TestStdLoggerPropagatesWriterError(t *testing.T) {
+	want := errors.New("writer failed")
+	logger := NewStdLogger(writerFunc(func(p []byte) (int, error) {
+		return len(p) / 2, want
+	}))
+
+	err := logger.Log(LevelError, "key", "value")
+	if !errors.Is(err, want) {
+		t.Fatalf("Log error = %v, want underlying writer error %v", err, want)
+	}
+}
+
+func TestStdLoggerReturnsShortWrite(t *testing.T) {
+	logger := NewStdLogger(writerFunc(func(p []byte) (int, error) {
+		return len(p) - 1, nil
+	}))
+
+	err := logger.Log(LevelInfo, "key", "value")
+	if !errors.Is(err, io.ErrShortWrite) {
+		t.Fatalf("Log error = %v, want %v", err, io.ErrShortWrite)
+	}
+}
+
+func TestStdLoggerSuccessfulWriteUnchanged(t *testing.T) {
+	var output bytes.Buffer
+	logger := NewStdLogger(&output)
+
+	if err := logger.Log(LevelWarn, "key", "value"); err != nil {
+		t.Fatalf("Log returned error: %v", err)
+	}
+	if got, want := output.String(), "[Warn] key=value\n"; got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## What
- return underlying writer errors from the standard logger
- convert nil-error short writes to `io.ErrShortWrite`
- add regressions for writer errors, short writes, and successful output

## Why
`stdLogger.Log` discarded `log.Logger.Output` failures, so callers could not detect lost or partial log writes.

## How
A small writer adapter enforces the `io.Writer` short-write contract, while `Log` returns the stdlib logger error after resetting and pooling its buffer.

## Tests
- `go test -race ./log -count=10`
- `go vet ./log`
- discard-output-error mutation: writer error and short-write tests fail
- remove-short-write-adapter mutation: short-write test fails