### PR TITLE
fix(mongodb): preserve task retention timestamps

### DIFF
--- a/distributed/backend/backend_mongodb/mongo.go
+++ b/distributed/backend/backend_mongodb/mongo.go
@@ -131,11 +131,10 @@ func (b *BackendMongoDB) TriggerCompleted(groupID string) (bool, error) {
 
 func (b *BackendMongoDB) SetStatePending(signature *task.Signature) error {
 	update := bson.M{
-		"_id":       signature.ID,
-		"status":    task.StatePending,
-		"group_id":  signature.GroupID,
-		"name":      signature.Name,
-		"create_at": time.Now().Local(),
+		"_id":      signature.ID,
+		"status":   task.StatePending,
+		"group_id": signature.GroupID,
+		"name":     signature.Name,
 	}
 	return b.updateStatus(signature, update)
 }
@@ -211,10 +210,19 @@ func (b *BackendMongoDB) ResetGroup(groupIDs ...string) error {
 
 // updateStatus 更新状态
 func (b *BackendMongoDB) updateStatus(signature *task.Signature, update bson.M) error {
-	update = bson.M{"$set": update}
+	update = buildTaskStatusUpdate(update, time.Now().Local())
 	query := bson.M{"_id": signature.ID}
 	_, err := b.taskTable.UpdateOne(context.Background(), query, update, moption.Update().SetUpsert(true))
 	return err
+}
+
+func buildTaskStatusUpdate(fields bson.M, createAt time.Time) bson.M {
+	return bson.M{
+		"$set": fields,
+		"$setOnInsert": bson.M{
+			"create_at": createAt,
+		},
+	}
 }
 
 func normalizeResultExpire(expire int64) int64 {

--- a/distributed/backend/backend_mongodb/retention_integration_test.go
+++ b/distributed/backend/backend_mongodb/retention_integration_test.go
@@ -1,0 +1,108 @@
+package backend_mongodb
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/songzhibin97/gkit/distributed/task"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	moption "go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func TestMongoTaskRetentionMetadata(t *testing.T) {
+	uri := os.Getenv("GKIT_MONGODB_URI")
+	if uri == "" {
+		t.Skip("GKIT_MONGODB_URI is not set")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	client, err := mongo.Connect(ctx, moption.Client().ApplyURI(uri))
+	if err != nil {
+		t.Fatal(err)
+	}
+	databaseName := fmt.Sprintf("gkit_retention_%d", time.Now().UnixNano())
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cleanupCancel()
+		if err := client.Database(databaseName).Drop(cleanupCtx); err != nil {
+			t.Errorf("drop test database: %v", err)
+		}
+		if err := client.Disconnect(cleanupCtx); err != nil {
+			t.Errorf("disconnect MongoDB client: %v", err)
+		}
+	})
+
+	const expireSeconds int32 = 600
+	backend, err := NewBackendMongoDBE(
+		client,
+		int64(expireSeconds),
+		SetDatabaseName(databaseName),
+		SetTableTaskName("tasks"),
+		SetTableGroupName("groups"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := backend.(*BackendMongoDB)
+	assertStoredTTLIndex(t, ctx, b.taskTable, taskTTLIndexName, expireSeconds)
+	assertStoredTTLIndex(t, ctx, b.groupTable, groupTTLIndexName, expireSeconds)
+
+	signature := &task.Signature{ID: "task-retention", GroupID: "group-retention", Name: "retention"}
+	if err := b.SetStateStarted(signature); err != nil {
+		t.Fatal(err)
+	}
+	status, err := b.GetStatus(signature.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.CreateAt.IsZero() {
+		t.Fatal("non-pending upsert stored a zero create_at, so the TTL index cannot expire it")
+	}
+
+	fixedCreateAt := time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC)
+	if _, err := b.taskTable.UpdateOne(ctx, bson.M{"_id": signature.ID}, bson.M{"$set": bson.M{"create_at": fixedCreateAt}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.SetStatePending(signature); err != nil {
+		t.Fatal(err)
+	}
+	status, err = b.GetStatus(signature.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !status.CreateAt.Equal(fixedCreateAt) {
+		t.Fatalf("existing task create_at = %v, want original creation time %v", status.CreateAt, fixedCreateAt)
+	}
+}
+
+func assertStoredTTLIndex(t *testing.T, ctx context.Context, collection *mongo.Collection, name string, expireSeconds int32) {
+	t.Helper()
+	specifications, err := collection.Indexes().ListSpecifications(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, specification := range specifications {
+		if specification.Name != name {
+			continue
+		}
+		var keys bson.D
+		if err := bson.Unmarshal(specification.KeysDocument, &keys); err != nil {
+			t.Fatal(err)
+		}
+		wantKeys := bson.D{{Key: "create_at", Value: int32(1)}}
+		if !reflect.DeepEqual(keys, wantKeys) {
+			t.Fatalf("TTL index %q keys = %#v, want %#v", name, keys, wantKeys)
+		}
+		if specification.ExpireAfterSeconds == nil || *specification.ExpireAfterSeconds != expireSeconds {
+			t.Fatalf("TTL index %q expiration = %v, want %d", name, specification.ExpireAfterSeconds, expireSeconds)
+		}
+		return
+	}
+	t.Fatalf("TTL index %q was not created", name)
+}

--- a/distributed/backend/backend_mongodb/retention_test.go
+++ b/distributed/backend/backend_mongodb/retention_test.go
@@ -1,0 +1,34 @@
+package backend_mongodb
+
+import (
+	"testing"
+	"time"
+
+	"github.com/songzhibin97/gkit/distributed/task"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func TestBuildTaskStatusUpdateSetsCreateAtOnlyOnInsert(t *testing.T) {
+	createdAt := time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC)
+	fields := bson.M{"status": task.StateStarted}
+	update := buildTaskStatusUpdate(fields, createdAt)
+
+	setFields, ok := update["$set"].(bson.M)
+	if !ok {
+		t.Fatalf("$set = %#v, want bson.M", update["$set"])
+	}
+	if setFields["status"] != task.StateStarted {
+		t.Fatalf("$set status = %#v, want %v", setFields["status"], task.StateStarted)
+	}
+	if _, ok := setFields["create_at"]; ok {
+		t.Fatalf("$set unexpectedly refreshes create_at: %#v", setFields)
+	}
+
+	setOnInsert, ok := update["$setOnInsert"].(bson.M)
+	if !ok {
+		t.Fatalf("$setOnInsert = %#v, want bson.M", update["$setOnInsert"])
+	}
+	if got, ok := setOnInsert["create_at"].(time.Time); !ok || !got.Equal(createdAt) {
+		t.Fatalf("$setOnInsert create_at = %#v, want %v", setOnInsert["create_at"], createdAt)
+	}
+}


### PR DESCRIPTION
## What

- write MongoDB task `create_at` only when a status document is first inserted
- preserve the original creation timestamp across later lifecycle updates
- add offline update-shape and isolated live Mongo retention regressions
- align the issue 79 product and technical specs with the stored-value contract

## Why

Only the pending-state path wrote `create_at`, and it wrote the field through `$set`. A non-pending state used as the first upsert therefore had no TTL timestamp, while a later pending update refreshed the timestamp and extended retention.

## How

- place `create_at` in `$setOnInsert` for every task status upsert
- keep mutable state fields in `$set`
- verify the actual task/group TTL index metadata and stored timestamps without waiting for the MongoDB TTL monitor

## Tests

- `go test ./distributed/backend/backend_mongodb -count=1`
- `GKIT_MONGODB_URI=<isolated-mongo> go test -race ./distributed/backend/backend_mongodb -count=10`
- `go vet ./distributed/backend/backend_mongodb`
- `git diff --check`
- mutation checks: removing `$setOnInsert` loses the initial timestamp; moving `create_at` into `$set` refreshes the stored timestamp

The separate cursor iteration error candidate is intentionally excluded from this atomic retention change.