### PR TITLE
fix(window): handle invalid constructor options safely

### DIFF
--- a/window/init.go
+++ b/window/init.go
@@ -8,14 +8,19 @@ import (
 	"github.com/songzhibin97/gkit/options"
 )
 
-// SetSize 设置大小
+const (
+	defaultWindowSize     uint          = 5
+	defaultWindowInterval time.Duration = time.Second
+)
+
+// SetSize 设置大小。零值会由 NewWindow 回落到默认大小。
 func SetSize(size uint) options.Option {
 	return func(c interface{}) {
 		c.(*conf).size = size
 	}
 }
 
-// SetInterval 设置间隔时间
+// SetInterval 设置间隔时间。非正值会由 NewWindow 回落到默认间隔。
 func SetInterval(interval time.Duration) options.Option {
 	return func(c interface{}) {
 		c.(*conf).interval = interval
@@ -34,13 +39,19 @@ func NewWindow(options ...options.Option) SlidingWindow {
 	w := Window{
 		// 默认值:
 		conf: conf{
-			size:     5,
-			interval: time.Second,
+			size:     defaultWindowSize,
+			interval: defaultWindowInterval,
 			ctx:      context.Background(),
 		},
 	}
 	for _, option := range options {
 		option(&w.conf)
+	}
+	if w.size == 0 {
+		w.size = defaultWindowSize
+	}
+	if w.interval <= 0 {
+		w.interval = defaultWindowInterval
 	}
 	w.buffer = make([]atomic.Value, w.size)
 	for i := uint(0); i < w.size; i++ {

--- a/window/invalid_options_test.go
+++ b/window/invalid_options_test.go
@@ -1,0 +1,111 @@
+package window
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/songzhibin97/gkit/options"
+)
+
+func TestNewWindowInvalidOptionsUseDefaults(t *testing.T) {
+	tests := []struct {
+		name string
+		opts []options.Option
+	}{
+		{name: "zero size", opts: []options.Option{SetSize(0)}},
+		{name: "zero interval", opts: []options.Option{SetInterval(0)}},
+		{name: "negative interval", opts: []options.Option{SetInterval(-time.Second)}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := NewWindow(tt.opts...).(*Window)
+			defer w.Shutdown()
+
+			if w.size != 5 {
+				t.Fatalf("size = %d, want default 5", w.size)
+			}
+			if w.interval != time.Second {
+				t.Fatalf("interval = %v, want default %v", w.interval, time.Second)
+			}
+			if len(w.buffer) != 5 {
+				t.Fatalf("buffer length = %d, want 5", len(w.buffer))
+			}
+			if cap(w.communication) != 5 {
+				t.Fatalf("communication capacity = %d, want 5", cap(w.communication))
+			}
+		})
+	}
+}
+
+func TestNewWindowValidOptionsUnchanged(t *testing.T) {
+	w := NewWindow(SetSize(2), SetInterval(time.Hour)).(*Window)
+	defer w.Shutdown()
+
+	if w.size != 2 {
+		t.Fatalf("size = %d, want 2", w.size)
+	}
+	if w.interval != time.Hour {
+		t.Fatalf("interval = %v, want %v", w.interval, time.Hour)
+	}
+	if len(w.buffer) != 2 {
+		t.Fatalf("buffer length = %d, want 2", len(w.buffer))
+	}
+	if cap(w.communication) != 2 {
+		t.Fatalf("communication capacity = %d, want 2", cap(w.communication))
+	}
+}
+
+func TestNewLeapArrayRejectsZeroDimensions(t *testing.T) {
+	tests := []struct {
+		name         string
+		n            uint64
+		intervalSize uint64
+	}{
+		{name: "zero bucket count", n: 0, intervalSize: IntervalSize},
+		{name: "zero interval", n: N, intervalSize: 0},
+		{name: "both zero", n: 0, intervalSize: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewLeapArray(tt.n, tt.intervalSize, &Mock{})
+			if got != nil {
+				t.Fatalf("NewLeapArray(%d, %d) = %#v, want nil", tt.n, tt.intervalSize, got)
+			}
+			if !errors.Is(err, ErrWindowNotSegmentation) {
+				t.Fatalf("NewLeapArray(%d, %d) error = %v, want ErrWindowNotSegmentation", tt.n, tt.intervalSize, err)
+			}
+		})
+	}
+}
+
+func TestNewLeapArrayNilBuilderTakesPrecedence(t *testing.T) {
+	got, err := NewLeapArray(0, 0, nil)
+	if got != nil {
+		t.Fatalf("NewLeapArray(0, 0, nil) = %#v, want nil", got)
+	}
+	if !errors.Is(err, ErrBucketBuilderIsNil) {
+		t.Fatalf("NewLeapArray(0, 0, nil) error = %v, want ErrBucketBuilderIsNil", err)
+	}
+}
+
+func TestNewLeapArrayValidDimensionsUnchanged(t *testing.T) {
+	got, err := NewLeapArray(4, 1000, &Mock{})
+	if err != nil {
+		t.Fatalf("NewLeapArray returned error: %v", err)
+	}
+	if got.n != 4 {
+		t.Fatalf("n = %d, want 4", got.n)
+	}
+	if got.intervalSize != 1000 {
+		t.Fatalf("intervalSize = %d, want 1000", got.intervalSize)
+	}
+	if got.bucketSize != 250 {
+		t.Fatalf("bucketSize = %d, want 250", got.bucketSize)
+	}
+	if got.array.length != 4 {
+		t.Fatalf("array length = %d, want 4", got.array.length)
+	}
+}

--- a/window/leap_array.go
+++ b/window/leap_array.go
@@ -139,10 +139,14 @@ func (s *LeapArray) ValuesChick(now uint64, chick TimeChick) []*Bucket {
 	return ret
 }
 
-// NewLeapArray 初始化 leap array
+// NewLeapArray 初始化 leap array。n 或 intervalSize 为零时返回
+// ErrWindowNotSegmentation。
 func NewLeapArray(n uint64, intervalSize uint64, builder BucketBuilder) (*LeapArray, error) {
 	if builder == nil {
 		return nil, ErrBucketBuilderIsNil
+	}
+	if n == 0 || intervalSize == 0 {
+		return nil, ErrWindowNotSegmentation
 	}
 	if intervalSize%n != 0 {
 		return nil, ErrWindowNotSegmentation


### PR DESCRIPTION
## What
- normalize zero window sizes and non-positive intervals to the existing defaults
- return `ErrWindowNotSegmentation` for zero `NewLeapArray` dimensions while preserving nil-builder precedence
- add deterministic regression coverage for invalid and valid constructor inputs

## Why
Invalid constructor inputs could panic asynchronously in the window sentinel or synchronously through integer divide-by-zero in leap-array initialization.

## How
`NewWindow` keeps its option-based, no-error API and falls back to the existing size and interval defaults. `NewLeapArray` uses its existing error channel and dimension error instead of guessing defaults.

## Tests
- `go test ./window -run '^(TestNewWindowInvalidOptionsUseDefaults|TestNewWindowValidOptionsUnchanged|TestNewLeapArrayRejectsZeroDimensions|TestNewLeapArrayNilBuilderTakesPrecedence|TestNewLeapArrayValidDimensionsUnchanged)$' -count=10`
- `go test -race ./window -count=10`
- `go vet ./window`
- reverse mutations for size, interval, zero dimensions, valid options, and validation precedence