### PR TITLE
fix(registry): handle empty rock-steadier clients

### DIFF
--- a/registry/empty_clients_test.go
+++ b/registry/empty_clients_test.go
@@ -1,0 +1,47 @@
+package registry
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestRockSteadierSubsetHandlesEmptyClients(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		services []int
+	}{
+		{name: "without services"},
+		{name: "with services", services: []int{10, 11}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			r := NewRockSteadierSubset(context.Background(), nil, test.services, func() int64 { return 1 })
+			defer r.Close()
+			if got := r.GetServices(1); len(got) != 0 {
+				t.Fatalf("GetServices with no clients = %v, want empty", got)
+			}
+			if err := r.AddService(context.Background(), []int{12}); !errors.Is(err, ErrorNoClients) {
+				t.Errorf("AddService with no clients error = %v, want %v", err, ErrorNoClients)
+			}
+			if err := r.RemoveService(context.Background(), []int{10}); !errors.Is(err, ErrorNoClients) {
+				t.Errorf("RemoveService with no clients error = %v, want %v", err, ErrorNoClients)
+			}
+		})
+	}
+}
+
+func TestRockSteadierSubsetSelectionSurvivesEmptyServiceSet(t *testing.T) {
+	r := NewRockSteadierSubset(context.Background(), []int{1}, []int{10}, func() int64 { return 1 })
+	defer r.Close()
+	if got := r.GetServices(1); len(got) != 1 || got[0] != 10 {
+		t.Fatalf("initial GetServices(1) = %v, want [10]", got)
+	}
+	r.removeService([]int{10})
+	if got := r.GetServices(1); len(got) != 0 {
+		t.Fatalf("GetServices after removing all services = %v, want empty", got)
+	}
+	r.addService([]int{11})
+	if got := r.GetServices(1); len(got) != 1 || got[0] != 11 {
+		t.Fatalf("GetServices after restoring service = %v, want [11]", got)
+	}
+}

--- a/registry/rock_steadier_subset.go
+++ b/registry/rock_steadier_subset.go
@@ -18,7 +18,10 @@ const Lot = 10
 // MagicNumberGeneration 要保证同一个服务种子一致
 type MagicNumberGeneration func() int64
 
-var ErrorHasBeenClosed = errors.New("has been closed")
+var (
+	ErrorHasBeenClosed = errors.New("has been closed")
+	ErrorNoClients     = errors.New("no clients")
+)
 
 //func corput(n int, base int) float64 {
 //	var q float64
@@ -151,16 +154,18 @@ func NewRockSteadierSubset(ctx context.Context, clients, services []int, magicNu
 		uniqueServices = append(uniqueServices, service)
 	}
 	col := 0
-	for i := 0; i < len(uniqueServices); i++ {
-		matrix[i%pad] = append(matrix[i%pad], toPoint(uniqueServices[i]))
-		col = max(col, len(matrix[i%pad]))
+	if pad > 0 {
+		for i := 0; i < len(uniqueServices); i++ {
+			matrix[i%pad] = append(matrix[i%pad], toPoint(uniqueServices[i]))
+			col = max(col, len(matrix[i%pad]))
+		}
+		// padding
+		ls := len(uniqueServices)
+		for ; ls%pad != 0; ls++ {
+			matrix[ls%pad] = append(matrix[ls%pad], nil)
+		}
+		shuffle(magicNumberGeneration(), clients, matrix)
 	}
-	// padding
-	ls := len(uniqueServices)
-	for ; ls%pad != 0; ls++ {
-		matrix[ls%pad] = append(matrix[ls%pad], nil)
-	}
-	shuffle(magicNumberGeneration(), clients, matrix)
 	hasClient := make(map[int]int)
 	hasService := make(map[int][2]int)
 	for idx, client := range clients {
@@ -215,6 +220,9 @@ func shuffle(magicNumber int64, clients []int, matrixServices [][]*int) {
 func (r *RockSteadierSubset) AddService(ctx context.Context, ids []int) error {
 	if atomic.LoadInt32(&r.close) == 1 {
 		return ErrorHasBeenClosed
+	}
+	if len(r.clients) == 0 {
+		return ErrorNoClients
 	}
 	select {
 	case <-ctx.Done():
@@ -282,6 +290,9 @@ func (r *RockSteadierSubset) addService(ids []int) {
 func (r *RockSteadierSubset) RemoveService(ctx context.Context, ids []int) error {
 	if atomic.LoadInt32(&r.close) == 1 {
 		return ErrorHasBeenClosed
+	}
+	if len(r.clients) == 0 {
+		return ErrorNoClients
 	}
 	select {
 	case <-ctx.Done():


### PR DESCRIPTION
## What
- construct a safe empty rock-steadier subset when no clients are registered
- return `ErrorNoClients` from AddService and RemoveService on empty client sets
- add regressions for direct empty clients and service sets filtered to empty

## Why
The constructor divided by the client count while laying out its matrix, so an empty client list panicked before callers could handle the absence of registrations.

## How
Skip matrix distribution and shuffling when the client count is zero, preserve empty GetServices results, and reject mutating operations before they reach the empty-matrix writer path.

## Tests
- `go test -race ./registry -count=10`
- `go vet ./registry`
- remove zero-client constructor guard mutation: divide-by-zero regression fails
- return nil from empty-client operation guards: explicit error assertions fail