### PR TITLE
fix(buffer): handle zero reads and negative sizes

### DIFF
--- a/cache/buffer/iobuffer.go
+++ b/cache/buffer/iobuffer.go
@@ -72,6 +72,9 @@ func (p *pipe) Len() int {
 
 // Read 等待数据可用,将缓冲区内容复制到buffer中
 func (p *pipe) Read(buffer []byte) (int, error) {
+	if len(buffer) == 0 {
+		return 0, nil
+	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.checkCond()
@@ -238,6 +241,9 @@ func (i *ioBuffer) ReadFrom(r io.Reader) (n int64, err error) {
 
 // Grow 扩张
 func (i *ioBuffer) Grow(n int) error {
+	if n < 0 {
+		return ErrNegativeCount
+	}
 	start, ok := i.tryGrowByRelies(n)
 	if !ok {
 		start = i.grow(n)
@@ -349,6 +355,9 @@ func (i *ioBuffer) WriteTo(w io.Writer) (n int64, err error) {
 
 // Peek 从缓冲区读取n个字节,不会消耗缓冲区,如果超过或不合法返回nil
 func (i *ioBuffer) Peek(n int) []byte {
+	if n < 0 {
+		return nil
+	}
 	if len(i.buffer)-i.off < n {
 		return nil
 	}
@@ -367,6 +376,9 @@ func (i *ioBuffer) Bytes() []byte {
 
 // Drain 排出缓冲区 offset 长度
 func (i *ioBuffer) Drain(offset int) {
+	if offset < 0 {
+		return
+	}
 	if i.off+offset > len(i.buffer) {
 		return
 	}

--- a/cache/buffer/iobuffer_.go
+++ b/cache/buffer/iobuffer_.go
@@ -23,8 +23,8 @@ type IoBuffer interface {
 	ReadFrom(r io.Reader) (n int64, err error)
 
 	// Grow updates the length of the buffer by n, growing the buffer as
-	// needed. The return value n is the length of p; err is always nil. If the
-	// buffer becomes too large, Write will panic with ErrTooLarge.
+	// needed. It returns ErrNegativeCount when n is negative. If the buffer
+	// becomes too large, Grow will panic with ErrTooLarge.
 	Grow(n int) error
 
 	// Write appends the contents of p to the buffer, growing the buffer as
@@ -64,7 +64,7 @@ type IoBuffer interface {
 	WriteTo(w io.Writer) (n int64, err error)
 
 	// Peek returns n bytes from buffer, without draining any buffered data.
-	// If n > readable buffer, nil will be returned.
+	// If n is negative or greater than the readable buffer, nil will be returned.
 	// It can be used in codec to check first-n-bytes magic bytes
 	// Note: do not change content in return bytes, use write instead
 	Peek(n int) []byte
@@ -74,7 +74,7 @@ type IoBuffer interface {
 	// Note: do not change content in return bytes, use write instead
 	Bytes() []byte
 
-	// Drain drains a offset length of bytes in buffer.
+	// Drain drains an offset length of bytes in buffer. Negative offsets are ignored.
 	// It can be used with Bytes(), after consuming a fixed-length of data
 	Drain(offset int)
 

--- a/cache/buffer/iobuffer_boundary_test.go
+++ b/cache/buffer/iobuffer_boundary_test.go
@@ -1,0 +1,97 @@
+package buffer
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+	"time"
+)
+
+const pipeZeroReadTimeout = 200 * time.Millisecond
+
+func TestPipeZeroLengthReadReturnsImmediately(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		read []byte
+	}{
+		{name: "nil", read: nil},
+		{name: "empty", read: []byte{}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			pipe := NewPipe(16)
+			type result struct {
+				n   int
+				err error
+			}
+			done := make(chan result, 1)
+			go func() {
+				n, err := pipe.Read(test.read)
+				done <- result{n: n, err: err}
+			}()
+
+			select {
+			case got := <-done:
+				if got.n != 0 || got.err != nil {
+					t.Fatalf("Read(zero-length) = (%d, %v), want (0, nil)", got.n, got.err)
+				}
+			case <-time.After(pipeZeroReadTimeout):
+				unblockErr := errors.New("unblock timed-out zero-length read")
+				pipe.CloseWithError(unblockErr)
+				<-done
+				t.Fatalf("Read(zero-length) blocked for %s", pipeZeroReadTimeout)
+			}
+
+			if _, err := pipe.Write([]byte("x")); err != nil {
+				t.Fatal(err)
+			}
+			read := make([]byte, 1)
+			if n, err := pipe.Read(read); n != 1 || err != nil || string(read) != "x" {
+				t.Fatalf("pipe after zero-length read = (%d, %v, %q)", n, err, read)
+			}
+			pipe.CloseWithError(nil)
+		})
+	}
+}
+
+func TestIoBufferPeekRejectsNegativeCountWithoutMutation(t *testing.T) {
+	buf := NewIoBufferBytes([]byte("abcdef"))
+	if got := buf.Peek(-1); got != nil {
+		t.Fatalf("Peek(-1) = %q, want nil", got)
+	}
+	if got := buf.Peek(3); !bytes.Equal(got, []byte("abc")) {
+		t.Fatalf("Peek(3) after Peek(-1) = %q, want abc", got)
+	}
+	if got := buf.Bytes(); !bytes.Equal(got, []byte("abcdef")) {
+		t.Fatalf("Peek(-1) mutated buffer: %q", got)
+	}
+}
+
+func TestIoBufferDrainRejectsNegativeCountWithoutMutation(t *testing.T) {
+	buf := NewIoBufferBytes([]byte("abcdef"))
+	beforeLen := buf.Len()
+	buf.Drain(-1)
+	if got := buf.Len(); got != beforeLen {
+		t.Fatalf("Len after Drain(-1) = %d, want %d", got, beforeLen)
+	}
+	buf.Drain(2)
+	if got := buf.Bytes(); !bytes.Equal(got, []byte("cdef")) {
+		t.Fatalf("Bytes after Drain(-1), Drain(2) = %q, want cdef", got)
+	}
+}
+
+func TestIoBufferGrowRejectsNegativeCountWithoutMutation(t *testing.T) {
+	buf := NewIoBufferBytes([]byte("abcdef"))
+	err := buf.Grow(-1)
+	if !errors.Is(err, ErrNegativeCount) {
+		t.Errorf("Grow(-1) error = %v, want %v", err, ErrNegativeCount)
+	}
+	if got := buf.Bytes(); !bytes.Equal(got, []byte("abcdef")) {
+		t.Errorf("Grow(-1) mutated buffer: %q", got)
+	}
+	if err := buf.Grow(2); err != nil {
+		t.Fatal(err)
+	}
+	if got := buf.Bytes(); !bytes.Equal(got, []byte{'a', 'b', 'c', 'd', 'e', 'f', 0, 0}) {
+		t.Fatalf("Bytes after Grow(2) = %v", got)
+	}
+}


### PR DESCRIPTION
## What
- make pipe zero-length reads return immediately
- reject negative `Peek`, `Drain`, and `Grow` sizes without corrupting buffer state
- document the boundary contracts and add regressions

## Why
Zero-length pipe reads could block indefinitely, while negative sizes could panic, move offsets backwards, or shrink and lose buffered data.

## How
Add minimal entry guards: zero-length reads return `(0, nil)`, negative peeks return nil, negative drains are ignored, and negative grows return the existing `ErrNegativeCount`.

## Tests
- `go test -race ./cache/buffer -count=10`
- `go vet ./cache/buffer`
- individually remove each of the four guards; the corresponding regression fails