### PR TITLE
fix(backend_db): preserve task IDs containing commas

### DIFF
--- a/distributed/backend/backend_db/COMPATIBILITY.md
+++ b/distributed/backend/backend_db/COMPATIBILITY.md
@@ -1,0 +1,46 @@
+# SQL group task ID encoding compatibility
+
+Reconciled against `distributed/task/group.go` and the SQL backend tests on
+2026-07-11.
+
+`GroupMeta.TaskIDs` is stored in the SQL `group_meta.task_ids` `TEXT` column.
+Historical rows use a comma-joined representation and are still read by
+splitting on commas. New writes whose task IDs are comma-free and whose joined
+bytes do not begin with the reserved marker keep those exact legacy bytes so
+ordinary traffic remains readable during a rolling upgrade.
+
+When any task ID contains a comma, or the legacy bytes would begin with the
+reserved `gkit:string-slice:v1:` marker, new writers store that marker followed
+by a JSON array of strings. Versioned reads require an array whose every element
+is a JSON string. Malformed JSON, `null`, objects, numbers, and null elements are
+reported as scan errors instead of being reinterpreted as legacy data.
+
+## Upgrade boundary
+
+The marker is a reserved namespace, not a collision-proof discriminator. A
+single existing `TEXT` column cannot distinguish a historical task ID whose raw
+legacy value begins with `gkit:string-slice:v1:` from a new versioned value.
+Before deploying readers with this format, scan existing rows:
+
+```sql
+SELECT _id, id, task_ids
+FROM group_meta
+WHERE task_ids LIKE 'gkit:string-slice:v1:%';
+```
+
+For every match, recover the intended task ID list from an authoritative source
+or backup and rewrite it as the versioned marker plus a JSON string array. An
+invalid suffix will fail reads after upgrade; a suffix that is already a valid
+JSON string array will be interpreted as versioned data. The compatibility test
+`TestSQLGroupHistoricalMarkerRowsFollowReservedNamespace` pins both outcomes.
+
+Historical comma-containing task IDs are also not recoverable automatically:
+the old encoding maps multiple distinct ID lists to the same bytes. Do not guess
+boundaries or bulk-split those rows as a repair. Reconstruct each affected list
+from authoritative data and write the versioned representation.
+
+No SQL schema migration is required. The scanner accepts `NULL`, `string`, and
+`[]byte` driver values; ordinary historical comma-separated rows remain
+readable. Old binaries cannot decode newly versioned comma-containing or
+marker-prefixed rows, so do not submit those exceptional IDs until every SQL
+backend process runs the new reader.

--- a/distributed/backend/backend_db/id_encoding_test.go
+++ b/distributed/backend/backend_db/id_encoding_test.go
@@ -1,0 +1,121 @@
+package backend_db
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/songzhibin97/gkit/distributed/task"
+)
+
+const reservedStringSlicePrefix = "gkit:string-slice:v1:"
+
+func TestSQLGroupCommaTaskIDsRoundTripWithoutFalseCompletion(t *testing.T) {
+	b := newSQLiteBackend(t)
+	groupID := "group,one"
+	wantTaskIDs := []string{"task,one", "task-two"}
+	if err := b.GroupTakeOver(groupID, "group", wantTaskIDs...); err != nil {
+		t.Fatalf("GroupTakeOver: %v", err)
+	}
+
+	group, err := b.getGroup(groupID)
+	if err != nil {
+		t.Fatalf("getGroup: %v", err)
+	}
+	if !reflect.DeepEqual([]string(group.TaskIDs), wantTaskIDs) {
+		t.Fatalf("task IDs = %#v, want %#v", group.TaskIDs, wantTaskIDs)
+	}
+
+	for _, id := range []string{"task", "one", "task-two"} {
+		if err := b.SetStateSuccess(&task.Signature{ID: id, GroupID: groupID, Name: id}, nil); err != nil {
+			t.Fatalf("SetStateSuccess(%q): %v", id, err)
+		}
+	}
+	completed, err := b.GroupCompleted(groupID)
+	if err != nil {
+		t.Fatalf("GroupCompleted: %v", err)
+	}
+	if completed {
+		t.Fatal("group completed from statuses belonging to comma-split task IDs")
+	}
+
+	if err := b.SetStateSuccess(&task.Signature{ID: "task,one", GroupID: groupID, Name: "task,one"}, nil); err != nil {
+		t.Fatalf("SetStateSuccess(comma ID): %v", err)
+	}
+	completed, err = b.GroupCompleted(groupID)
+	if err != nil {
+		t.Fatalf("GroupCompleted after intended statuses: %v", err)
+	}
+	if !completed {
+		t.Fatal("group did not complete after both intended task IDs completed")
+	}
+}
+
+func TestSQLGroupReadsLegacyTaskIDsAndPreservesOrdinaryWrites(t *testing.T) {
+	b := newSQLiteBackend(t)
+	legacyGroupID := "legacy,group"
+	if err := b.gClient.Exec(
+		"INSERT INTO group_meta (id, name, task_ids, trigger_chord, lock, ttl, create_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+		legacyGroupID, "legacy", "legacy-a,legacy-b", false, false, -1, time.Now(),
+	).Error; err != nil {
+		t.Fatalf("insert legacy group: %v", err)
+	}
+	group, err := b.getGroup(legacyGroupID)
+	if err != nil {
+		t.Fatalf("get legacy group: %v", err)
+	}
+	wantLegacy := []string{"legacy-a", "legacy-b"}
+	if !reflect.DeepEqual([]string(group.TaskIDs), wantLegacy) {
+		t.Fatalf("legacy task IDs = %#v, want %#v", group.TaskIDs, wantLegacy)
+	}
+
+	ordinaryGroupID := "ordinary,group"
+	if err := b.GroupTakeOver(ordinaryGroupID, "ordinary", "task-a", "task-b"); err != nil {
+		t.Fatalf("GroupTakeOver ordinary: %v", err)
+	}
+	var raw string
+	if err := b.gClient.Model(&task.GroupMeta{}).
+		Select("task_ids").
+		Where("id = ?", ordinaryGroupID).
+		Scan(&raw).Error; err != nil {
+		t.Fatalf("read raw task_ids: %v", err)
+	}
+	if raw != "task-a,task-b" {
+		t.Fatalf("ordinary task_ids bytes = %q, want legacy encoding %q", raw, "task-a,task-b")
+	}
+}
+
+// TestSQLGroupHistoricalMarkerRowsFollowReservedNamespace documents the
+// unavoidable compatibility boundary: a historical legacy value beginning
+// with the reserved prefix cannot be distinguished from a versioned value in
+// the same TEXT column. Upgrade tooling must migrate such rows before rollout.
+func TestSQLGroupHistoricalMarkerRowsFollowReservedNamespace(t *testing.T) {
+	b := newSQLiteBackend(t)
+	insertRaw := func(groupID, taskIDs string) {
+		t.Helper()
+		if err := b.gClient.Exec(
+			"INSERT INTO group_meta (id, name, task_ids, trigger_chord, lock, ttl, create_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+			groupID, "legacy", taskIDs, false, false, -1, time.Now(),
+		).Error; err != nil {
+			t.Fatalf("insert raw group %q: %v", groupID, err)
+		}
+	}
+
+	insertRaw("historical-marker-invalid", reservedStringSlicePrefix+"legacy-task")
+	if _, err := b.getGroup("historical-marker-invalid"); err == nil {
+		t.Fatal("invalid historical marker row was silently accepted")
+	} else if !strings.Contains(err.Error(), "invalid versioned payload") {
+		t.Fatalf("invalid historical marker error = %v, want invalid versioned payload", err)
+	}
+
+	insertRaw("historical-marker-valid", reservedStringSlicePrefix+`["decoded-as-versioned"]`)
+	group, err := b.getGroup("historical-marker-valid")
+	if err != nil {
+		t.Fatalf("get valid-looking historical marker row: %v", err)
+	}
+	want := []string{"decoded-as-versioned"}
+	if !reflect.DeepEqual([]string(group.TaskIDs), want) {
+		t.Fatalf("valid-looking historical marker row = %#v, want versioned interpretation %#v", group.TaskIDs, want)
+	}
+}

--- a/distributed/task/group.go
+++ b/distributed/task/group.go
@@ -2,7 +2,9 @@ package task
 
 import (
 	"database/sql/driver"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -11,12 +13,50 @@ import (
 
 type StringSlice []string
 
+// stringSliceJSONPrefix reserves a namespace in the task_ids TEXT column for
+// versioned values. Deployments must migrate historical rows beginning with
+// this prefix before upgrading; the same column cannot distinguish those rows
+// from versioned data. See backend_db/COMPATIBILITY.md.
+const stringSliceJSONPrefix = "gkit:string-slice:v1:"
+
 func (s *StringSlice) Scan(src interface{}) error {
-	str, ok := src.([]byte)
-	if !ok {
+	var raw string
+	switch value := src.(type) {
+	case nil:
+		*s = nil
+		return nil
+	case string:
+		raw = value
+	case []byte:
+		raw = string(value)
+	default:
 		return errors.New("failed to scan StringSlice field - source is not a string")
 	}
-	*s = strings.Split(string(str), ",")
+	if strings.HasPrefix(raw, stringSliceJSONPrefix) {
+		var elements []json.RawMessage
+		if err := json.Unmarshal([]byte(strings.TrimPrefix(raw, stringSliceJSONPrefix)), &elements); err != nil {
+			return fmt.Errorf("failed to scan StringSlice field - invalid versioned payload: %w", err)
+		}
+		if elements == nil {
+			return errors.New("failed to scan StringSlice field - invalid versioned payload: null")
+		}
+		decoded := make([]string, len(elements))
+		for index, element := range elements {
+			var value *string
+			if err := json.Unmarshal(element, &value); err != nil {
+				return fmt.Errorf("failed to scan StringSlice field - invalid element %d: %w", index, err)
+			}
+			if value == nil {
+				return fmt.Errorf("failed to scan StringSlice field - invalid element %d: null", index)
+			}
+			decoded[index] = *value
+		}
+		*s = decoded
+		return nil
+	}
+	// Historical rows used comma joining. IDs containing commas in those rows
+	// are already ambiguous and cannot be reconstructed without guessing.
+	*s = strings.Split(raw, ",")
 	return nil
 }
 
@@ -24,7 +64,24 @@ func (s StringSlice) Value() (driver.Value, error) {
 	if s == nil || len(s) == 0 {
 		return nil, nil
 	}
-	return strings.Join(s, ","), nil
+	legacy := strings.Join(s, ",")
+	needsVersionedEncoding := strings.HasPrefix(legacy, stringSliceJSONPrefix)
+	if !needsVersionedEncoding {
+		for _, value := range s {
+			if strings.Contains(value, ",") {
+				needsVersionedEncoding = true
+				break
+			}
+		}
+	}
+	if !needsVersionedEncoding {
+		return legacy, nil
+	}
+	encoded, err := json.Marshal([]string(s))
+	if err != nil {
+		return nil, err
+	}
+	return stringSliceJSONPrefix + string(encoded), nil
 }
 
 // GroupMeta 组详情

--- a/distributed/task/group_encoding_test.go
+++ b/distributed/task/group_encoding_test.go
@@ -1,0 +1,89 @@
+package task
+
+import (
+	"reflect"
+	"testing"
+)
+
+const testStringSliceJSONPrefix = "gkit:string-slice:v1:"
+
+func TestStringSliceValuePreservesLegacyEncodingForOrdinaryIDs(t *testing.T) {
+	got, err := (StringSlice{"task-a", "task-b"}).Value()
+	if err != nil {
+		t.Fatalf("Value: %v", err)
+	}
+	if got != "task-a,task-b" {
+		t.Fatalf("Value = %#v, want legacy bytes %q", got, "task-a,task-b")
+	}
+}
+
+func TestStringSliceVersionedRoundTripForCommaID(t *testing.T) {
+	want := StringSlice{"task,one", "task-two"}
+	encoded, err := want.Value()
+	if err != nil {
+		t.Fatalf("Value: %v", err)
+	}
+	if encoded != testStringSliceJSONPrefix+`["task,one","task-two"]` {
+		t.Fatalf("Value = %#v, want versioned JSON", encoded)
+	}
+
+	var got StringSlice
+	if err := got.Scan(encoded); err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("round trip = %#v, want %#v", got, want)
+	}
+}
+
+func TestStringSliceVersionedRoundTripForMarkerCollision(t *testing.T) {
+	want := StringSlice{testStringSliceJSONPrefix + `["literal"]`}
+	encoded, err := want.Value()
+	if err != nil {
+		t.Fatalf("Value: %v", err)
+	}
+	if encoded == want[0] {
+		t.Fatal("marker-looking legacy value was not escaped into the versioned format")
+	}
+
+	var got StringSlice
+	if err := got.Scan(encoded); err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("round trip = %#v, want %#v", got, want)
+	}
+}
+
+func TestStringSliceScanLegacyDriverRepresentations(t *testing.T) {
+	for _, src := range []interface{}{[]byte("task-a,task-b"), "task-a,task-b"} {
+		var got StringSlice
+		if err := got.Scan(src); err != nil {
+			t.Fatalf("Scan(%T): %v", src, err)
+		}
+		want := StringSlice{"task-a", "task-b"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("Scan(%T) = %#v, want %#v", src, got, want)
+		}
+	}
+
+	got := StringSlice{"stale"}
+	if err := got.Scan(nil); err != nil {
+		t.Fatalf("Scan(nil): %v", err)
+	}
+	if got != nil {
+		t.Fatalf("Scan(nil) = %#v, want nil", got)
+	}
+}
+
+func TestStringSliceScanRejectsMalformedVersionedPayload(t *testing.T) {
+	for _, payload := range []string{`{`, `null`, `{}`, `"task"`, `[null]`, `["ok",null]`, `[1]`} {
+		got := StringSlice{"unchanged"}
+		if err := got.Scan(testStringSliceJSONPrefix + payload); err == nil {
+			t.Fatalf("Scan accepted invalid versioned payload %q", payload)
+		}
+		if !reflect.DeepEqual(got, StringSlice{"unchanged"}) {
+			t.Fatalf("failed Scan(%q) mutated receiver to %#v", payload, got)
+		}
+	}
+}


### PR DESCRIPTION
## What
- preserve SQL group task IDs containing commas with a versioned JSON-array encoding
- keep ordinary comma-free writes byte-compatible with the historical comma format
- accept NULL, string, and byte driver values while strictly rejecting malformed or non-string versioned elements
- add SQLite/MySQL regressions and an operator compatibility guide

## Why
The legacy comma join/split format is not reversible. A task ID such as `task,one` was read as two IDs, allowing unrelated split-ID status rows to make `GroupCompleted` return true.

## How
Only ambiguous task-ID slices or marker collisions use `gkit:string-slice:v1:` followed by a JSON string array. All ordinary writes retain the old bytes, and unmarked historical rows retain the old read path.

## Upgrade compatibility
- `gkit:string-slice:v1:` is a reserved namespace, not a collision-proof discriminator.
- Before rollout, scan `group_meta.task_ids` for `LIKE 'gkit:string-slice:v1:%'` and migrate every match from an authoritative source or backup.
- Historical task IDs already stored with commas are irreversibly ambiguous in the legacy bytes and must not be repaired by guessing boundaries.
- Old binaries cannot decode newly versioned exceptional IDs; do not submit comma-containing or marker-prefixed IDs until every SQL backend process runs the new reader.
- See `distributed/backend/backend_db/COMPATIBILITY.md` for the exact procedure and failure behavior.

## Tests
- `go test -race ./distributed/task ./distributed/backend/backend_db -count=10`
- `go vet ./distributed/...`
- isolated MySQL 8 round-trip and false-completion verification
- SQLite raw legacy and reserved-marker compatibility coverage
- seven mutation checks, including permissive null-element decoding
- clean combined race/vet verification with PR #99 and PR #106 independently