### PR TITLE
fix(aes): reject negative padded key lengths

### DIFF
--- a/encrypt/aes/aes.go
+++ b/encrypt/aes/aes.go
@@ -30,6 +30,10 @@ const defaultKey = "gkit"
 // fallback ("gkit"), which produced a publicly-known KDF.
 var ErrEmptyKey = errors.New("aes: empty key")
 
+// ErrInvalidTargetLength is returned by PadKeyToLengthE when targetLength is
+// negative.
+var ErrInvalidTargetLength = errors.New("aes: invalid target length")
+
 // PadKey pads s to a valid AES key length (16, 24, or 32 bytes).
 //
 // Deprecated: PadKey("") silently substitutes the hard-coded "gkit" default,
@@ -88,10 +92,13 @@ func PadKeyToLength(s string, targetLength int) string {
 }
 
 // PadKeyToLengthE pads s to targetLength bytes. It returns ErrEmptyKey when s
-// is empty.
+// is empty and ErrInvalidTargetLength when targetLength is negative.
 func PadKeyToLengthE(s string, targetLength int) (string, error) {
 	if s == "" {
 		return "", ErrEmptyKey
+	}
+	if targetLength < 0 {
+		return "", ErrInvalidTargetLength
 	}
 	return PadKeyToLength(s, targetLength), nil
 }

--- a/encrypt/aes/aes_test.go
+++ b/encrypt/aes/aes_test.go
@@ -160,8 +160,29 @@ func TestPadKeyE_EmptyReturnsError(t *testing.T) {
 }
 
 func TestPadKeyToLengthE_EmptyReturnsError(t *testing.T) {
-	if _, err := PadKeyToLengthE("", 16); err != ErrEmptyKey {
-		t.Fatalf("PadKeyToLengthE(\"\", 16) err = %v, want ErrEmptyKey", err)
+	for _, targetLength := range []int{16, -1} {
+		if _, err := PadKeyToLengthE("", targetLength); err != ErrEmptyKey {
+			t.Fatalf("PadKeyToLengthE(\"\", %d) err = %v, want ErrEmptyKey", targetLength, err)
+		}
+	}
+}
+
+func TestPadKeyToLengthE_NegativeLengthReturnsError(t *testing.T) {
+	if _, err := PadKeyToLengthE("x", -1); err != ErrInvalidTargetLength {
+		t.Fatalf("PadKeyToLengthE(\"x\", -1) err = %v, want ErrInvalidTargetLength", err)
+	}
+}
+
+func TestPadKeyToLengthE_NonNegativeLengthsPreserveLegacyResult(t *testing.T) {
+	for _, targetLength := range []int{0, 1, 3, 8} {
+		want := PadKeyToLength("abc", targetLength)
+		got, err := PadKeyToLengthE("abc", targetLength)
+		if err != nil {
+			t.Fatalf("PadKeyToLengthE(\"abc\", %d) err = %v", targetLength, err)
+		}
+		if got != want {
+			t.Fatalf("PadKeyToLengthE(\"abc\", %d) = %q, want %q", targetLength, got, want)
+		}
 	}
 }
 


### PR DESCRIPTION
## What
- add `ErrInvalidTargetLength` for negative `PadKeyToLengthE` targets
- preserve existing empty-key precedence and non-negative padding behavior
- add regression coverage for negative lengths and guard ordering

## Why
A negative target length reached the deprecated slice-based helper and panicked instead of returning an error.

## How
Validate negative lengths in the error-returning API before delegating to the legacy helper. The deprecated non-error API remains unchanged because it has no error channel.

## Tests
- `go test ./encrypt/aes -run '^TestPadKeyToLengthE' -count=10`
- `go test -race ./encrypt/aes -count=10`
- `go vet ./encrypt/aes`
- reverse mutations for the negative-length guard and empty-key guard ordering