### PR TITLE
fix(lscq): align arm64 assembly labels with declarations

### DIFF
--- a/structure/lscq/asm_arm64.s
+++ b/structure/lscq/asm_arm64.s
@@ -16,7 +16,7 @@ TEXT ·compareAndSwapUint128(SB), NOSPLIT, $0-41
 	BNE 	ok
 	CMP 	R3, R7
 	CSET	EQ, R0
-	MOVB	R0, ret+40(FP)
+	MOVB	R0, swapped+40(FP)
 	RET
 load_store_loop:
 	LDAXP	(R0), (R6, R7)
@@ -28,28 +28,28 @@ load_store_loop:
 	CBNZ	R6, load_store_loop
 ok:
 	CSET	EQ, R0
-	MOVB	R0, ret+40(FP)
+	MOVB	R0, swapped+40(FP)
 	RET
 
 TEXT ·loadUint128(SB),NOSPLIT,$0-24
-	MOVD	ptr+0(FP), R0
+	MOVD	addr+0(FP), R0
 	LDAXP	(R0), (R0, R1)
-	MOVD	R0, ret+8(FP)
-	MOVD	R1, ret+16(FP)
+	MOVD	R0, val_0+8(FP)
+	MOVD	R1, val_1+16(FP)
 	RET
 
 TEXT ·loadSCQNodeUint64(SB),NOSPLIT,$0
-	MOVD	ptr+0(FP), R0
+	MOVD	addr+0(FP), R0
 	LDAXP	(R0), (R0, R1)
-	MOVD	R0, ret+8(FP)
-	MOVD	R1, ret+16(FP)
+	MOVD	R0, val_flags+8(FP)
+	MOVD	R1, val_data+16(FP)
 	RET
 
 TEXT ·loadSCQNodePointer(SB),NOSPLIT,$0
-	MOVD	ptr+0(FP), R0
+	MOVD	addr+0(FP), R0
 	LDAXP	(R0), (R0, R1)
-	MOVD	R0, ret+8(FP)
-	MOVD	R1, ret+16(FP)
+	MOVD	R0, val_flags+8(FP)
+	MOVD	R1, val_data+16(FP)
 	RET
 
 TEXT ·atomicTestAndSetFirstBit(SB),NOSPLIT,$0


### PR DESCRIPTION
## What
- align arm64 assembly FP labels with the parameter and result names in the Go declarations
- fix all 11 arm64 `asmdecl` diagnostics from `go vet`

## Why
The arm64 package built and ran correctly, but `go vet ./structure/lscq` failed because symbolic labels such as `ptr` and `ret` did not match declaration names such as `addr`, `swapped`, and `val_*`.

## How
This is a quality-gate-only change. It renames symbolic FP labels without changing offsets, instructions, frame sizes, atomic ordering, write barriers, API behavior, or queue logic.

## Machine-code evidence
Pre-fix and post-fix `go tool objdump` output for all four affected arm64 functions is identical. The reverse mutation restores the exact 11 vet failures.

## Tests
- native Darwin/arm64 `go vet ./structure/lscq`
- native Darwin/arm64 `go test ./structure/lscq -count=10`
- native Darwin/arm64 `go test -race ./structure/lscq -count=10`
- Linux arm64 and amd64 cross vet plus `go test -c`
- Darwin amd64 vet, compile, test, and race under Rosetta