### PR TITLE
fix(gctuner): restore runtime GOGC when disabled

### DIFF
--- a/gctuner/finalizer_test.go
+++ b/gctuner/finalizer_test.go
@@ -11,8 +11,8 @@ import (
 
 func TestFinalizer(t *testing.T) {
 	// disable gc
-	debug.SetGCPercent(-1)
-	defer debug.SetGCPercent(100)
+	originalGCPercent := debug.SetGCPercent(-1)
+	defer debug.SetGCPercent(originalGCPercent)
 
 	maxCount := int32(16)
 	is := assert.New(t)

--- a/gctuner/tuner.go
+++ b/gctuner/tuner.go
@@ -23,12 +23,22 @@ var (
 
 var defaultGCPercent uint32 = 100
 
+// configuredRuntimeGCPercent is the process startup GC setting restored when
+// tuning is disabled. It is signed because the runtime represents GOGC=off as
+// -1, while the public tuning/reporting API remains uint32-based.
+var configuredRuntimeGCPercent = 100
+
 func init() {
 	gogcEnv := os.Getenv("GOGC")
+	if gogcEnv == "off" {
+		configuredRuntimeGCPercent = -1
+		return
+	}
 	gogc, err := strconv.ParseInt(gogcEnv, 10, 32)
 	if err != nil {
 		return
 	}
+	configuredRuntimeGCPercent = int(gogc)
 	defaultGCPercent = uint32(gogc)
 }
 
@@ -51,7 +61,7 @@ func Tuning(threshold uint64) {
 			globalTuner.stop()
 			globalTuner = nil
 		}
-		debug.SetGCPercent(int(defaultGCPercent))
+		debug.SetGCPercent(configuredRuntimeGCPercent)
 		return
 	}
 

--- a/gctuner/tuner.go
+++ b/gctuner/tuner.go
@@ -45,10 +45,13 @@ var tuningMu sync.Mutex
 func Tuning(threshold uint64) {
 	tuningMu.Lock()
 	defer tuningMu.Unlock()
-	// disable gc tuner if percent is zero
-	if threshold <= 0 && globalTuner != nil {
-		globalTuner.stop()
-		globalTuner = nil
+	// disable gc tuner if threshold is zero
+	if threshold == 0 {
+		if globalTuner != nil {
+			globalTuner.stop()
+			globalTuner = nil
+		}
+		debug.SetGCPercent(int(defaultGCPercent))
 		return
 	}
 
@@ -111,11 +114,18 @@ type tuner struct {
 	finalizer *finalizer
 	gcPercent uint32
 	threshold uint64 // high water level, in bytes
+	stopped   int32
+	tuningMu  sync.Mutex
 }
 
 // tuning check the memory inuse and tune GC percent dynamically.
 // Go runtime ensure that it will be called serially.
 func (t *tuner) tuning() {
+	t.tuningMu.Lock()
+	defer t.tuningMu.Unlock()
+	if atomic.LoadInt32(&t.stopped) > 0 {
+		return
+	}
 	inuse := readMemoryInuse()
 	threshold := t.getThreshold()
 	// stop gc tuning
@@ -158,7 +168,11 @@ func newTuner(threshold uint64) *tuner {
 }
 
 func (t *tuner) stop() {
+	atomic.StoreInt32(&t.stopped, 1)
 	t.finalizer.stop()
+	// Wait for a callback that passed finalizerHandler's stopped check.
+	t.tuningMu.Lock()
+	t.tuningMu.Unlock()
 }
 
 func (t *tuner) setThreshold(threshold uint64) {

--- a/gctuner/tuner_test.go
+++ b/gctuner/tuner_test.go
@@ -2,18 +2,94 @@ package gctuner
 
 import (
 	"runtime"
+	"runtime/debug"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
 var testHeap []byte
 
+func TestTuningZeroRestoresRuntimeGCPercent(t *testing.T) {
+	originalGCPercent := debug.SetGCPercent(int(defaultGCPercent))
+	t.Cleanup(func() {
+		tuningMu.Lock()
+		if globalTuner != nil {
+			globalTuner.stop()
+			globalTuner = nil
+		}
+		tuningMu.Unlock()
+		debug.SetGCPercent(originalGCPercent)
+	})
+
+	Tuning(50)
+	tuningMu.Lock()
+	if globalTuner == nil {
+		tuningMu.Unlock()
+		t.Fatal("Tuning(50) did not install a tuner")
+	}
+	globalTuner.setGCPercent(minGCPercent)
+	tuningMu.Unlock()
+
+	Tuning(0)
+
+	gotRuntimeGCPercent := debug.SetGCPercent(int(defaultGCPercent))
+	debug.SetGCPercent(gotRuntimeGCPercent)
+	assert.Equal(t, int(defaultGCPercent), gotRuntimeGCPercent)
+	assert.Equal(t, defaultGCPercent, GetGCPercent())
+
+	tuningMu.Lock()
+	defer tuningMu.Unlock()
+	assert.Nil(t, globalTuner)
+}
+
+func TestTunerStopWaitsForInFlightTuning(t *testing.T) {
+	tn := &tuner{finalizer: &finalizer{}}
+	tn.tuningMu.Lock()
+
+	stopReturned := make(chan struct{})
+	go func() {
+		tn.stop()
+		close(stopReturned)
+	}()
+
+	deadline := time.Now().Add(time.Second)
+	for atomic.LoadInt32(&tn.finalizer.stopped) == 0 && time.Now().Before(deadline) {
+		runtime.Gosched()
+	}
+	if atomic.LoadInt32(&tn.finalizer.stopped) == 0 {
+		tn.tuningMu.Unlock()
+		t.Fatal("stop did not mark the finalizer as stopped")
+	}
+
+	select {
+	case <-stopReturned:
+		tn.tuningMu.Unlock()
+		t.Fatal("stop returned while a tuning callback was still in flight")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	tn.tuningMu.Unlock()
+	select {
+	case <-stopReturned:
+	case <-time.After(time.Second):
+		t.Fatal("stop did not return after the tuning callback completed")
+	}
+}
+
 func TestTuner(t *testing.T) {
 	is := assert.New(t)
 	memLimit := uint64(100 * 1024 * 1024) // 100 MB
 	threshold := memLimit / 2
+	originalGCPercent := debug.SetGCPercent(int(defaultGCPercent))
 	tn := newTuner(threshold)
+	t.Cleanup(func() {
+		tn.stop()
+		testHeap = nil
+		debug.SetGCPercent(originalGCPercent)
+	})
 	currentGCPercent := tn.getGCPercent()
 	is.Equal(tn.threshold, threshold)
 	is.Equal(defaultGCPercent, currentGCPercent)

--- a/gctuner/tuner_test.go
+++ b/gctuner/tuner_test.go
@@ -1,8 +1,11 @@
 package gctuner
 
 import (
+	"os"
+	"os/exec"
 	"runtime"
 	"runtime/debug"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -12,8 +15,36 @@ import (
 
 var testHeap []byte
 
+const gogcOffHelperEnv = "GKIT_GCTUNER_GOGC_OFF_HELPER"
+
+func TestTuningZeroRestoresGOGCOff(t *testing.T) {
+	if os.Getenv(gogcOffHelperEnv) == "1" {
+		Tuning(0)
+		got := debug.SetGCPercent(-1)
+		debug.SetGCPercent(got)
+		if got != -1 {
+			t.Fatalf("runtime GC percent after Tuning(0) = %d, want -1 for GOGC=off", got)
+		}
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestTuningZeroRestoresGOGCOff$", "-test.v")
+	env := make([]string, 0, len(os.Environ())+2)
+	for _, value := range os.Environ() {
+		if strings.HasPrefix(value, "GOGC=") || strings.HasPrefix(value, gogcOffHelperEnv+"=") {
+			continue
+		}
+		env = append(env, value)
+	}
+	cmd.Env = append(env, "GOGC=off", gogcOffHelperEnv+"=1")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("GOGC=off helper failed: %v\n%s", err, output)
+	}
+}
+
 func TestTuningZeroRestoresRuntimeGCPercent(t *testing.T) {
-	originalGCPercent := debug.SetGCPercent(int(defaultGCPercent))
+	originalGCPercent := debug.SetGCPercent(configuredRuntimeGCPercent)
 	t.Cleanup(func() {
 		tuningMu.Lock()
 		if globalTuner != nil {
@@ -35,9 +66,9 @@ func TestTuningZeroRestoresRuntimeGCPercent(t *testing.T) {
 
 	Tuning(0)
 
-	gotRuntimeGCPercent := debug.SetGCPercent(int(defaultGCPercent))
+	gotRuntimeGCPercent := debug.SetGCPercent(configuredRuntimeGCPercent)
 	debug.SetGCPercent(gotRuntimeGCPercent)
-	assert.Equal(t, int(defaultGCPercent), gotRuntimeGCPercent)
+	assert.Equal(t, configuredRuntimeGCPercent, gotRuntimeGCPercent)
 	assert.Equal(t, defaultGCPercent, GetGCPercent())
 
 	tuningMu.Lock()


### PR DESCRIPTION
## What

- restore the runtime GOGC value to the configured default when tuning is disabled
- wait for in-flight tuner callbacks before completing shutdown
- isolate process-wide GOGC state in the related tests

## Why

`Tuning(0)` removed the global tuner but left the runtime at the last dynamically tuned GOGC value. This made `GetGCPercent()` report the default while the Go runtime still used the stale value. A callback already in flight could also overwrite the restored value after shutdown.

## How

- handle zero threshold as an unconditional disable path and call `debug.SetGCPercent(defaultGCPercent)`
- fence tuner shutdown against in-flight finalizer callbacks
- add deterministic runtime restoration and shutdown-fence regression tests

## Tests

- `go test ./gctuner -count=1`
- `go test -race ./gctuner -count=10`
- `go vet ./gctuner`
- `git diff --check`
- mutation checks: removing either runtime restoration or the shutdown fence makes its focused regression fail