### PR TITLE
fix(timeout): expose DbJSON marshal errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1516,6 +1516,7 @@ func main() {
 ```
 Other(currently, gorm also has a related type that is supported.)
 > timeout.DbJSON // provides some functionality in db json format
+> Use timeout.DBJSONFromObjectE to create DbJSON from Go values and handle JSON encoding errors. The deprecated DBJSONFromObject preserves its legacy nil fallback on encoding failure.
 > timeout.DTime // provides some functionality in db 15:04:05 format
 > DateStruct // provides some functionality in db 15:04:05 format Embedded in struct mode
 > Date // provides some functionality in db 2006-01-02 format

--- a/README_zh.md
+++ b/README_zh.md
@@ -1512,6 +1512,7 @@ func main() {
 ```
 其他(目前，GORM还有一个受支持的相关类型.)
 > timeout.DbJSON // provides some functionality in db json format
+> 使用 timeout.DBJSONFromObjectE 从 Go 值创建 DbJSON 并处理 JSON 编码错误。已弃用的 DBJSONFromObject 在编码失败时保留原有的 nil 回退行为。
 > timeout.DTime // provides some functionality in db 15:04:05 format
 > DateStruct // provides some functionality in db 15:04:05 format Embedded in struct mode
 > Date // provides some functionality in db 2006-01-02 format

--- a/timeout/c_json.go
+++ b/timeout/c_json.go
@@ -10,9 +10,22 @@ import (
 
 type DbJSON []byte
 
+// DBJSONFromObject marshals obj into DbJSON. On marshal failure it returns nil,
+// preserving the legacy behavior that DbJSON.Value treats as SQL NULL.
+//
+// Deprecated: use DBJSONFromObjectE and handle the returned error.
 func DBJSONFromObject(obj interface{}) DbJSON {
-	bin, _ := json.Marshal(obj)
-	return DbJSON(bin)
+	bin, _ := DBJSONFromObjectE(obj)
+	return bin
+}
+
+// DBJSONFromObjectE marshals obj into DbJSON and reports JSON encoding errors.
+func DBJSONFromObjectE(obj interface{}) (DbJSON, error) {
+	bin, err := json.Marshal(obj)
+	if err != nil {
+		return nil, fmt.Errorf("timeout: marshal DbJSON: %w", err)
+	}
+	return DbJSON(bin), nil
 }
 
 func (j *DbJSON) Scan(value interface{}) error {

--- a/timeout/c_json_test.go
+++ b/timeout/c_json_test.go
@@ -1,0 +1,79 @@
+package timeout
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestDBJSONFromObjectEReturnsMarshalError(t *testing.T) {
+	got, err := DBJSONFromObjectE(make(chan int))
+	if err == nil {
+		t.Fatal("DBJSONFromObjectE returned nil error for an unsupported channel")
+	}
+	if got != nil {
+		t.Fatalf("DBJSONFromObjectE returned %q on error, want nil", got)
+	}
+	var typeErr *json.UnsupportedTypeError
+	if !errors.As(err, &typeErr) {
+		t.Fatalf("DBJSONFromObjectE error = %T %v, want json.UnsupportedTypeError", err, err)
+	}
+	if !strings.HasPrefix(err.Error(), "timeout: marshal DbJSON: ") {
+		t.Fatalf("DBJSONFromObjectE error = %q, want timeout marshal context", err)
+	}
+}
+
+func TestDBJSONFromObjectEValidAndNullSemantics(t *testing.T) {
+	got, err := DBJSONFromObjectE(map[string]int{"answer": 42})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != `{"answer":42}` {
+		t.Fatalf("DBJSONFromObjectE object = %q, want compact JSON", got)
+	}
+	value, err := got.Value()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if value != `{"answer":42}` {
+		t.Fatalf("DbJSON.Value() = %#v, want JSON string", value)
+	}
+
+	nullJSON, err := DBJSONFromObjectE(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(nullJSON) != "null" {
+		t.Fatalf("DBJSONFromObjectE(nil) = %q, want null", nullJSON)
+	}
+	nullValue, err := nullJSON.Value()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if nullValue != nil {
+		t.Fatalf("DbJSON(null).Value() = %#v, want SQL NULL", nullValue)
+	}
+}
+
+func TestDBJSONFromObjectPreservesLegacyFallback(t *testing.T) {
+	legacyNull := DBJSONFromObject(make(chan int))
+	if legacyNull != nil {
+		t.Fatalf("DBJSONFromObject(channel) = %q, want legacy nil fallback", legacyNull)
+	}
+	value, err := legacyNull.Value()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if value != nil {
+		t.Fatalf("legacy nil fallback Value() = %#v, want SQL NULL", value)
+	}
+
+	want, err := DBJSONFromObjectE(map[string]bool{"ok": true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := DBJSONFromObject(map[string]bool{"ok": true}); string(got) != string(want) {
+		t.Fatalf("DBJSONFromObject(valid) = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## What

- add `DBJSONFromObjectE` with an explicit error return
- preserve and deprecate the legacy `DBJSONFromObject` nil fallback
- document the new API and its SQL NULL compatibility behavior

## Why

`DBJSONFromObject` discarded `json.Marshal` errors. Unsupported values therefore became a nil `DbJSON`, whose database value is SQL NULL, making invalid input indistinguishable from an intentional null.

## How

- return contextual, wrapped JSON marshal errors from the additive `DBJSONFromObjectE` API
- keep the existing signature and fallback for source compatibility
- cover unsupported values, valid JSON, intentional null, SQL values, and legacy behavior

## Tests

- `go test ./timeout -count=1`
- `go test -race ./timeout -count=10`
- `go vet ./timeout`
- `git diff --check`
- mutation checks: swallowing the error or removing its context makes the focused regression fail