### PR TITLE
fix(backend_db): enforce result expiration on access

### DIFF
--- a/distributed/backend/backend_db/db.go
+++ b/distributed/backend/backend_db/db.go
@@ -111,7 +111,7 @@ func (b *BackendSQLDB) getTaskStatus(taskIDs []string) ([]*task.Status, error) {
 		if deleted {
 			continue
 		}
-		if isSQLRecordExpired(status.CreateAt, status.TTL, now) {
+		if b.isStatusExpired(status, now) {
 			current, err := b.GetStatus(status.TaskID)
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				continue
@@ -210,7 +210,7 @@ func (b *BackendSQLDB) GetStatus(taskID string) (*task.Status, error) {
 		if deleted {
 			return nil, gorm.ErrRecordNotFound
 		}
-		if !isSQLRecordExpired(status.CreateAt, status.TTL, now) {
+		if !b.isStatusExpired(&status, now) {
 			return &status, nil
 		}
 	}
@@ -262,6 +262,17 @@ func isSQLRecordExpired(createdAt time.Time, ttl int64, now time.Time) bool {
 	return !now.Before(expiresAt)
 }
 
+func (b *BackendSQLDB) isStatusExpired(status *task.Status, now time.Time) bool {
+	ttl := status.TTL
+	if ttl == 0 {
+		// Status rows written before TTL persistence was introduced have zero in
+		// the database. Apply the configured retention on read instead of
+		// silently treating every legacy row as having the one-hour default.
+		ttl = b.configuredResultExpire()
+	}
+	return isSQLRecordExpired(status.CreateAt, ttl, now)
+}
+
 func (b *BackendSQLDB) deleteExpiredStatusByTaskID(taskID string, now time.Time) error {
 	var status task.Status
 	result := b.gClient.Select("_id", "id", "ttl", "create_at").Where("id = ?", taskID).Limit(1).Find(&status)
@@ -276,7 +287,7 @@ func (b *BackendSQLDB) deleteExpiredStatusByTaskID(taskID string, now time.Time)
 }
 
 func (b *BackendSQLDB) deleteExpiredStatusSnapshot(status *task.Status, now time.Time) (bool, error) {
-	if status == nil || !isSQLRecordExpired(status.CreateAt, status.TTL, now) {
+	if status == nil || !b.isStatusExpired(status, now) {
 		return false, nil
 	}
 	result := b.gClient.Unscoped().Where("_id = ? AND id = ?", status.ID, status.TaskID).Delete(&task.Status{})

--- a/distributed/backend/backend_db/db.go
+++ b/distributed/backend/backend_db/db.go
@@ -2,8 +2,11 @@ package backend_db
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
+	"math"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/songzhibin97/gkit/distributed/task"
@@ -16,6 +19,11 @@ import (
 	"github.com/songzhibin97/gkit/distributed/backend"
 )
 
+const (
+	defaultSQLResultExpireSeconds int64 = 3600
+	expiryReadRetryLimit                = 8
+)
+
 // BackendSQLDB 支持mysql&pgsql
 type BackendSQLDB struct {
 	// gClient db客户端
@@ -24,16 +32,25 @@ type BackendSQLDB struct {
 	// -1 代表永不过期
 	// 0 会设置默认过期时间
 	// 单位为s
-	resultExpire int64
+	resultExpireMu sync.RWMutex
+	resultExpire   int64
+	now            func() time.Time
 }
 
 // SetResultExpire 设置结果超时时间
 func (b *BackendSQLDB) SetResultExpire(expire int64) {
-	b.resultExpire = expire
+	b.resultExpireMu.Lock()
+	b.resultExpire = normalizeSQLResultExpire(expire)
+	b.resultExpireMu.Unlock()
 }
 
 func (b *BackendSQLDB) GroupTakeOver(groupID string, name string, taskIDs ...string) error {
-	group := task.InitGroupMeta(groupID, name, b.resultExpire, taskIDs...)
+	now := b.currentTime()
+	if err := b.deleteExpiredGroupsByID(groupID, now); err != nil {
+		return err
+	}
+	group := task.InitGroupMeta(groupID, name, b.configuredResultExpire(), taskIDs...)
+	group.CreateAt = now
 	return b.gClient.Create(group).Error
 }
 
@@ -57,12 +74,25 @@ func (b *BackendSQLDB) GroupCompleted(groupID string) (bool, error) {
 }
 
 func (b *BackendSQLDB) getGroup(groupID string) (*task.GroupMeta, error) {
-	var group task.GroupMeta
-	err := b.gClient.Model(&task.GroupMeta{}).Where("id = ?", groupID).First(&group).Error
-	if err != nil {
-		return nil, err
+	for attempt := 0; attempt < expiryReadRetryLimit; attempt++ {
+		var group task.GroupMeta
+		err := b.gClient.Model(&task.GroupMeta{}).Where("id = ?", groupID).First(&group).Error
+		if err != nil {
+			return nil, err
+		}
+		now := b.currentTime()
+		deleted, err := b.deleteExpiredGroupSnapshot(&group, now)
+		if err != nil {
+			return nil, err
+		}
+		if deleted {
+			return nil, gorm.ErrRecordNotFound
+		}
+		if !isSQLRecordExpired(group.CreateAt, group.TTL, now) {
+			return &group, nil
+		}
 	}
-	return &group, nil
+	return nil, fmt.Errorf("backend_db: group %q changed during expiry cleanup", groupID)
 }
 
 func (b *BackendSQLDB) getTaskStatus(taskIDs []string) ([]*task.Status, error) {
@@ -71,7 +101,30 @@ func (b *BackendSQLDB) getTaskStatus(taskIDs []string) ([]*task.Status, error) {
 	if err != nil {
 		return nil, err
 	}
-	return statusList, nil
+	live := make([]*task.Status, 0, len(statusList))
+	now := b.currentTime()
+	for _, status := range statusList {
+		deleted, err := b.deleteExpiredStatusSnapshot(status, now)
+		if err != nil {
+			return nil, err
+		}
+		if deleted {
+			continue
+		}
+		if isSQLRecordExpired(status.CreateAt, status.TTL, now) {
+			current, err := b.GetStatus(status.TaskID)
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				continue
+			}
+			if err != nil {
+				return nil, err
+			}
+			live = append(live, current)
+			continue
+		}
+		live = append(live, status)
+	}
+	return live, nil
 }
 
 func (b *BackendSQLDB) GroupTaskStatus(groupID string) ([]*task.Status, error) {
@@ -83,7 +136,11 @@ func (b *BackendSQLDB) GroupTaskStatus(groupID string) ([]*task.Status, error) {
 }
 
 func (b *BackendSQLDB) TriggerCompleted(groupID string) (bool, error) {
-	result := b.gClient.Model(&task.GroupMeta{}).Where(map[string]interface{}{"id": groupID, "lock": false}).Update("lock", true)
+	group, err := b.getGroup(groupID)
+	if err != nil {
+		return false, err
+	}
+	result := b.gClient.Model(&task.GroupMeta{}).Where(map[string]interface{}{"_id": group.ID, "lock": false}).Update("lock", true)
 	if result.Error != nil {
 		return false, result.Error
 	}
@@ -97,6 +154,9 @@ func (b *BackendSQLDB) TriggerCompleted(groupID string) (bool, error) {
 // RecordNotFound and both Create, hitting a unique-key violation; or
 // Update could run on a row deleted between SELECT and UPDATE.
 func (b *BackendSQLDB) upsertStatus(s *task.Status, updateColumns []string) error {
+	if err := b.deleteExpiredStatusByTaskID(s.TaskID, s.CreateAt); err != nil {
+		return err
+	}
 	// Conflict target is the DB column TaskID maps to (`id`, uniqueIndex), NOT
 	// the field name. GORM writes the conflict column verbatim, so `task_id`
 	// (no such column) errored on Postgres; and the column must be a UNIQUE
@@ -108,74 +168,146 @@ func (b *BackendSQLDB) upsertStatus(s *task.Status, updateColumns []string) erro
 }
 
 func (b *BackendSQLDB) SetStatePending(signature *task.Signature) error {
-	return b.upsertStatus(&task.Status{
-		TaskID:   signature.ID,
-		GroupID:  signature.GroupID,
-		Name:     signature.Name,
-		Status:   task.StatePending,
-		CreateAt: time.Now(),
-	}, []string{"status"})
+	return b.upsertStatus(b.newStatus(signature, task.StatePending), []string{"status"})
 }
 
 func (b *BackendSQLDB) SetStateReceived(signature *task.Signature) error {
-	return b.upsertStatus(&task.Status{
-		TaskID:   signature.ID,
-		GroupID:  signature.GroupID,
-		Name:     signature.Name,
-		Status:   task.StateReceived,
-		CreateAt: time.Now(),
-	}, []string{"status"})
+	return b.upsertStatus(b.newStatus(signature, task.StateReceived), []string{"status"})
 }
 
 func (b *BackendSQLDB) SetStateStarted(signature *task.Signature) error {
-	return b.upsertStatus(&task.Status{
-		TaskID:   signature.ID,
-		GroupID:  signature.GroupID,
-		Name:     signature.Name,
-		Status:   task.StateStarted,
-		CreateAt: time.Now(),
-	}, []string{"status"})
+	return b.upsertStatus(b.newStatus(signature, task.StateStarted), []string{"status"})
 }
 
 func (b *BackendSQLDB) SetStateRetry(t *task.Signature) error {
-	return b.upsertStatus(&task.Status{
-		TaskID:   t.ID,
-		GroupID:  t.GroupID,
-		Name:     t.Name,
-		Status:   task.StateRetry,
-		CreateAt: time.Now(),
-	}, []string{"status"})
+	return b.upsertStatus(b.newStatus(t, task.StateRetry), []string{"status"})
 }
 
 func (b *BackendSQLDB) SetStateSuccess(signature *task.Signature, results []*task.Result) error {
-	return b.upsertStatus(&task.Status{
-		TaskID:   signature.ID,
-		GroupID:  signature.GroupID,
-		Name:     signature.Name,
-		Status:   task.StateSuccess,
-		Results:  task.Results(results),
-		CreateAt: time.Now(),
-	}, []string{"status", "results"})
+	status := b.newStatus(signature, task.StateSuccess)
+	status.Results = task.Results(results)
+	return b.upsertStatus(status, []string{"status", "results"})
 }
 
 func (b *BackendSQLDB) SetStateFailure(signature *task.Signature, err string) error {
-	return b.upsertStatus(&task.Status{
-		TaskID:   signature.ID,
-		GroupID:  signature.GroupID,
-		Name:     signature.Name,
-		Status:   task.StateFailure,
-		Error:    err,
-		CreateAt: time.Now(),
-	}, []string{"status", "error"})
+	status := b.newStatus(signature, task.StateFailure)
+	status.Error = err
+	return b.upsertStatus(status, []string{"status", "error"})
 }
 
 func (b *BackendSQLDB) GetStatus(taskID string) (*task.Status, error) {
-	var status task.Status
-	err := b.gClient.Where("id = ?", taskID).First(&status).Error
-	if err != nil {
-		return nil, err
+	for attempt := 0; attempt < expiryReadRetryLimit; attempt++ {
+		var status task.Status
+		err := b.gClient.Where("id = ?", taskID).First(&status).Error
+		if err != nil {
+			return nil, err
+		}
+		now := b.currentTime()
+		deleted, err := b.deleteExpiredStatusSnapshot(&status, now)
+		if err != nil {
+			return nil, err
+		}
+		if deleted {
+			return nil, gorm.ErrRecordNotFound
+		}
+		if !isSQLRecordExpired(status.CreateAt, status.TTL, now) {
+			return &status, nil
+		}
 	}
-	return &status, nil
+	return nil, fmt.Errorf("backend_db: task %q changed during expiry cleanup", taskID)
+}
+
+func (b *BackendSQLDB) newStatus(signature *task.Signature, state task.State) *task.Status {
+	return &task.Status{
+		TaskID:   signature.ID,
+		GroupID:  signature.GroupID,
+		Name:     signature.Name,
+		Status:   state,
+		TTL:      b.configuredResultExpire(),
+		CreateAt: b.currentTime(),
+	}
+}
+
+func normalizeSQLResultExpire(expire int64) int64 {
+	if expire == 0 {
+		return defaultSQLResultExpireSeconds
+	}
+	return expire
+}
+
+func (b *BackendSQLDB) configuredResultExpire() int64 {
+	b.resultExpireMu.RLock()
+	expire := b.resultExpire
+	b.resultExpireMu.RUnlock()
+	return normalizeSQLResultExpire(expire)
+}
+
+func (b *BackendSQLDB) currentTime() time.Time {
+	if b.now != nil {
+		return b.now()
+	}
+	return time.Now()
+}
+
+func isSQLRecordExpired(createdAt time.Time, ttl int64, now time.Time) bool {
+	ttl = normalizeSQLResultExpire(ttl)
+	if ttl < 0 {
+		return false
+	}
+	createdUnix := createdAt.Unix()
+	if createdUnix > math.MaxInt64-ttl {
+		return false
+	}
+	expiresAt := time.Unix(createdUnix+ttl, int64(createdAt.Nanosecond()))
+	return !now.Before(expiresAt)
+}
+
+func (b *BackendSQLDB) deleteExpiredStatusByTaskID(taskID string, now time.Time) error {
+	var status task.Status
+	result := b.gClient.Select("_id", "id", "ttl", "create_at").Where("id = ?", taskID).Limit(1).Find(&status)
+	if result.Error != nil {
+		return fmt.Errorf("backend_db: inspect task %q for expiry: %w", taskID, result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return nil
+	}
+	_, err := b.deleteExpiredStatusSnapshot(&status, now)
+	return err
+}
+
+func (b *BackendSQLDB) deleteExpiredStatusSnapshot(status *task.Status, now time.Time) (bool, error) {
+	if status == nil || !isSQLRecordExpired(status.CreateAt, status.TTL, now) {
+		return false, nil
+	}
+	result := b.gClient.Unscoped().Where("_id = ? AND id = ?", status.ID, status.TaskID).Delete(&task.Status{})
+	if result.Error != nil {
+		return false, fmt.Errorf("backend_db: delete expired task %q: %w", status.TaskID, result.Error)
+	}
+	return result.RowsAffected != 0, nil
+}
+
+func (b *BackendSQLDB) deleteExpiredGroupsByID(groupID string, now time.Time) error {
+	var groups []*task.GroupMeta
+	if err := b.gClient.Select("_id", "id", "ttl", "create_at").Where("id = ?", groupID).Find(&groups).Error; err != nil {
+		return fmt.Errorf("backend_db: inspect group %q for expiry: %w", groupID, err)
+	}
+	for _, group := range groups {
+		if _, err := b.deleteExpiredGroupSnapshot(group, now); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (b *BackendSQLDB) deleteExpiredGroupSnapshot(group *task.GroupMeta, now time.Time) (bool, error) {
+	if group == nil || !isSQLRecordExpired(group.CreateAt, group.TTL, now) {
+		return false, nil
+	}
+	result := b.gClient.Unscoped().Where("_id = ? AND id = ?", group.ID, group.GroupID).Delete(&task.GroupMeta{})
+	if result.Error != nil {
+		return false, fmt.Errorf("backend_db: delete expired group %q: %w", group.GroupID, result.Error)
+	}
+	return result.RowsAffected != 0, nil
 }
 
 func (b *BackendSQLDB) ResetTask(taskIDs ...string) error {
@@ -244,7 +376,7 @@ func NewBackendSQLDBE(db *sql.DB, resultExpire int64, dbType string, config *gor
 	}
 	b := &BackendSQLDB{
 		gClient:      gdb,
-		resultExpire: resultExpire,
+		resultExpire: normalizeSQLResultExpire(resultExpire),
 	}
 	if err := b.autoMigrate(); err != nil {
 		return nil, fmt.Errorf("backend_db: auto migrate: %w", err)

--- a/distributed/backend/backend_db/result_expire_mysql_test.go
+++ b/distributed/backend/backend_db/result_expire_mysql_test.go
@@ -1,0 +1,109 @@
+package backend_db
+
+import (
+	"database/sql"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/songzhibin97/gkit/distributed/task"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+)
+
+const sqlExpiryMySQLDSNEnv = "GKIT_TEST_MYSQL_DSN"
+
+// These test-only models isolate the expiry contract from PR #99's pending
+// production migration fix. Explicit identifier sizes let MySQL create the
+// indexes while retaining the same table/column layout used by BackendSQLDB.
+type sqlExpiryMySQLStatus struct {
+	ID        uint           `gorm:"column:_id;primaryKey"`
+	TaskID    string         `gorm:"column:id;size:191;uniqueIndex"`
+	GroupID   string         `gorm:"column:group_id"`
+	Name      string         `gorm:"column:name"`
+	Status    task.State     `gorm:"column:status"`
+	TTL       int64          `gorm:"column:ttl"`
+	Error     string         `gorm:"column:error"`
+	Results   task.Results   `gorm:"column:results;type:text"`
+	CreateAt  time.Time      `gorm:"column:create_at"`
+	DeletedAt gorm.DeletedAt `gorm:"column:deleted_at;index"`
+}
+
+func (sqlExpiryMySQLStatus) TableName() string { return "statuses" }
+
+type sqlExpiryMySQLGroup struct {
+	ID               uint             `gorm:"column:_id;primaryKey"`
+	GroupID          string           `gorm:"column:id;size:191;uniqueIndex"`
+	Name             string           `gorm:"column:name"`
+	TaskIDs          task.StringSlice `gorm:"column:task_ids;type:text"`
+	TriggerCompleted bool             `gorm:"column:trigger_chord"`
+	Lock             bool             `gorm:"column:lock"`
+	TTL              int64            `gorm:"column:ttl"`
+	CreateAt         time.Time        `gorm:"column:create_at"`
+	DeletedAt        gorm.DeletedAt   `gorm:"column:deleted_at;index"`
+}
+
+func (sqlExpiryMySQLGroup) TableName() string { return "group_meta" }
+
+func openSQLExpiryMySQL(t *testing.T) *gorm.DB {
+	t.Helper()
+	dsn := os.Getenv(sqlExpiryMySQLDSNEnv)
+	if dsn == "" {
+		t.Skipf("set %s to run the isolated MySQL expiry contract", sqlExpiryMySQLDSNEnv)
+	}
+	sqlDB, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("open MySQL: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	if err := sqlDB.Ping(); err != nil {
+		t.Fatalf("ping MySQL: %v", err)
+	}
+	gdb, err := gorm.Open(mysql.New(mysql.Config{Conn: sqlDB}), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open GORM MySQL: %v", err)
+	}
+	var database string
+	if err := gdb.Raw("SELECT DATABASE()").Scan(&database).Error; err != nil {
+		t.Fatalf("read MySQL database name: %v", err)
+	}
+	if !strings.HasSuffix(strings.ToLower(database), "_test") {
+		t.Fatalf("%s must select an isolated database ending in _test, got %q", sqlExpiryMySQLDSNEnv, database)
+	}
+	if err := gdb.Migrator().DropTable(&task.Status{}, &task.GroupMeta{}); err != nil {
+		t.Fatalf("drop MySQL test tables: %v", err)
+	}
+	t.Cleanup(func() { _ = gdb.Migrator().DropTable(&task.Status{}, &task.GroupMeta{}) })
+	return gdb
+}
+
+func TestSQLResultExpireMySQLGroupStatusContract(t *testing.T) {
+	base := time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC)
+	clock := &sqlExpiryClock{now: base}
+	b := &BackendSQLDB{gClient: openSQLExpiryMySQL(t), now: clock.Now}
+	b.SetResultExpire(20)
+	if err := b.gClient.AutoMigrate(&sqlExpiryMySQLStatus{}, &sqlExpiryMySQLGroup{}); err != nil {
+		t.Fatalf("create isolated expiry schema: %v", err)
+	}
+	if err := b.GroupTakeOver("group", "group", "member"); err != nil {
+		t.Fatalf("GroupTakeOver: %v", err)
+	}
+	b.SetResultExpire(5)
+	if err := b.SetStatePending(&task.Signature{ID: "member", GroupID: "group", Name: "task"}); err != nil {
+		t.Fatalf("SetStatePending: %v", err)
+	}
+	stored := readStoredStatus(t, b, "member")
+
+	clock.Set(base.Add(5 * time.Second))
+	statuses, err := b.GroupTaskStatus("group")
+	if err != nil {
+		t.Fatalf("GroupTaskStatus: %v", err)
+	}
+	if len(statuses) != 0 {
+		t.Fatalf("statuses = %v, want expired member omitted", statuses)
+	}
+	if count := countUnscopedRows(t, b.gClient, &task.Status{}, "_id = ?", stored.ID); count != 0 {
+		t.Fatalf("physical expired member rows = %d, want 0", count)
+	}
+}

--- a/distributed/backend/backend_db/result_expire_test.go
+++ b/distributed/backend/backend_db/result_expire_test.go
@@ -152,6 +152,69 @@ func TestSQLResultExpireBoundaryAndModes(t *testing.T) {
 	})
 }
 
+func TestSQLResultExpireLegacyZeroStatusUsesConfiguredNeverExpire(t *testing.T) {
+	base := time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC)
+	b, clock := newSQLiteExpiryBackend(t, base, -1)
+	legacy := task.Status{
+		TaskID:   "legacy-never-expire",
+		GroupID:  "group",
+		Name:     "task",
+		Status:   task.StatePending,
+		TTL:      0,
+		CreateAt: base,
+	}
+	if err := b.gClient.Create(&legacy).Error; err != nil {
+		t.Fatalf("insert legacy status: %v", err)
+	}
+
+	clock.Set(base.Add(100 * 365 * 24 * time.Hour))
+	status, err := b.GetStatus(legacy.TaskID)
+	if err != nil || status == nil {
+		t.Fatalf("GetStatus for legacy zero-TTL row with never-expire config = (%v, %v), want live row", status, err)
+	}
+	if count := countUnscopedRows(t, b.gClient, &task.Status{}, "_id = ?", legacy.ID); count != 1 {
+		t.Fatalf("physical legacy rows = %d, want 1", count)
+	}
+}
+
+func TestSQLResultExpireLegacyZeroStatusUsesConfiguredPositiveExpiry(t *testing.T) {
+	base := time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC)
+	b, clock := newSQLiteExpiryBackend(t, base, int64((2*time.Hour)/time.Second))
+	legacy := task.Status{
+		TaskID:   "legacy-positive-expiry",
+		GroupID:  "group",
+		Name:     "task",
+		Status:   task.StatePending,
+		TTL:      0,
+		CreateAt: base,
+	}
+	if err := b.gClient.Create(&legacy).Error; err != nil {
+		t.Fatalf("insert legacy status: %v", err)
+	}
+
+	clock.Set(base.Add(time.Hour))
+	status, err := b.GetStatus(legacy.TaskID)
+	if err != nil || status == nil {
+		t.Fatalf("GetStatus after one hour = (%v, %v), want live legacy row", status, err)
+	}
+	if count := countUnscopedRows(t, b.gClient, &task.Status{}, "_id = ?", legacy.ID); count != 1 {
+		t.Fatalf("physical legacy rows after one hour = %d, want 1", count)
+	}
+
+	clock.Set(base.Add(2*time.Hour - time.Nanosecond))
+	if _, err := b.GetStatus(legacy.TaskID); err != nil {
+		t.Fatalf("GetStatus immediately before configured expiry: %v", err)
+	}
+	clock.Set(base.Add(2 * time.Hour))
+	status, err = b.GetStatus(legacy.TaskID)
+	if !errors.Is(err, gorm.ErrRecordNotFound) || status != nil {
+		t.Fatalf("GetStatus at configured expiry = (%v, %v), want (nil, gorm.ErrRecordNotFound)", status, err)
+	}
+	if count := countUnscopedRows(t, b.gClient, &task.Status{}, "_id = ?", legacy.ID); count != 0 {
+		t.Fatalf("physical legacy rows at configured expiry = %d, want 0", count)
+	}
+}
+
 func TestSQLResultExpireStateTransitionsDoNotRestartRetention(t *testing.T) {
 	base := time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC)
 	b, clock := newSQLiteExpiryBackend(t, base, 10)

--- a/distributed/backend/backend_db/result_expire_test.go
+++ b/distributed/backend/backend_db/result_expire_test.go
@@ -1,0 +1,429 @@
+package backend_db
+
+import (
+	"errors"
+	"math"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/songzhibin97/gkit/distributed/task"
+	"gorm.io/gorm"
+)
+
+type sqlExpiryClock struct {
+	mu  sync.RWMutex
+	now time.Time
+}
+
+func (c *sqlExpiryClock) Now() time.Time {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.now
+}
+
+func (c *sqlExpiryClock) Set(now time.Time) {
+	c.mu.Lock()
+	c.now = now
+	c.mu.Unlock()
+}
+
+func newSQLiteExpiryBackend(t *testing.T, now time.Time, expire int64) (*BackendSQLDB, *sqlExpiryClock) {
+	t.Helper()
+	b := newSQLiteBackend(t)
+	sqlDB, err := b.gClient.DB()
+	if err != nil {
+		t.Fatalf("get sqlite connection: %v", err)
+	}
+	// SQLite :memory: databases are connection-local. Keep this deterministic
+	// when race tests issue concurrent backend calls.
+	sqlDB.SetMaxOpenConns(1)
+	clock := &sqlExpiryClock{now: now}
+	b.now = clock.Now
+	b.SetResultExpire(expire)
+	return b, clock
+}
+
+func countUnscopedRows(t *testing.T, db *gorm.DB, model interface{}, where string, args ...interface{}) int64 {
+	t.Helper()
+	var count int64
+	if err := db.Unscoped().Model(model).Where(where, args...).Count(&count).Error; err != nil {
+		t.Fatalf("count rows: %v", err)
+	}
+	return count
+}
+
+func readStoredStatus(t *testing.T, b *BackendSQLDB, taskID string) task.Status {
+	t.Helper()
+	var status task.Status
+	if err := b.gClient.Where("id = ?", taskID).First(&status).Error; err != nil {
+		t.Fatalf("read stored status: %v", err)
+	}
+	return status
+}
+
+func TestSQLResultExpireBoundaryAndModes(t *testing.T) {
+	base := time.Date(2026, 7, 11, 12, 0, 0, 123, time.UTC)
+	signature := &task.Signature{ID: "task", GroupID: "group", Name: "task"}
+
+	t.Run("positive expires at exact boundary", func(t *testing.T) {
+		b, clock := newSQLiteExpiryBackend(t, base, 10)
+		if err := b.SetStatePending(signature); err != nil {
+			t.Fatalf("SetStatePending: %v", err)
+		}
+		stored := readStoredStatus(t, b, signature.ID)
+		if stored.TTL != 10 || !stored.CreateAt.Equal(base) {
+			t.Fatalf("stored retention = (%d, %v), want (10, %v)", stored.TTL, stored.CreateAt, base)
+		}
+
+		clock.Set(base.Add(10*time.Second - time.Nanosecond))
+		if _, err := b.GetStatus(signature.ID); err != nil {
+			t.Fatalf("GetStatus immediately before expiry: %v", err)
+		}
+		clock.Set(base.Add(10 * time.Second))
+		status, err := b.GetStatus(signature.ID)
+		if !errors.Is(err, gorm.ErrRecordNotFound) || status != nil {
+			t.Fatalf("GetStatus at expiry = (%v, %v), want (nil, gorm.ErrRecordNotFound)", status, err)
+		}
+		if count := countUnscopedRows(t, b.gClient, &task.Status{}, "_id = ?", stored.ID); count != 0 {
+			t.Fatalf("physical expired rows = %d, want 0", count)
+		}
+	})
+
+	t.Run("zero uses one hour default", func(t *testing.T) {
+		b, clock := newSQLiteExpiryBackend(t, base, 0)
+		if err := b.SetStatePending(signature); err != nil {
+			t.Fatalf("SetStatePending: %v", err)
+		}
+		stored := readStoredStatus(t, b, signature.ID)
+		if stored.TTL != defaultSQLResultExpireSeconds {
+			t.Fatalf("stored TTL = %d, want %d", stored.TTL, defaultSQLResultExpireSeconds)
+		}
+		clock.Set(base.Add(time.Hour - time.Nanosecond))
+		if _, err := b.GetStatus(signature.ID); err != nil {
+			t.Fatalf("GetStatus immediately before default expiry: %v", err)
+		}
+		clock.Set(base.Add(time.Hour))
+		if _, err := b.GetStatus(signature.ID); !errors.Is(err, gorm.ErrRecordNotFound) {
+			t.Fatalf("GetStatus at default expiry error = %v, want gorm.ErrRecordNotFound", err)
+		}
+	})
+
+	t.Run("group zero uses one hour default", func(t *testing.T) {
+		b, clock := newSQLiteExpiryBackend(t, base, 0)
+		if err := b.GroupTakeOver("group", "group"); err != nil {
+			t.Fatalf("GroupTakeOver: %v", err)
+		}
+		var stored task.GroupMeta
+		if err := b.gClient.Where("id = ?", "group").First(&stored).Error; err != nil {
+			t.Fatalf("read stored group: %v", err)
+		}
+		if stored.TTL != defaultSQLResultExpireSeconds || !stored.CreateAt.Equal(base) {
+			t.Fatalf("stored group retention = (%d, %v), want (%d, %v)", stored.TTL, stored.CreateAt, defaultSQLResultExpireSeconds, base)
+		}
+		clock.Set(base.Add(time.Hour))
+		if _, err := b.GroupTaskStatus(stored.GroupID); !errors.Is(err, gorm.ErrRecordNotFound) {
+			t.Fatalf("GroupTaskStatus at default expiry error = %v, want gorm.ErrRecordNotFound", err)
+		}
+	})
+
+	t.Run("negative never expires", func(t *testing.T) {
+		b, clock := newSQLiteExpiryBackend(t, base, -7)
+		if err := b.SetStatePending(signature); err != nil {
+			t.Fatalf("SetStatePending: %v", err)
+		}
+		clock.Set(base.Add(100 * 365 * 24 * time.Hour))
+		status, err := b.GetStatus(signature.ID)
+		if err != nil || status == nil {
+			t.Fatalf("GetStatus with negative TTL = (%v, %v), want live row", status, err)
+		}
+	})
+
+	t.Run("large TTL does not overflow", func(t *testing.T) {
+		b, clock := newSQLiteExpiryBackend(t, base, math.MaxInt64)
+		if err := b.SetStatePending(signature); err != nil {
+			t.Fatalf("SetStatePending: %v", err)
+		}
+		clock.Set(base.Add(100 * 365 * 24 * time.Hour))
+		if _, err := b.GetStatus(signature.ID); err != nil {
+			t.Fatalf("GetStatus with large TTL: %v", err)
+		}
+	})
+}
+
+func TestSQLResultExpireStateTransitionsDoNotRestartRetention(t *testing.T) {
+	base := time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC)
+	b, clock := newSQLiteExpiryBackend(t, base, 10)
+	signature := &task.Signature{ID: "task", GroupID: "group", Name: "task"}
+	if err := b.SetStatePending(signature); err != nil {
+		t.Fatalf("SetStatePending: %v", err)
+	}
+	first := readStoredStatus(t, b, signature.ID)
+
+	clock.Set(base.Add(5 * time.Second))
+	if err := b.SetStateSuccess(signature, nil); err != nil {
+		t.Fatalf("SetStateSuccess: %v", err)
+	}
+	updated := readStoredStatus(t, b, signature.ID)
+	if updated.ID != first.ID || updated.TTL != first.TTL || !updated.CreateAt.Equal(first.CreateAt) {
+		t.Fatalf("state transition changed retention: before=%+v after=%+v", first, updated)
+	}
+	clock.Set(base.Add(10 * time.Second))
+	if _, err := b.GetStatus(signature.ID); !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Fatalf("GetStatus at original expiry error = %v, want gorm.ErrRecordNotFound", err)
+	}
+}
+
+func TestSQLResultExpireGroupReadAndTransitionSeams(t *testing.T) {
+	base := time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name  string
+		touch func(*BackendSQLDB, string) error
+	}{
+		{name: "GroupTaskStatus", touch: func(b *BackendSQLDB, groupID string) error {
+			_, err := b.GroupTaskStatus(groupID)
+			return err
+		}},
+		{name: "GroupCompleted", touch: func(b *BackendSQLDB, groupID string) error {
+			_, err := b.GroupCompleted(groupID)
+			return err
+		}},
+		{name: "TriggerCompleted", touch: func(b *BackendSQLDB, groupID string) error {
+			_, err := b.TriggerCompleted(groupID)
+			return err
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, clock := newSQLiteExpiryBackend(t, base, 5)
+			if err := b.GroupTakeOver("group", "group"); err != nil {
+				t.Fatalf("GroupTakeOver: %v", err)
+			}
+			var stored task.GroupMeta
+			if err := b.gClient.Where("id = ?", "group").First(&stored).Error; err != nil {
+				t.Fatalf("read stored group: %v", err)
+			}
+			clock.Set(base.Add(5 * time.Second))
+			if err := tt.touch(b, stored.GroupID); !errors.Is(err, gorm.ErrRecordNotFound) {
+				t.Fatalf("touch error = %v, want gorm.ErrRecordNotFound", err)
+			}
+			if count := countUnscopedRows(t, b.gClient, &task.GroupMeta{}, "_id = ?", stored.ID); count != 0 {
+				t.Fatalf("physical expired group rows = %d, want 0", count)
+			}
+		})
+	}
+
+}
+
+func TestSQLResultExpireBatchStatusOmitsExpiredMembers(t *testing.T) {
+	base := time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC)
+	b, clock := newSQLiteExpiryBackend(t, base, 5)
+	if err := b.SetStatePending(&task.Signature{ID: "member", GroupID: "group", Name: "task"}); err != nil {
+		t.Fatalf("SetStatePending: %v", err)
+	}
+	stored := readStoredStatus(t, b, "member")
+
+	clock.Set(base.Add(6 * time.Second))
+	statuses, err := b.getTaskStatus([]string{"member"})
+	if err != nil {
+		t.Fatalf("getTaskStatus: %v", err)
+	}
+	if len(statuses) != 0 {
+		t.Fatalf("statuses = %v, want expired member omitted", statuses)
+	}
+	if count := countUnscopedRows(t, b.gClient, &task.Status{}, "_id = ?", stored.ID); count != 0 {
+		t.Fatalf("physical expired member rows = %d, want 0", count)
+	}
+}
+
+func TestSQLResultExpireReusesExpiredIdentifiers(t *testing.T) {
+	base := time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC)
+
+	t.Run("task", func(t *testing.T) {
+		b, clock := newSQLiteExpiryBackend(t, base, 5)
+		signature := &task.Signature{ID: "task", GroupID: "group", Name: "task"}
+		if err := b.SetStatePending(signature); err != nil {
+			t.Fatalf("first SetStatePending: %v", err)
+		}
+		first := readStoredStatus(t, b, signature.ID)
+		clock.Set(base.Add(5 * time.Second))
+		if err := b.SetStatePending(signature); err != nil {
+			t.Fatalf("replacement SetStatePending: %v", err)
+		}
+		replacement := readStoredStatus(t, b, signature.ID)
+		if replacement.ID == first.ID || !replacement.CreateAt.Equal(clock.Now()) {
+			t.Fatalf("replacement did not get fresh identity/window: first=%+v replacement=%+v", first, replacement)
+		}
+		if count := countUnscopedRows(t, b.gClient, &task.Status{}, "id = ?", signature.ID); count != 1 {
+			t.Fatalf("physical rows for reused task = %d, want 1", count)
+		}
+	})
+
+	t.Run("group", func(t *testing.T) {
+		b, clock := newSQLiteExpiryBackend(t, base, 5)
+		if err := b.GroupTakeOver("group", "first"); err != nil {
+			t.Fatalf("first GroupTakeOver: %v", err)
+		}
+		var first task.GroupMeta
+		if err := b.gClient.Where("id = ?", "group").First(&first).Error; err != nil {
+			t.Fatalf("read first group: %v", err)
+		}
+		clock.Set(base.Add(5 * time.Second))
+		if err := b.GroupTakeOver("group", "replacement"); err != nil {
+			t.Fatalf("replacement GroupTakeOver: %v", err)
+		}
+		var replacement task.GroupMeta
+		if err := b.gClient.Where("id = ?", "group").First(&replacement).Error; err != nil {
+			t.Fatalf("read replacement group: %v", err)
+		}
+		if replacement.ID == first.ID || !replacement.CreateAt.Equal(clock.Now()) {
+			t.Fatalf("replacement did not get fresh identity/window: first=%+v replacement=%+v", first, replacement)
+		}
+		if count := countUnscopedRows(t, b.gClient, &task.GroupMeta{}, "id = ?", "group"); count != 1 {
+			t.Fatalf("physical rows for reused group = %d, want 1", count)
+		}
+	})
+}
+
+func TestSQLResultExpireStaleSnapshotsPreserveReplacements(t *testing.T) {
+	base := time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC)
+	now := base.Add(10 * time.Second)
+	b, _ := newSQLiteExpiryBackend(t, now, 5)
+
+	t.Run("task", func(t *testing.T) {
+		stale := &task.Status{TaskID: "task", TTL: 5, CreateAt: base}
+		if err := b.gClient.Create(stale).Error; err != nil {
+			t.Fatalf("create stale status: %v", err)
+		}
+		if err := b.gClient.Unscoped().Where("_id = ?", stale.ID).Delete(&task.Status{}).Error; err != nil {
+			t.Fatalf("replace stale status: %v", err)
+		}
+		replacement := &task.Status{TaskID: stale.TaskID, TTL: 5, CreateAt: now, Status: task.StatePending}
+		if err := b.gClient.Create(replacement).Error; err != nil {
+			t.Fatalf("create replacement status: %v", err)
+		}
+		deleted, err := b.deleteExpiredStatusSnapshot(stale, now)
+		if err != nil || deleted {
+			t.Fatalf("stale cleanup = (%t, %v), want (false, nil)", deleted, err)
+		}
+		if count := countUnscopedRows(t, b.gClient, &task.Status{}, "_id = ?", replacement.ID); count != 1 {
+			t.Fatalf("replacement status rows = %d, want 1", count)
+		}
+	})
+
+	t.Run("group", func(t *testing.T) {
+		stale := &task.GroupMeta{GroupID: "group", TTL: 5, CreateAt: base}
+		if err := b.gClient.Create(stale).Error; err != nil {
+			t.Fatalf("create stale group: %v", err)
+		}
+		if err := b.gClient.Unscoped().Where("_id = ?", stale.ID).Delete(&task.GroupMeta{}).Error; err != nil {
+			t.Fatalf("replace stale group: %v", err)
+		}
+		replacement := &task.GroupMeta{GroupID: stale.GroupID, TTL: 5, CreateAt: now}
+		if err := b.gClient.Create(replacement).Error; err != nil {
+			t.Fatalf("create replacement group: %v", err)
+		}
+		deleted, err := b.deleteExpiredGroupSnapshot(stale, now)
+		if err != nil || deleted {
+			t.Fatalf("stale cleanup = (%t, %v), want (false, nil)", deleted, err)
+		}
+		if count := countUnscopedRows(t, b.gClient, &task.GroupMeta{}, "_id = ?", replacement.ID); count != 1 {
+			t.Fatalf("replacement group rows = %d, want 1", count)
+		}
+	})
+}
+
+func TestSQLResultExpireCleanupErrorsAreReturned(t *testing.T) {
+	base := time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC)
+	cleanupErr := errors.New("cleanup failed")
+
+	tests := []struct {
+		name  string
+		touch func(*BackendSQLDB, *task.Signature) error
+	}{
+		{name: "read", touch: func(b *BackendSQLDB, signature *task.Signature) error {
+			_, err := b.GetStatus(signature.ID)
+			return err
+		}},
+		{name: "same ID write", touch: func(b *BackendSQLDB, signature *task.Signature) error {
+			return b.SetStateStarted(signature)
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, clock := newSQLiteExpiryBackend(t, base, 5)
+			signature := &task.Signature{ID: "task", GroupID: "group", Name: "task"}
+			if err := b.SetStatePending(signature); err != nil {
+				t.Fatalf("SetStatePending: %v", err)
+			}
+			stored := readStoredStatus(t, b, signature.ID)
+			if err := b.gClient.Callback().Delete().Before("gorm:delete").Register("test:expiry-delete-failure", func(db *gorm.DB) {
+				db.AddError(cleanupErr)
+			}); err != nil {
+				t.Fatalf("register delete callback: %v", err)
+			}
+			clock.Set(base.Add(5 * time.Second))
+			err := tt.touch(b, signature)
+			if !errors.Is(err, cleanupErr) {
+				t.Fatalf("touch error = %v, want cleanup failure", err)
+			}
+			if count := countUnscopedRows(t, b.gClient, &task.Status{}, "_id = ?", stored.ID); count != 1 {
+				t.Fatalf("rows after failed cleanup = %d, want original row retained", count)
+			}
+			after := readStoredStatus(t, b, signature.ID)
+			if !reflect.DeepEqual(after, stored) {
+				t.Fatalf("stored status changed after failed cleanup:\n before=%+v\n  after=%+v", stored, after)
+			}
+		})
+	}
+
+	t.Run("group read", func(t *testing.T) {
+		b, clock := newSQLiteExpiryBackend(t, base, 5)
+		if err := b.GroupTakeOver("group", "group"); err != nil {
+			t.Fatalf("GroupTakeOver: %v", err)
+		}
+		var stored task.GroupMeta
+		if err := b.gClient.Where("id = ?", "group").First(&stored).Error; err != nil {
+			t.Fatalf("read stored group: %v", err)
+		}
+		if err := b.gClient.Callback().Delete().Before("gorm:delete").Register("test:group-expiry-delete-failure", func(db *gorm.DB) {
+			db.AddError(cleanupErr)
+		}); err != nil {
+			t.Fatalf("register delete callback: %v", err)
+		}
+		clock.Set(base.Add(5 * time.Second))
+		_, err := b.GroupTaskStatus(stored.GroupID)
+		if !errors.Is(err, cleanupErr) {
+			t.Fatalf("GroupTaskStatus error = %v, want cleanup failure", err)
+		}
+		if count := countUnscopedRows(t, b.gClient, &task.GroupMeta{}, "_id = ?", stored.ID); count != 1 {
+			t.Fatalf("rows after failed group cleanup = %d, want original row retained", count)
+		}
+	})
+}
+
+func TestSQLResultExpireConcurrentConfigurationAndWrites(t *testing.T) {
+	base := time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC)
+	b, _ := newSQLiteExpiryBackend(t, base, 1)
+	var wg sync.WaitGroup
+	for index := 0; index < 20; index++ {
+		index := index
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			values := []int64{0, -1, 1, 60}
+			b.SetResultExpire(values[index%len(values)])
+		}()
+		go func() {
+			defer wg.Done()
+			signature := &task.Signature{ID: string(rune('a' + index)), GroupID: "group", Name: "task"}
+			if err := b.SetStatePending(signature); err != nil {
+				t.Errorf("SetStatePending(%d): %v", index, err)
+			}
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## What

- normalize SQL result retention (`0` = 3600 seconds, negative = never, positive = per-record seconds)
- persist retention on task/group creation and enforce it on reads and same-ID writes
- lazily hard-delete expired physical rows while protecting concurrent replacements with the auto-increment primary key
- add deterministic SQLite, isolated MySQL, race, failure-propagation, and mutation coverage plus PRODUCT/TECH specs

## Why

`BackendSQLDB.resultExpire` was configuration-only: task TTLs were never populated, SQL reads never checked task/group TTLs, and expired rows remained readable and stored indefinitely. This diverged from the documented Redis/Mongo retention behavior.

## How

Expiry uses the existing `ttl` and `create_at` columns with an injectable internal clock. Reads and identifier reuse evaluate the stored per-row retention in Go, hard-delete only the matching physical `_id`, and return `gorm.ErrRecordNotFound` after expiry. Cleanup errors stop the requested operation and preserve their wrapped cause. Runtime retention changes are synchronized.

This is lazy cleanup, not a full-table vacuum: a row becomes logically unavailable at its expiry boundary and is physically removed when read or when its identifier is reused. Rows that are never touched still require an operator-owned database retention job if autonomous physical vacuuming is desired; no lifecycle-less backend goroutine is introduced.

## Integration requirements

- PR #99 also changes `GroupTakeOver`; integration must keep its duplicate-key translation to `backend.ErrGroupAlreadyExists` after this PRs expired-row purge and before/around create
- PR #106 SQL durable paths must replace two direct `task.NewPendingState` inserts with the retention-aware `BackendSQLDB.newStatus`, and replace direct `b.resultExpire` use with `configuredResultExpire`
- the pending SQL `StringSlice` encoding work has no production-file overlap with this change

## Verification

- `go test -race ./distributed/backend/backend_db -count=10`
- `go vet ./distributed/...`
- `git diff --check`
- deterministic mutations killed: disable expiry, delete by logical ID, remove zero normalization, restart retention on state update, swallow cleanup errors, and continue same-ID upsert after returning the cleanup error
- isolated MySQL contract is available through `GKIT_TEST_MYSQL_DSN` and requires a database name ending in `_test`; the variable was not configured locally, so that contract skipped safely
- `go test ./distributed/... -count=1`: all packages pass except the pre-existing live-Redis `TestControllerRedis_StartConsuming`, which stops after 10 seconds and returns `context canceled`; the same failure is unrelated to this backend
