### PR TITLE
fix(trace): avoid mutating the global tracer provider

### DIFF
--- a/trace/option.go
+++ b/trace/option.go
@@ -18,7 +18,8 @@ func WithPropagator(propagator propagation.TextMapPropagator) options.Option {
 	}
 }
 
-// WithTracerProvider with tracer provider.
+// WithTracerProvider configures the provider used by the returned Tracer. It
+// does not install provider as OpenTelemetry's global provider.
 func WithTracerProvider(provider trace.TracerProvider) options.Option {
 	return func(o interface{}) {
 		o.(*config).tracerProvider = provider

--- a/trace/provider_test.go
+++ b/trace/provider_test.go
@@ -1,0 +1,40 @@
+package trace
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	otelemetrytrace "go.opentelemetry.io/otel/trace"
+)
+
+func TestNewTracerWithProviderDoesNotReplaceGlobalProvider(t *testing.T) {
+	originalProvider := otel.GetTracerProvider()
+	localProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(tracetest.NewSpanRecorder()))
+	t.Cleanup(func() {
+		if err := localProvider.Shutdown(context.Background()); err != nil {
+			t.Errorf("shutdown local provider: %v", err)
+		}
+	})
+
+	tracer := NewTracer(otelemetrytrace.SpanKindClient, WithTracerProvider(localProvider))
+	if got := otel.GetTracerProvider(); got != originalProvider {
+		t.Fatalf("NewTracer replaced global provider: got %p, want original %p", got, originalProvider)
+	}
+
+	_, localSpan := tracer.Start(context.Background(), "local", propagation.MapCarrier{})
+	if got := localSpan.TracerProvider(); got != localProvider {
+		t.Fatalf("configured tracer provider = %p, want local provider %p", got, localProvider)
+	}
+	localSpan.End()
+
+	globalTracer := NewTracer(otelemetrytrace.SpanKindClient)
+	_, globalSpan := globalTracer.Start(context.Background(), "global", propagation.MapCarrier{})
+	if got := globalSpan.TracerProvider(); got != originalProvider {
+		t.Fatalf("default tracer provider = %p, want original global %p", got, originalProvider)
+	}
+	globalSpan.End()
+}

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -20,7 +20,9 @@ type Tracer struct {
 	opt    *config
 }
 
-// NewTracer 创建追踪器
+// NewTracer creates a tracer. A provider supplied with WithTracerProvider is
+// scoped to the returned Tracer and does not replace OpenTelemetry's global
+// provider.
 func NewTracer(kind trace.SpanKind, opts ...options.Option) *Tracer {
 	cfg := config{
 		propagator: propagation.NewCompositeTextMapPropagator(Metadata{}, propagation.Baggage{}, propagation.TraceContext{}),
@@ -28,15 +30,16 @@ func NewTracer(kind trace.SpanKind, opts ...options.Option) *Tracer {
 	for _, o := range opts {
 		o(&cfg)
 	}
-	if cfg.tracerProvider != nil {
-		otel.SetTracerProvider(cfg.tracerProvider)
+	provider := cfg.tracerProvider
+	if provider == nil {
+		provider = otel.GetTracerProvider()
 	}
 
 	switch kind {
 	case trace.SpanKindClient:
-		return &Tracer{tracer: otel.Tracer("gkit"), kind: kind, opt: &cfg}
+		return &Tracer{tracer: provider.Tracer("gkit"), kind: kind, opt: &cfg}
 	case trace.SpanKindServer:
-		return &Tracer{tracer: otel.Tracer("gkit"), kind: kind, opt: &cfg}
+		return &Tracer{tracer: provider.Tracer("gkit"), kind: kind, opt: &cfg}
 	default:
 		panic(fmt.Sprintf("unsupported span kind: %v", kind))
 	}


### PR DESCRIPTION
## What

- keep `WithTracerProvider` scoped to the returned gkit tracer
- preserve the existing OpenTelemetry global provider during construction
- document the local provider contract

## Why

`NewTracer` called `otel.SetTracerProvider` whenever a provider option was supplied. Constructing one middleware or tracer therefore changed process-wide tracing behavior for unrelated instrumentation.

## How

- obtain the `gkit` tracer directly from the configured provider
- fall back to the current global provider only when no provider is supplied
- verify provider ownership without writing OpenTelemetry global state in the test

## Tests

- `go test ./trace -run ^'TestNewTracerWithProviderDoesNotReplaceGlobalProvider$' -count=100`
- `go test ./trace -count=1`
- `go test -race ./trace -count=10`
- `go vet ./trace`
- `git diff --check`
- mutation check: restoring `otel.SetTracerProvider` makes the focused regression fail