### PR TITLE
fix(distributed): compensate failed task publication

### DIFF
--- a/distributed/backend/backend.go
+++ b/distributed/backend/backend.go
@@ -49,3 +49,19 @@ type Backend interface {
 	// 在使用controller中接管时候统一设置
 	SetResultExpire(expire int64)
 }
+
+// PublicationAttemptBackend is an optional extension for backends that can
+// compensate an ambiguous single-task publication without overwriting worker
+// progress or a newer publication attempt. Backend intentionally does not
+// embed this interface so existing third-party implementations remain source
+// compatible.
+type PublicationAttemptBackend interface {
+	// SetStatePendingAttempt atomically records PENDING and private ownership by
+	// attemptID before the task is published.
+	SetStatePendingAttempt(signature *task.Signature, attemptID string) error
+
+	// FailPendingAttempt changes only the matching PENDING attempt to FAILURE.
+	// changed is false when the task is missing, belongs to another attempt, or
+	// has already advanced to another state.
+	FailPendingAttempt(signature *task.Signature, attemptID, reason string) (changed bool, err error)
+}

--- a/distributed/backend/backend_db/db.go
+++ b/distributed/backend/backend_db/db.go
@@ -27,6 +27,15 @@ type BackendSQLDB struct {
 	resultExpire int64
 }
 
+const publicationAttemptColumn = "publication_attempt_id"
+
+// statusPublicationAttempt is migration metadata for a private column on the
+// task status table. It deliberately stays out of task.Status so the public
+// status and backend interfaces remain compatible.
+type statusPublicationAttempt struct {
+	PublicationAttemptID string `gorm:"column:publication_attempt_id;size:64"`
+}
+
 // SetResultExpire 设置结果超时时间
 func (b *BackendSQLDB) SetResultExpire(expire int64) {
 	b.resultExpire = expire
@@ -97,24 +106,67 @@ func (b *BackendSQLDB) TriggerCompleted(groupID string) (bool, error) {
 // RecordNotFound and both Create, hitting a unique-key violation; or
 // Update could run on a row deleted between SELECT and UPDATE.
 func (b *BackendSQLDB) upsertStatus(s *task.Status, updateColumns []string) error {
+	return b.upsertStatusWithDB(b.gClient, s, updateColumns)
+}
+
+func (b *BackendSQLDB) upsertStatusWithDB(db *gorm.DB, s *task.Status, updateColumns []string) error {
 	// Conflict target is the DB column TaskID maps to (`id`, uniqueIndex), NOT
 	// the field name. GORM writes the conflict column verbatim, so `task_id`
 	// (no such column) errored on Postgres; and the column must be a UNIQUE
 	// index for ON CONFLICT / ON DUPLICATE KEY to dedupe at all.
-	return b.gClient.Clauses(clause.OnConflict{
+	return db.Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "id"}},
 		DoUpdates: clause.AssignmentColumns(updateColumns),
 	}).Create(s).Error
 }
 
 func (b *BackendSQLDB) SetStatePending(signature *task.Signature) error {
-	return b.upsertStatus(&task.Status{
+	return b.setStatePendingAttempt(signature, "")
+}
+
+func (b *BackendSQLDB) SetStatePendingAttempt(signature *task.Signature, attemptID string) error {
+	if attemptID == "" {
+		return fmt.Errorf("backend_db: empty publication attempt ID")
+	}
+	return b.setStatePendingAttempt(signature, attemptID)
+}
+
+func (b *BackendSQLDB) setStatePendingAttempt(signature *task.Signature, attemptID string) error {
+	status := &task.Status{
 		TaskID:   signature.ID,
 		GroupID:  signature.GroupID,
 		Name:     signature.Name,
 		Status:   task.StatePending,
 		CreateAt: time.Now(),
-	}, []string{"status", "error"})
+	}
+	return b.gClient.Transaction(func(tx *gorm.DB) error {
+		if err := b.upsertStatusWithDB(tx, status, []string{"status", "error"}); err != nil {
+			return err
+		}
+		var value interface{}
+		if attemptID != "" {
+			value = attemptID
+		}
+		return tx.Model(&task.Status{}).
+			Where("id = ?", signature.ID).
+			Update(publicationAttemptColumn, value).Error
+	})
+}
+
+func (b *BackendSQLDB) FailPendingAttempt(signature *task.Signature, attemptID, reason string) (bool, error) {
+	if attemptID == "" {
+		return false, nil
+	}
+	result := b.gClient.Model(&task.Status{}).
+		Where("id = ? AND status = ? AND "+publicationAttemptColumn+" = ?", signature.ID, task.StatePending, attemptID).
+		Updates(map[string]interface{}{
+			"status": task.StateFailure,
+			"error":  reason,
+		})
+	if result.Error != nil {
+		return false, result.Error
+	}
+	return result.RowsAffected > 0, nil
 }
 
 func (b *BackendSQLDB) SetStateReceived(signature *task.Signature) error {
@@ -200,10 +252,21 @@ func (b *BackendSQLDB) ResetGroup(groupIDs ...string) error {
 // duplicate task IDs must de-duplicate first; otherwise the upsert
 // (ON CONFLICT id) cannot dedupe.
 func (b *BackendSQLDB) autoMigrate() error {
-	return b.gClient.AutoMigrate(
+	if err := b.gClient.AutoMigrate(
 		task.GroupMeta{},
 		task.Status{},
-	)
+	); err != nil {
+		return err
+	}
+	stmt := &gorm.Statement{DB: b.gClient}
+	if err := stmt.Parse(&task.Status{}); err != nil {
+		return err
+	}
+	migrator := b.gClient.Table(stmt.Schema.Table).Migrator()
+	if migrator.HasColumn(&statusPublicationAttempt{}, "PublicationAttemptID") {
+		return nil
+	}
+	return migrator.AddColumn(&statusPublicationAttempt{}, "PublicationAttemptID")
 }
 
 // NewBackendSQLDB constructs a SQL-backed Backend. Returns nil on failure

--- a/distributed/backend/backend_db/db.go
+++ b/distributed/backend/backend_db/db.go
@@ -114,7 +114,7 @@ func (b *BackendSQLDB) SetStatePending(signature *task.Signature) error {
 		Name:     signature.Name,
 		Status:   task.StatePending,
 		CreateAt: time.Now(),
-	}, []string{"status"})
+	}, []string{"status", "error"})
 }
 
 func (b *BackendSQLDB) SetStateReceived(signature *task.Signature) error {
@@ -124,7 +124,7 @@ func (b *BackendSQLDB) SetStateReceived(signature *task.Signature) error {
 		Name:     signature.Name,
 		Status:   task.StateReceived,
 		CreateAt: time.Now(),
-	}, []string{"status"})
+	}, []string{"status", "error"})
 }
 
 func (b *BackendSQLDB) SetStateStarted(signature *task.Signature) error {
@@ -134,7 +134,7 @@ func (b *BackendSQLDB) SetStateStarted(signature *task.Signature) error {
 		Name:     signature.Name,
 		Status:   task.StateStarted,
 		CreateAt: time.Now(),
-	}, []string{"status"})
+	}, []string{"status", "error"})
 }
 
 func (b *BackendSQLDB) SetStateRetry(t *task.Signature) error {
@@ -144,7 +144,7 @@ func (b *BackendSQLDB) SetStateRetry(t *task.Signature) error {
 		Name:     t.Name,
 		Status:   task.StateRetry,
 		CreateAt: time.Now(),
-	}, []string{"status"})
+	}, []string{"status", "error"})
 }
 
 func (b *BackendSQLDB) SetStateSuccess(signature *task.Signature, results []*task.Result) error {
@@ -155,7 +155,7 @@ func (b *BackendSQLDB) SetStateSuccess(signature *task.Signature, results []*tas
 		Status:   task.StateSuccess,
 		Results:  task.Results(results),
 		CreateAt: time.Now(),
-	}, []string{"status", "results"})
+	}, []string{"status", "results", "error"})
 }
 
 func (b *BackendSQLDB) SetStateFailure(signature *task.Signature, err string) error {

--- a/distributed/backend/backend_db/publication_attempt_integration_test.go
+++ b/distributed/backend/backend_db/publication_attempt_integration_test.go
@@ -1,0 +1,72 @@
+package backend_db
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/songzhibin97/gkit/distributed/task"
+	"gorm.io/gorm"
+	"gorm.io/gorm/schema"
+)
+
+func TestPublicationAttemptCompensationLiveSQL(t *testing.T) {
+	tests := []struct {
+		name       string
+		env        string
+		driverName string
+		dbType     string
+	}{
+		{name: "mysql", env: "GKIT_MYSQL_DSN", driverName: "mysql", dbType: "mysql"},
+		{name: "postgres", env: "GKIT_POSTGRES_DSN", driverName: "pgx", dbType: "pgsql"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dsn := os.Getenv(tt.env)
+			if dsn == "" {
+				t.Skip(tt.env + " is not set")
+			}
+			sqlDB, err := sql.Open(tt.driverName, dsn)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = sqlDB.Close() })
+			prefix := fmt.Sprintf("gkit_attempt_%d_", time.Now().UnixNano())
+			constructed, err := NewBackendSQLDBE(sqlDB, -1, tt.dbType, &gorm.Config{
+				NamingStrategy: schema.NamingStrategy{TablePrefix: prefix},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			backend, ok := constructed.(*BackendSQLDB)
+			if !ok {
+				t.Fatalf("backend type = %T, want *BackendSQLDB", constructed)
+			}
+			t.Cleanup(func() {
+				if err := backend.gClient.Migrator().DropTable(&task.GroupMeta{}, &task.Status{}); err != nil {
+					t.Errorf("drop isolated integration tables: %v", err)
+				}
+			})
+
+			signature := &task.Signature{ID: "live-sql-attempt", GroupID: "group", Name: "task"}
+			if err := backend.SetStatePendingAttempt(signature, "attempt-a"); err != nil {
+				t.Fatal(err)
+			}
+			if changed, err := backend.FailPendingAttempt(signature, "attempt-a", "publish failed"); err != nil || !changed {
+				t.Fatalf("matching compensation = (%t, %v), want true, nil", changed, err)
+			}
+			if err := backend.SetStatePendingAttempt(signature, "attempt-b"); err != nil {
+				t.Fatal(err)
+			}
+			if changed, err := backend.FailPendingAttempt(signature, "attempt-a", "stale attempt"); err != nil || changed {
+				t.Fatalf("stale compensation = (%t, %v), want false, nil", changed, err)
+			}
+			status, err := backend.GetStatus(signature.ID)
+			if err != nil || status.Status != task.StatePending || status.Error != "" {
+				t.Fatalf("final status = %#v, %v", status, err)
+			}
+		})
+	}
+}

--- a/distributed/backend/backend_db/upsert_test.go
+++ b/distributed/backend/backend_db/upsert_test.go
@@ -104,6 +104,49 @@ func TestResetTask_AllowsReuse(t *testing.T) {
 	}
 }
 
+func TestNonFailureTransitionsClearPreviousError(t *testing.T) {
+	tests := []struct {
+		name       string
+		wantState  task.State
+		transition func(*BackendSQLDB, *task.Signature) error
+	}{
+		{name: "pending", wantState: task.StatePending, transition: func(b *BackendSQLDB, sig *task.Signature) error { return b.SetStatePending(sig) }},
+		{name: "received", wantState: task.StateReceived, transition: func(b *BackendSQLDB, sig *task.Signature) error { return b.SetStateReceived(sig) }},
+		{name: "started", wantState: task.StateStarted, transition: func(b *BackendSQLDB, sig *task.Signature) error { return b.SetStateStarted(sig) }},
+		{name: "retry", wantState: task.StateRetry, transition: func(b *BackendSQLDB, sig *task.Signature) error { return b.SetStateRetry(sig) }},
+		{name: "success", wantState: task.StateSuccess, transition: func(b *BackendSQLDB, sig *task.Signature) error { return b.SetStateSuccess(sig, nil) }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := newSQLiteBackend(t)
+			sig := &task.Signature{ID: "task-" + tt.name, GroupID: "g1", Name: "n"}
+			if err := b.SetStateFailure(sig, "stale failure"); err != nil {
+				t.Fatalf("SetStateFailure: %v", err)
+			}
+			failed, err := b.GetStatus(sig.ID)
+			if err != nil {
+				t.Fatalf("GetStatus after failure: %v", err)
+			}
+			if failed.Status != task.StateFailure || failed.Error != "stale failure" {
+				t.Fatalf("failure state = (%s, %q), want (FAILURE, stale failure)", failed.Status, failed.Error)
+			}
+			if err := tt.transition(b, sig); err != nil {
+				t.Fatalf("%s transition: %v", tt.name, err)
+			}
+			status, err := b.GetStatus(sig.ID)
+			if err != nil {
+				t.Fatalf("GetStatus: %v", err)
+			}
+			if status.Status != tt.wantState {
+				t.Fatalf("status = %s, want %s", status.Status, tt.wantState)
+			}
+			if status.Error != "" {
+				t.Fatalf("%s error = %q, want cleared", tt.name, status.Error)
+			}
+		})
+	}
+}
+
 // TestNewBackendSQLDB_NilOnFailure pins the deprecated constructor's documented
 // contract: it returns nil (not panic) on failure. An unsupported dbType fails
 // before any connection, so this needs no live DB. (Regression: the PR briefly

--- a/distributed/backend/backend_db/upsert_test.go
+++ b/distributed/backend/backend_db/upsert_test.go
@@ -9,6 +9,11 @@ import (
 	"github.com/songzhibin97/gkit/distributed/task"
 )
 
+type publicationAttemptBackendForTest interface {
+	SetStatePendingAttempt(*task.Signature, string) error
+	FailPendingAttempt(*task.Signature, string, string) (bool, error)
+}
+
 func newSQLiteBackend(t *testing.T) *BackendSQLDB {
 	t.Helper()
 	gdb, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
@@ -144,6 +149,124 @@ func TestNonFailureTransitionsClearPreviousError(t *testing.T) {
 				t.Fatalf("%s error = %q, want cleared", tt.name, status.Error)
 			}
 		})
+	}
+}
+
+func TestPublicationAttemptCompensation(t *testing.T) {
+	b := newSQLiteBackend(t)
+	attemptBackend, ok := interface{}(b).(publicationAttemptBackendForTest)
+	if !ok {
+		t.Fatal("BackendSQLDB does not implement atomic publication-attempt compensation")
+	}
+	signature := &task.Signature{ID: "publication-attempt", GroupID: "group", Name: "task"}
+	if err := attemptBackend.SetStatePendingAttempt(signature, "attempt-a"); err != nil {
+		t.Fatal(err)
+	}
+	if changed, err := attemptBackend.FailPendingAttempt(signature, "attempt-a", "publish failed"); err != nil || !changed {
+		t.Fatalf("matching compensation = (%t, %v), want true, nil", changed, err)
+	}
+	status, err := b.GetStatus(signature.ID)
+	if err != nil || status.Status != task.StateFailure || status.Error != "publish failed" {
+		t.Fatalf("matching status = %#v, %v", status, err)
+	}
+	createAt := status.CreateAt
+
+	if err := attemptBackend.SetStatePendingAttempt(signature, "attempt-b"); err != nil {
+		t.Fatal(err)
+	}
+	if changed, err := attemptBackend.FailPendingAttempt(signature, "attempt-a", "stale attempt"); err != nil || changed {
+		t.Fatalf("stale compensation = (%t, %v), want false, nil", changed, err)
+	}
+	status, err = b.GetStatus(signature.ID)
+	if err != nil || status.Status != task.StatePending || status.Error != "" {
+		t.Fatalf("stale-attempt status = %#v, %v", status, err)
+	}
+	if !status.CreateAt.Equal(createAt) {
+		t.Fatalf("create_at changed from %v to %v on a new attempt", createAt, status.CreateAt)
+	}
+
+	tests := []struct {
+		name       string
+		want       task.State
+		transition func(*task.Signature) error
+	}{
+		{name: "received", want: task.StateReceived, transition: b.SetStateReceived},
+		{name: "started", want: task.StateStarted, transition: b.SetStateStarted},
+		{name: "retry", want: task.StateRetry, transition: b.SetStateRetry},
+		{name: "success", want: task.StateSuccess, transition: func(signature *task.Signature) error { return b.SetStateSuccess(signature, nil) }},
+		{name: "failure", want: task.StateFailure, transition: func(signature *task.Signature) error { return b.SetStateFailure(signature, "worker failed") }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sig := &task.Signature{ID: "advanced-" + tt.name, GroupID: "group", Name: "task"}
+			if err := attemptBackend.SetStatePendingAttempt(sig, "attempt"); err != nil {
+				t.Fatal(err)
+			}
+			if err := tt.transition(sig); err != nil {
+				t.Fatal(err)
+			}
+			if changed, err := attemptBackend.FailPendingAttempt(sig, "attempt", "publish failed"); err != nil || changed {
+				t.Fatalf("advanced compensation = (%t, %v), want false, nil", changed, err)
+			}
+			status, err := b.GetStatus(sig.ID)
+			if err != nil || status.Status != tt.want {
+				t.Fatalf("advanced status = %#v, %v; want %s", status, err, tt.want)
+			}
+		})
+	}
+}
+
+func TestPublicationAttemptCompensationLegacyRecordDoesNotMatch(t *testing.T) {
+	b := newSQLiteBackend(t)
+	attemptBackend, ok := interface{}(b).(publicationAttemptBackendForTest)
+	if !ok {
+		t.Fatal("BackendSQLDB does not implement atomic publication-attempt compensation")
+	}
+	signature := &task.Signature{ID: "legacy-pending", GroupID: "group", Name: "task"}
+	if err := attemptBackend.SetStatePendingAttempt(signature, "stale-owner"); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.SetStatePending(signature); err != nil {
+		t.Fatal(err)
+	}
+	if changed, err := attemptBackend.FailPendingAttempt(signature, "stale-owner", "publish failed"); err != nil || changed {
+		t.Fatalf("legacy compensation = (%t, %v), want false, nil", changed, err)
+	}
+	status, err := b.GetStatus(signature.ID)
+	if err != nil || status.Status != task.StatePending {
+		t.Fatalf("legacy status = %#v, %v", status, err)
+	}
+}
+
+func TestPublicationAttemptColumnMigratesExistingStatusTable(t *testing.T) {
+	gdb, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.AutoMigrate(&task.Status{}); err != nil {
+		t.Fatalf("create legacy status table: %v", err)
+	}
+	legacy := &task.Status{TaskID: "legacy-before-migration", GroupID: "group", Name: "task", Status: task.StatePending}
+	if err := gdb.Create(legacy).Error; err != nil {
+		t.Fatalf("insert legacy status: %v", err)
+	}
+
+	b := &BackendSQLDB{gClient: gdb}
+	if err := b.autoMigrate(); err != nil {
+		t.Fatalf("migrate publication attempt column: %v", err)
+	}
+	if !gdb.Migrator().HasColumn(&task.Status{}, publicationAttemptColumn) {
+		t.Fatalf("status table is missing %s after migration", publicationAttemptColumn)
+	}
+	if changed, err := b.FailPendingAttempt(
+		&task.Signature{ID: legacy.TaskID},
+		"unknown-attempt",
+		"publish failed",
+	); err != nil || changed {
+		t.Fatalf("legacy row compensation = (%t, %v), want false, nil", changed, err)
+	}
+	if err := b.SetStatePendingAttempt(&task.Signature{ID: legacy.TaskID, GroupID: "group", Name: "task"}, "attempt"); err != nil {
+		t.Fatalf("write publication attempt after migration: %v", err)
 	}
 }
 

--- a/distributed/backend/backend_mongodb/mongo.go
+++ b/distributed/backend/backend_mongodb/mongo.go
@@ -22,6 +22,7 @@ const (
 	mongoIndexSetupTimeout                = 5 * time.Second
 	taskTTLIndexName                      = "gkit_tasks_create_at_ttl"
 	groupTTLIndexName                     = "gkit_groups_create_at_ttl"
+	publicationAttemptField               = "publication_attempt_id"
 )
 
 type BackendMongoDB struct {
@@ -131,14 +132,52 @@ func (b *BackendMongoDB) TriggerCompleted(groupID string) (bool, error) {
 
 func (b *BackendMongoDB) SetStatePending(signature *task.Signature) error {
 	update := bson.M{
-		"_id":       signature.ID,
-		"status":    task.StatePending,
-		"group_id":  signature.GroupID,
-		"name":      signature.Name,
-		"error":     "",
-		"create_at": time.Now().Local(),
+		"_id":      signature.ID,
+		"status":   task.StatePending,
+		"group_id": signature.GroupID,
+		"name":     signature.Name,
 	}
+	return b.updatePendingStatus(signature, update, "")
+}
+
+func (b *BackendMongoDB) SetStatePendingAttempt(signature *task.Signature, attemptID string) error {
+	if attemptID == "" {
+		return errors.New("backend_mongodb: empty publication attempt ID")
+	}
+	update := bson.M{
+		"_id":      signature.ID,
+		"status":   task.StatePending,
+		"group_id": signature.GroupID,
+		"name":     signature.Name,
+	}
+	return b.updatePendingStatus(signature, update, attemptID)
+}
+
+func (b *BackendMongoDB) updatePendingStatus(signature *task.Signature, update bson.M, attemptID string) error {
+	update["error"] = ""
+	update[publicationAttemptField] = attemptID
 	return b.updateStatus(signature, update)
+}
+
+func (b *BackendMongoDB) FailPendingAttempt(signature *task.Signature, attemptID, reason string) (bool, error) {
+	if attemptID == "" {
+		return false, nil
+	}
+	query := bson.M{
+		"_id":                   signature.ID,
+		"status":                task.StatePending,
+		publicationAttemptField: attemptID,
+	}
+	result, err := b.taskTable.UpdateOne(context.Background(), query, bson.M{
+		"$set": bson.M{
+			"status": task.StateFailure,
+			"error":  reason,
+		},
+	})
+	if err != nil {
+		return false, err
+	}
+	return result.ModifiedCount > 0, nil
 }
 
 func (b *BackendMongoDB) SetStateReceived(signature *task.Signature) error {
@@ -216,10 +255,19 @@ func (b *BackendMongoDB) ResetGroup(groupIDs ...string) error {
 
 // updateStatus 更新状态
 func (b *BackendMongoDB) updateStatus(signature *task.Signature, update bson.M) error {
-	update = bson.M{"$set": update}
+	update = buildTaskStatusUpdate(update, time.Now().Local())
 	query := bson.M{"_id": signature.ID}
 	_, err := b.taskTable.UpdateOne(context.Background(), query, update, moption.Update().SetUpsert(true))
 	return err
+}
+
+func buildTaskStatusUpdate(fields bson.M, createAt time.Time) bson.M {
+	return bson.M{
+		"$set": fields,
+		"$setOnInsert": bson.M{
+			"create_at": createAt,
+		},
+	}
 }
 
 func normalizeResultExpire(expire int64) int64 {

--- a/distributed/backend/backend_mongodb/mongo.go
+++ b/distributed/backend/backend_mongodb/mongo.go
@@ -135,6 +135,7 @@ func (b *BackendMongoDB) SetStatePending(signature *task.Signature) error {
 		"status":    task.StatePending,
 		"group_id":  signature.GroupID,
 		"name":      signature.Name,
+		"error":     "",
 		"create_at": time.Now().Local(),
 	}
 	return b.updateStatus(signature, update)
@@ -143,6 +144,7 @@ func (b *BackendMongoDB) SetStatePending(signature *task.Signature) error {
 func (b *BackendMongoDB) SetStateReceived(signature *task.Signature) error {
 	update := bson.M{
 		"status": task.StateReceived,
+		"error":  "",
 	}
 	return b.updateStatus(signature, update)
 }
@@ -150,6 +152,7 @@ func (b *BackendMongoDB) SetStateReceived(signature *task.Signature) error {
 func (b *BackendMongoDB) SetStateStarted(signature *task.Signature) error {
 	update := bson.M{
 		"status": task.StateStarted,
+		"error":  "",
 	}
 	return b.updateStatus(signature, update)
 }
@@ -157,6 +160,7 @@ func (b *BackendMongoDB) SetStateStarted(signature *task.Signature) error {
 func (b *BackendMongoDB) SetStateRetry(signature *task.Signature) error {
 	update := bson.M{
 		"status": task.StateRetry,
+		"error":  "",
 	}
 	return b.updateStatus(signature, update)
 }
@@ -165,6 +169,7 @@ func (b *BackendMongoDB) SetStateSuccess(signature *task.Signature, results []*t
 	update := bson.M{
 		"status":  task.StateSuccess,
 		"results": results,
+		"error":   "",
 	}
 	return b.updateStatus(signature, update)
 }

--- a/distributed/backend/backend_mongodb/pending_error_integration_test.go
+++ b/distributed/backend/backend_mongodb/pending_error_integration_test.go
@@ -8,11 +8,13 @@ import (
 	"time"
 
 	"github.com/songzhibin97/gkit/distributed/task"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	moption "go.mongodb.org/mongo-driver/mongo/options"
 )
 
-func TestNonFailureTransitionsClearPreviousError(t *testing.T) {
+func newMongoIntegrationBackend(t *testing.T) *BackendMongoDB {
+	t.Helper()
 	uri := os.Getenv("GKIT_MONGODB_URI")
 	if uri == "" {
 		t.Skip("GKIT_MONGODB_URI is not set")
@@ -36,7 +38,7 @@ func TestNonFailureTransitionsClearPreviousError(t *testing.T) {
 		}
 	})
 
-	backend, err := NewBackendMongoDBE(
+	constructed, err := NewBackendMongoDBE(
 		client,
 		-1,
 		SetDatabaseName(databaseName),
@@ -46,6 +48,15 @@ func TestNonFailureTransitionsClearPreviousError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	backend, ok := constructed.(*BackendMongoDB)
+	if !ok {
+		t.Fatalf("backend type = %T, want *BackendMongoDB", constructed)
+	}
+	return backend
+}
+
+func TestNonFailureTransitionsClearPreviousError(t *testing.T) {
+	backend := newMongoIntegrationBackend(t)
 	tests := []struct {
 		name       string
 		wantState  task.State
@@ -84,5 +95,107 @@ func TestNonFailureTransitionsClearPreviousError(t *testing.T) {
 				t.Fatalf("%s error = %q, want cleared", tt.name, status.Error)
 			}
 		})
+	}
+}
+
+func TestPublicationAttemptCompensation(t *testing.T) {
+	backend := newMongoIntegrationBackend(t)
+	signature := &task.Signature{ID: "publication-attempt", GroupID: "group", Name: "task"}
+
+	if err := backend.SetStatePendingAttempt(signature, "attempt-a"); err != nil {
+		t.Fatal(err)
+	}
+	if changed, err := backend.FailPendingAttempt(signature, "attempt-a", "publish failed"); err != nil || !changed {
+		t.Fatalf("matching compensation = (%t, %v), want true, nil", changed, err)
+	}
+	status, err := backend.GetStatus(signature.ID)
+	if err != nil || status.Status != task.StateFailure || status.Error != "publish failed" {
+		t.Fatalf("matching status = %#v, %v", status, err)
+	}
+	createAt := status.CreateAt
+
+	if err := backend.SetStatePendingAttempt(signature, "attempt-b"); err != nil {
+		t.Fatal(err)
+	}
+	if changed, err := backend.FailPendingAttempt(signature, "attempt-a", "stale attempt"); err != nil || changed {
+		t.Fatalf("stale compensation = (%t, %v), want false, nil", changed, err)
+	}
+	status, err = backend.GetStatus(signature.ID)
+	if err != nil || status.Status != task.StatePending || status.Error != "" {
+		t.Fatalf("stale-attempt status = %#v, %v", status, err)
+	}
+	if !status.CreateAt.Equal(createAt) {
+		t.Fatalf("create_at changed from %v to %v on a new attempt", createAt, status.CreateAt)
+	}
+}
+
+func TestPublicationAttemptCompensationPreservesAdvancedState(t *testing.T) {
+	backend := newMongoIntegrationBackend(t)
+	tests := []struct {
+		name       string
+		want       task.State
+		transition func(*task.Signature) error
+	}{
+		{name: "received", want: task.StateReceived, transition: backend.SetStateReceived},
+		{name: "started", want: task.StateStarted, transition: backend.SetStateStarted},
+		{name: "retry", want: task.StateRetry, transition: backend.SetStateRetry},
+		{name: "success", want: task.StateSuccess, transition: func(signature *task.Signature) error { return backend.SetStateSuccess(signature, nil) }},
+		{name: "failure", want: task.StateFailure, transition: func(signature *task.Signature) error { return backend.SetStateFailure(signature, "worker failed") }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			signature := &task.Signature{ID: "advanced-" + tt.name, GroupID: "group", Name: "task"}
+			if err := backend.SetStatePendingAttempt(signature, "attempt"); err != nil {
+				t.Fatal(err)
+			}
+			if err := tt.transition(signature); err != nil {
+				t.Fatal(err)
+			}
+			if changed, err := backend.FailPendingAttempt(signature, "attempt", "publish failed"); err != nil || changed {
+				t.Fatalf("advanced compensation = (%t, %v), want false, nil", changed, err)
+			}
+			status, err := backend.GetStatus(signature.ID)
+			if err != nil || status.Status != tt.want {
+				t.Fatalf("advanced status = %#v, %v; want %s", status, err, tt.want)
+			}
+		})
+	}
+}
+
+func TestPublicationAttemptCompensationLegacyRecordDoesNotMatch(t *testing.T) {
+	backend := newMongoIntegrationBackend(t)
+	signature := &task.Signature{ID: "legacy-pending", GroupID: "group", Name: "task"}
+	if err := backend.SetStatePendingAttempt(signature, "stale-owner"); err != nil {
+		t.Fatal(err)
+	}
+	if err := backend.SetStatePending(signature); err != nil {
+		t.Fatal(err)
+	}
+	if changed, err := backend.FailPendingAttempt(signature, "stale-owner", "publish failed"); err != nil || changed {
+		t.Fatalf("legacy compensation = (%t, %v), want false, nil", changed, err)
+	}
+	status, err := backend.GetStatus(signature.ID)
+	if err != nil || status.Status != task.StatePending {
+		t.Fatalf("legacy status = %#v, %v", status, err)
+	}
+	var stored bson.M
+	if err := backend.taskTable.FindOne(context.Background(), bson.M{"_id": signature.ID}).Decode(&stored); err != nil {
+		t.Fatal(err)
+	}
+	if got := stored[publicationAttemptField]; got != "" {
+		t.Fatalf("legacy pending %s = %#v, want cleared ownership", publicationAttemptField, got)
+	}
+
+	missingSignature := &task.Signature{ID: "legacy-missing-metadata", GroupID: "group", Name: "task"}
+	if _, err := backend.taskTable.InsertOne(context.Background(), bson.M{
+		"_id":      missingSignature.ID,
+		"status":   task.StatePending,
+		"group_id": missingSignature.GroupID,
+		"name":     missingSignature.Name,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if changed, err := backend.FailPendingAttempt(missingSignature, "unknown-attempt", "publish failed"); err != nil || changed {
+		t.Fatalf("missing-metadata compensation = (%t, %v), want false, nil", changed, err)
 	}
 }

--- a/distributed/backend/backend_mongodb/pending_error_integration_test.go
+++ b/distributed/backend/backend_mongodb/pending_error_integration_test.go
@@ -1,0 +1,88 @@
+package backend_mongodb
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/songzhibin97/gkit/distributed/task"
+	"go.mongodb.org/mongo-driver/mongo"
+	moption "go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func TestNonFailureTransitionsClearPreviousError(t *testing.T) {
+	uri := os.Getenv("GKIT_MONGODB_URI")
+	if uri == "" {
+		t.Skip("GKIT_MONGODB_URI is not set")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	client, err := mongo.Connect(ctx, moption.Client().ApplyURI(uri))
+	if err != nil {
+		t.Fatal(err)
+	}
+	databaseName := fmt.Sprintf("gkit_pending_error_%d", time.Now().UnixNano())
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cleanupCancel()
+		if err := client.Database(databaseName).Drop(cleanupCtx); err != nil {
+			t.Errorf("drop test database: %v", err)
+		}
+		if err := client.Disconnect(cleanupCtx); err != nil {
+			t.Errorf("disconnect MongoDB client: %v", err)
+		}
+	})
+
+	backend, err := NewBackendMongoDBE(
+		client,
+		-1,
+		SetDatabaseName(databaseName),
+		SetTableTaskName("tasks"),
+		SetTableGroupName("groups"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name       string
+		wantState  task.State
+		transition func(*task.Signature) error
+	}{
+		{name: "pending", wantState: task.StatePending, transition: backend.SetStatePending},
+		{name: "received", wantState: task.StateReceived, transition: backend.SetStateReceived},
+		{name: "started", wantState: task.StateStarted, transition: backend.SetStateStarted},
+		{name: "retry", wantState: task.StateRetry, transition: backend.SetStateRetry},
+		{name: "success", wantState: task.StateSuccess, transition: func(sig *task.Signature) error { return backend.SetStateSuccess(sig, nil) }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			signature := &task.Signature{ID: "task-" + tt.name, GroupID: "group", Name: "task"}
+			if err := backend.SetStateFailure(signature, "stale failure"); err != nil {
+				t.Fatal(err)
+			}
+			failed, err := backend.GetStatus(signature.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if failed.Status != task.StateFailure || failed.Error != "stale failure" {
+				t.Fatalf("failure state = (%s, %q), want (FAILURE, stale failure)", failed.Status, failed.Error)
+			}
+			if err := tt.transition(signature); err != nil {
+				t.Fatal(err)
+			}
+			status, err := backend.GetStatus(signature.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if status.Status != tt.wantState {
+				t.Fatalf("status = %s, want %s", status.Status, tt.wantState)
+			}
+			if status.Error != "" {
+				t.Fatalf("%s error = %q, want cleared", tt.name, status.Error)
+			}
+		})
+	}
+}

--- a/distributed/backend/backend_mongodb/status_update_test.go
+++ b/distributed/backend/backend_mongodb/status_update_test.go
@@ -1,0 +1,36 @@
+package backend_mongodb
+
+import (
+	"testing"
+	"time"
+
+	"github.com/songzhibin97/gkit/distributed/task"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func TestBuildTaskStatusUpdatePreservesCreateAtOnExistingRows(t *testing.T) {
+	createAt := time.Unix(1_700_000_000, 0)
+	fields := bson.M{
+		"status": task.StatePending,
+		"error":  "",
+	}
+	update := buildTaskStatusUpdate(fields, createAt)
+
+	set, ok := update["$set"].(bson.M)
+	if !ok {
+		t.Fatalf("$set = %#v, want bson.M", update["$set"])
+	}
+	if _, exists := set["create_at"]; exists {
+		t.Fatal("create_at must not be overwritten on an existing task")
+	}
+	if set["error"] != "" {
+		t.Fatalf("error = %#v, want explicit empty string", set["error"])
+	}
+	setOnInsert, ok := update["$setOnInsert"].(bson.M)
+	if !ok {
+		t.Fatalf("$setOnInsert = %#v, want bson.M", update["$setOnInsert"])
+	}
+	if got := setOnInsert["create_at"]; got != createAt {
+		t.Fatalf("insert create_at = %#v, want %v", got, createAt)
+	}
+}

--- a/distributed/backend/backend_redis/durable_chord_namespace_regression_test.go
+++ b/distributed/backend/backend_redis/durable_chord_namespace_regression_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/go-redis/redis/v8"
@@ -73,6 +74,137 @@ func TestRedisRawKeyWritersRejectDurableChordNamespace(t *testing.T) {
 		}
 		if _, err := client.Get(context.Background(), id).Result(); !errors.Is(err, redis.Nil) {
 			t.Fatalf("fresh reserved key was created: %v", err)
+		}
+	})
+}
+
+func TestRedisPublicationAttemptAPIsRejectDurableChordNamespace(t *testing.T) {
+	recordKey, err := redisChordRecordKey(backend.ChordDeliveryKey("reserved-group", "reserved-callback"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	reservedIDs := []struct {
+		name string
+		id   string
+	}{
+		{name: "chord record", id: recordKey},
+		{name: "delivery index", id: redisChordDeliveryIndexKey},
+		{name: "metadata index", id: redisChordIndexStateKey},
+	}
+	attemptAPIs := []struct {
+		name string
+		call func(*BackendRedis, *task.Signature) (bool, error)
+	}{
+		{
+			name: "pending with attempt",
+			call: func(b *BackendRedis, signature *task.Signature) (bool, error) {
+				return false, b.SetStatePendingAttempt(signature, "attempt-b")
+			},
+		},
+		{
+			name: "fail pending attempt",
+			call: func(b *BackendRedis, signature *task.Signature) (bool, error) {
+				return b.FailPendingAttempt(signature, "attempt-a", "must not be written")
+			},
+		},
+	}
+
+	for _, api := range attemptAPIs {
+		t.Run(api.name, func(t *testing.T) {
+			for _, reserved := range reservedIDs {
+				t.Run(reserved.name, func(t *testing.T) {
+					mr := miniredis.RunT(t)
+					client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+					t.Cleanup(func() { _ = client.Close() })
+					b := NewBackendRedis(client, 60).(*BackendRedis)
+					signature := &task.Signature{ID: reserved.id, GroupID: "group", Name: "task"}
+					seeded := &persistedTaskStatus{
+						Status:               task.NewPendingState(signature),
+						PublicationAttemptID: "attempt-a",
+					}
+					body, err := json.Marshal(seeded)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if err := client.Set(context.Background(), reserved.id, body, 5*time.Minute).Err(); err != nil {
+						t.Fatal(err)
+					}
+					beforeBody, err := client.Get(context.Background(), reserved.id).Bytes()
+					if err != nil {
+						t.Fatal(err)
+					}
+					beforeTTL, err := client.PTTL(context.Background(), reserved.id).Result()
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					changed, callErr := api.call(b, signature)
+					if changed {
+						t.Fatal("reserved attempt API reported a state change")
+					}
+					if !errors.Is(callErr, backend.ErrChordInvalidInput) {
+						t.Fatalf("attempt API error = %v, want ErrChordInvalidInput", callErr)
+					}
+					wantErr := fmt.Sprintf(
+						"%s: redis task id %q uses reserved key prefix %q",
+						backend.ErrChordInvalidInput,
+						reserved.id,
+						redisChordKeyPrefix,
+					)
+					if callErr.Error() != wantErr {
+						t.Fatalf("attempt API error = %q, want %q", callErr, wantErr)
+					}
+
+					afterBody, err := client.Get(context.Background(), reserved.id).Bytes()
+					if err != nil {
+						t.Fatal(err)
+					}
+					afterTTL, err := client.PTTL(context.Background(), reserved.id).Result()
+					if err != nil {
+						t.Fatal(err)
+					}
+					if string(afterBody) != string(beforeBody) || afterTTL != beforeTTL {
+						t.Fatalf(
+							"reserved attempt API changed Redis value or TTL: body=%q want=%q ttl=%s want=%s",
+							afterBody,
+							beforeBody,
+							afterTTL,
+							beforeTTL,
+						)
+					}
+					var stored persistedTaskStatus
+					if err := json.Unmarshal(afterBody, &stored); err != nil {
+						t.Fatal(err)
+					}
+					if stored.Status == nil || stored.Status.Status != task.StatePending || stored.Status.Error != "" || stored.PublicationAttemptID != "attempt-a" {
+						t.Fatalf("reserved attempt state changed: %#v", stored)
+					}
+				})
+			}
+		})
+	}
+
+	t.Run("ordinary user key retains attempt CAS", func(t *testing.T) {
+		mr := miniredis.RunT(t)
+		client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+		t.Cleanup(func() { _ = client.Close() })
+		b := NewBackendRedis(client, 60).(*BackendRedis)
+		signature := &task.Signature{ID: "ordinary-publication-attempt", GroupID: "group", Name: "task"}
+		if err := b.SetStatePendingAttempt(signature, "attempt-a"); err != nil {
+			t.Fatal(err)
+		}
+		if changed, err := b.FailPendingAttempt(signature, "stale-attempt", "stale"); err != nil || changed {
+			t.Fatalf("stale attempt = (%t, %v), want false, nil", changed, err)
+		}
+		if changed, err := b.FailPendingAttempt(signature, "attempt-a", "publish failed"); err != nil || !changed {
+			t.Fatalf("matching attempt = (%t, %v), want true, nil", changed, err)
+		}
+		status, err := b.GetStatus(signature.ID)
+		if err != nil || status.Status != task.StateFailure || status.Error != "publish failed" {
+			t.Fatalf("ordinary attempt status = %#v, %v", status, err)
+		}
+		if ttl := mr.TTL(signature.ID); ttl <= 0 || ttl > time.Minute {
+			t.Fatalf("ordinary attempt TTL = %s, want preserved positive TTL", ttl)
 		}
 	})
 }

--- a/distributed/backend/backend_redis/error_reset_test.go
+++ b/distributed/backend/backend_redis/error_reset_test.go
@@ -2,11 +2,17 @@ package backend_redis
 
 import (
 	"testing"
+	"time"
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/go-redis/redis/v8"
 	"github.com/songzhibin97/gkit/distributed/task"
 )
+
+type publicationAttemptBackendForTest interface {
+	SetStatePendingAttempt(*task.Signature, string) error
+	FailPendingAttempt(*task.Signature, string, string) (bool, error)
+}
 
 func TestNonFailureTransitionsClearPreviousError(t *testing.T) {
 	mr := miniredis.RunT(t)
@@ -51,5 +57,67 @@ func TestNonFailureTransitionsClearPreviousError(t *testing.T) {
 				t.Fatalf("%s error = %q, want cleared", tt.name, status.Error)
 			}
 		})
+	}
+}
+
+func TestPublicationAttemptCompensation(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	b := NewBackendRedis(client, 60)
+	attemptBackend, ok := b.(publicationAttemptBackendForTest)
+	if !ok {
+		t.Fatal("BackendRedis does not implement atomic publication-attempt compensation")
+	}
+	signature := &task.Signature{ID: "publication-attempt", GroupID: "group", Name: "task"}
+	if err := attemptBackend.SetStatePendingAttempt(signature, "attempt-a"); err != nil {
+		t.Fatal(err)
+	}
+	ttlBefore := mr.TTL(signature.ID)
+	if changed, err := attemptBackend.FailPendingAttempt(signature, "attempt-a", "publish failed"); err != nil || !changed {
+		t.Fatalf("matching compensation = (%t, %v), want true, nil", changed, err)
+	}
+	if ttlAfter := mr.TTL(signature.ID); ttlAfter != ttlBefore || ttlAfter <= 0 || ttlAfter > time.Minute {
+		t.Fatalf("TTL after compensation = %s, before %s", ttlAfter, ttlBefore)
+	}
+	status, err := b.GetStatus(signature.ID)
+	if err != nil || status.Status != task.StateFailure || status.Error != "publish failed" {
+		t.Fatalf("matching status = %#v, %v", status, err)
+	}
+
+	if err := attemptBackend.SetStatePendingAttempt(signature, "attempt-b"); err != nil {
+		t.Fatal(err)
+	}
+	if changed, err := attemptBackend.FailPendingAttempt(signature, "attempt-a", "stale attempt"); err != nil || changed {
+		t.Fatalf("stale compensation = (%t, %v), want false, nil", changed, err)
+	}
+	status, err = b.GetStatus(signature.ID)
+	if err != nil || status.Status != task.StatePending || status.Error != "" {
+		t.Fatalf("stale-attempt status = %#v, %v", status, err)
+	}
+}
+
+func TestPublicationAttemptCompensationLegacyRecordDoesNotMatch(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	b := NewBackendRedis(client, -1)
+	attemptBackend, ok := b.(publicationAttemptBackendForTest)
+	if !ok {
+		t.Fatal("BackendRedis does not implement atomic publication-attempt compensation")
+	}
+	signature := &task.Signature{ID: "legacy-pending", GroupID: "group", Name: "task"}
+	if err := attemptBackend.SetStatePendingAttempt(signature, "stale-owner"); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.SetStatePending(signature); err != nil {
+		t.Fatal(err)
+	}
+	if changed, err := attemptBackend.FailPendingAttempt(signature, "stale-owner", "publish failed"); err != nil || changed {
+		t.Fatalf("legacy compensation = (%t, %v), want false, nil", changed, err)
+	}
+	status, err := b.GetStatus(signature.ID)
+	if err != nil || status.Status != task.StatePending {
+		t.Fatalf("legacy status = %#v, %v", status, err)
 	}
 }

--- a/distributed/backend/backend_redis/error_reset_test.go
+++ b/distributed/backend/backend_redis/error_reset_test.go
@@ -1,0 +1,55 @@
+package backend_redis
+
+import (
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/go-redis/redis/v8"
+	"github.com/songzhibin97/gkit/distributed/task"
+)
+
+func TestNonFailureTransitionsClearPreviousError(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	backend := NewBackendRedis(client, -1)
+	tests := []struct {
+		name       string
+		wantState  task.State
+		transition func(*task.Signature) error
+	}{
+		{name: "pending", wantState: task.StatePending, transition: backend.SetStatePending},
+		{name: "received", wantState: task.StateReceived, transition: backend.SetStateReceived},
+		{name: "started", wantState: task.StateStarted, transition: backend.SetStateStarted},
+		{name: "retry", wantState: task.StateRetry, transition: backend.SetStateRetry},
+		{name: "success", wantState: task.StateSuccess, transition: func(sig *task.Signature) error { return backend.SetStateSuccess(sig, nil) }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			signature := &task.Signature{ID: "task-" + tt.name, GroupID: "group", Name: "task"}
+			if err := backend.SetStateFailure(signature, "stale failure"); err != nil {
+				t.Fatal(err)
+			}
+			failed, err := backend.GetStatus(signature.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if failed.Status != task.StateFailure || failed.Error != "stale failure" {
+				t.Fatalf("failure state = (%s, %q), want (FAILURE, stale failure)", failed.Status, failed.Error)
+			}
+			if err := tt.transition(signature); err != nil {
+				t.Fatal(err)
+			}
+			status, err := backend.GetStatus(signature.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if status.Status != tt.wantState {
+				t.Fatalf("status = %s, want %s", status.Status, tt.wantState)
+			}
+			if status.Error != "" {
+				t.Fatalf("%s error = %q, want cleared", tt.name, status.Error)
+			}
+		})
+	}
+}

--- a/distributed/backend/backend_redis/publication_attempt_integration_test.go
+++ b/distributed/backend/backend_redis/publication_attempt_integration_test.go
@@ -1,0 +1,59 @@
+package backend_redis
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/go-redis/redis/v8"
+	"github.com/songzhibin97/gkit/distributed/task"
+)
+
+func TestPublicationAttemptCompensationRealRedis(t *testing.T) {
+	addr := os.Getenv("GKIT_REDIS_ADDR")
+	if addr == "" {
+		t.Skip("GKIT_REDIS_ADDR is not set")
+	}
+	client := redis.NewClient(&redis.Options{Addr: addr})
+	t.Cleanup(func() { _ = client.Close() })
+	if err := client.Ping(context.Background()).Err(); err != nil {
+		t.Fatal(err)
+	}
+	backend := NewBackendRedis(client, 60).(*BackendRedis)
+	signature := &task.Signature{
+		ID:      fmt.Sprintf("gkit-publication-attempt-%d", time.Now().UnixNano()),
+		GroupID: "group",
+		Name:    "task",
+	}
+	t.Cleanup(func() { _ = client.Del(context.Background(), signature.ID).Err() })
+
+	if err := backend.SetStatePendingAttempt(signature, "attempt-a"); err != nil {
+		t.Fatal(err)
+	}
+	ttlBefore, err := client.PTTL(context.Background(), signature.ID).Result()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed, err := backend.FailPendingAttempt(signature, "attempt-a", "publish failed"); err != nil || !changed {
+		t.Fatalf("matching compensation = (%t, %v), want true, nil", changed, err)
+	}
+	ttlAfter, err := client.PTTL(context.Background(), signature.ID).Result()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ttlAfter <= 0 || ttlAfter > ttlBefore || ttlBefore-ttlAfter > time.Second {
+		t.Fatalf("TTL changed unexpectedly: before=%s after=%s", ttlBefore, ttlAfter)
+	}
+	if err := backend.SetStatePendingAttempt(signature, "attempt-b"); err != nil {
+		t.Fatal(err)
+	}
+	if changed, err := backend.FailPendingAttempt(signature, "attempt-a", "stale attempt"); err != nil || changed {
+		t.Fatalf("stale compensation = (%t, %v), want false, nil", changed, err)
+	}
+	status, err := backend.GetStatus(signature.ID)
+	if err != nil || status.Status != task.StatePending || status.Error != "" {
+		t.Fatalf("final status = %#v, %v", status, err)
+	}
+}

--- a/distributed/backend/backend_redis/redis.go
+++ b/distributed/backend/backend_redis/redis.go
@@ -241,6 +241,9 @@ func (b *BackendRedis) FailPendingAttempt(signature *task.Signature, attemptID, 
 	if attemptID == "" {
 		return false, nil
 	}
+	if err := validateRedisUserKey("task", signature.ID); err != nil {
+		return false, err
+	}
 	changed, err := failPendingAttemptScript.Run(
 		context.Background(),
 		b.client,

--- a/distributed/backend/backend_redis/redis.go
+++ b/distributed/backend/backend_redis/redis.go
@@ -28,6 +28,41 @@ var ErrType = errors.New("err type")
 // Redis transport failure.
 var ErrGroupAlreadyExists = errors.New("group already exists")
 
+type persistedTaskStatus struct {
+	*task.Status
+	PublicationAttemptID string `json:"publication_attempt_id,omitempty"`
+}
+
+var failPendingAttemptScript = redis.NewScript(`
+local raw = redis.call("GET", KEYS[1])
+if not raw then
+  return 0
+end
+
+local current = cjson.decode(raw)
+if tonumber(current.status) ~= tonumber(ARGV[2]) then
+  return 0
+end
+if current.publication_attempt_id ~= ARGV[1] then
+  return 0
+end
+
+local ttl = redis.call("PTTL", KEYS[1])
+if ttl == 0 or ttl == -2 then
+  return 0
+end
+
+current.status = tonumber(ARGV[3])
+current.error = ARGV[4]
+local updated = cjson.encode(current)
+if ttl > 0 then
+  redis.call("SET", KEYS[1], updated, "PX", ttl)
+else
+  redis.call("SET", KEYS[1], updated)
+end
+return 1
+`)
+
 type BackendRedis struct {
 	// client redis客户端
 	client redis.UniversalClient
@@ -188,6 +223,32 @@ func (b *BackendRedis) SetStatePending(signature *task.Signature) error {
 	return b.updateStatus(task.NewPendingState(signature))
 }
 
+func (b *BackendRedis) SetStatePendingAttempt(signature *task.Signature, attemptID string) error {
+	if attemptID == "" {
+		return errors.New("backend_redis: empty publication attempt ID")
+	}
+	return b.updateStatusWithAttempt(task.NewPendingState(signature), attemptID)
+}
+
+func (b *BackendRedis) FailPendingAttempt(signature *task.Signature, attemptID, reason string) (bool, error) {
+	if attemptID == "" {
+		return false, nil
+	}
+	changed, err := failPendingAttemptScript.Run(
+		context.Background(),
+		b.client,
+		[]string{signature.ID},
+		attemptID,
+		int(task.StatePending),
+		int(task.StateFailure),
+		reason,
+	).Int()
+	if err != nil {
+		return false, err
+	}
+	return changed == 1, nil
+}
+
 func (b *BackendRedis) SetStateReceived(signature *task.Signature) error {
 	dst := task.NewReceivedState(signature)
 	b.migrate(dst)
@@ -281,7 +342,14 @@ func (b *BackendRedis) getGroup(groupID string) (*task.GroupMeta, error) {
 
 // updateStatus 更新状态
 func (b *BackendRedis) updateStatus(status *task.Status) error {
-	body, err := json.Marshal(status)
+	return b.updateStatusWithAttempt(status, "")
+}
+
+func (b *BackendRedis) updateStatusWithAttempt(status *task.Status, attemptID string) error {
+	body, err := json.Marshal(&persistedTaskStatus{
+		Status:               status,
+		PublicationAttemptID: attemptID,
+	})
 	if err != nil {
 		return err
 	}

--- a/distributed/callback_publish_compensation_test.go
+++ b/distributed/callback_publish_compensation_test.go
@@ -1,6 +1,7 @@
 package distributed
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	"github.com/songzhibin97/gkit/distributed/backend"
 	backendredis "github.com/songzhibin97/gkit/distributed/backend/backend_redis"
 	"github.com/songzhibin97/gkit/distributed/task"
+	"github.com/songzhibin97/gkit/log"
 )
 
 const wantTaskPublicationFailureMessage = "task publication outcome unknown"
@@ -473,6 +475,61 @@ func TestOrdinaryCallbackPublicationErrorsReachErrorHandler(t *testing.T) {
 			}
 			if callbackErr == nil || !errors.Is(callbackErr, publishErr) || !errors.Is(callbackErr, compensationErr) {
 				t.Fatalf("reported errors = %v, want joined callback publication and compensation errors", reported)
+			}
+		})
+	}
+}
+
+func TestOrdinaryCallbackPublicationErrorsReachStructuredLogger(t *testing.T) {
+	publishErr := errors.New("callback publish failed")
+	compensationErr := errors.New("callback compensation failed")
+	parentErr := errors.New("parent task failed")
+	tests := []struct {
+		name     string
+		dispatch func(*Worker, *task.Signature) error
+	}{
+		{name: "success callback", dispatch: func(worker *Worker, parent *task.Signature) error {
+			return worker.handlerSucceeded(parent, nil)
+		}},
+		{name: "error callback", dispatch: func(worker *Worker, parent *task.Signature) error {
+			return worker.handlerFailed(parent, parentErr)
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server, baseBackend := newCallbackPublishTestServer(t, func(context.Context, *task.Signature) error {
+				return publishErr
+			})
+			server.backend = &callbackCompensationFailBackend{Backend: baseBackend, err: compensationErr}
+			var logs bytes.Buffer
+			server.helper = log.NewHelper(log.NewStdLogger(&logs))
+
+			const sensitivePayload = "sensitive-callback-payload"
+			callback := task.NewSignature("logged-callback", "callback")
+			callback.Args = []task.Arg{{Type: "string", Value: sensitivePayload}}
+			parent := task.NewSignature("logged-parent", "parent")
+			parent.CallbackOnSuccess = []*task.Signature{callback}
+			parent.CallbackOnError = []*task.Signature{callback}
+			worker := &Worker{bindService: server}
+
+			if err := tt.dispatch(worker, parent); err != nil {
+				t.Fatalf("dispatch returned error: %v", err)
+			}
+			output := logs.String()
+			if strings.Contains(output, sensitivePayload) {
+				t.Fatal("structured callback publication log exposed callback arguments")
+			}
+			for _, want := range []string{
+				"[Error] message=Callback publication failed:",
+				callback.ID,
+				parent.ID,
+				publishErr.Error(),
+				compensationErr.Error(),
+			} {
+				if !strings.Contains(output, want) {
+					t.Fatalf("structured callback publication log = %q, want %q", output, want)
+				}
 			}
 		})
 	}

--- a/distributed/callback_publish_compensation_test.go
+++ b/distributed/callback_publish_compensation_test.go
@@ -1,0 +1,234 @@
+package distributed
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/go-redis/redis/v8"
+	"github.com/songzhibin97/gkit/distributed/backend"
+	backendredis "github.com/songzhibin97/gkit/distributed/backend/backend_redis"
+	"github.com/songzhibin97/gkit/distributed/task"
+)
+
+const wantTaskPublicationFailureMessage = "task publication outcome unknown"
+
+type callbackPublishController struct {
+	publish func(context.Context, *task.Signature) error
+}
+
+func (*callbackPublishController) RegisterTask(...string)     {}
+func (*callbackPublishController) IsRegisterTask(string) bool { return true }
+func (*callbackPublishController) StartConsuming(int, task.Processor) (bool, error) {
+	return false, nil
+}
+func (*callbackPublishController) StopConsuming() {}
+func (c *callbackPublishController) Publish(ctx context.Context, signature *task.Signature) error {
+	if c.publish != nil {
+		return c.publish(ctx, signature)
+	}
+	return nil
+}
+func (*callbackPublishController) GetPendingTasks(string) ([]*task.Signature, error) { return nil, nil }
+func (*callbackPublishController) GetDelayedTasks() ([]*task.Signature, error)       { return nil, nil }
+func (*callbackPublishController) SetConsumingQueue(string)                          {}
+func (*callbackPublishController) SetDelayedQueue(string)                            {}
+
+type callbackCompensationFailBackend struct {
+	backend.Backend
+	err error
+}
+
+func (b *callbackCompensationFailBackend) SetStateFailure(*task.Signature, string) error {
+	return b.err
+}
+
+func newCallbackPublishTestServer(t *testing.T, publish func(context.Context, *task.Signature) error) (*Server, backend.Backend) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	b := backendredis.NewBackendRedis(client, -1)
+	return &Server{
+		config:     &Config{ConsumeQueue: "callback-test"},
+		backend:    b,
+		controller: &callbackPublishController{publish: publish},
+	}, b
+}
+
+func assertCallbackTaskState(t *testing.T, b backend.Backend, taskID string, wantState task.State, wantError string) {
+	t.Helper()
+	status, err := b.GetStatus(taskID)
+	if err != nil {
+		t.Fatalf("GetStatus(%q): %v", taskID, err)
+	}
+	if status.Status != wantState {
+		t.Fatalf("status %q = %s, want %s", taskID, status.Status, wantState)
+	}
+	if status.Error != wantError {
+		t.Fatalf("status %q error = %q, want %q", taskID, status.Error, wantError)
+	}
+}
+
+func assertPendingAtPublish(t *testing.T, b backend.Backend, signature *task.Signature) {
+	t.Helper()
+	assertCallbackTaskState(t, b, signature.ID, task.StatePending, "")
+}
+
+func TestSendTaskPublishFailureConvergesPendingState(t *testing.T) {
+	publishErr := errors.New("broker publish failed")
+	var b backend.Backend
+	server, b := newCallbackPublishTestServer(t, func(_ context.Context, signature *task.Signature) error {
+		assertPendingAtPublish(t, b, signature)
+		return publishErr
+	})
+	signature := task.NewSignature("callback-failed", "callback")
+
+	asyncResult, err := server.SendTaskWithContext(context.Background(), signature)
+	if asyncResult != nil {
+		t.Fatalf("async result = %#v, want nil on publication failure", asyncResult)
+	}
+	if !errors.Is(err, publishErr) {
+		t.Fatalf("error = %v, want wrapped publication error", err)
+	}
+	if !strings.Contains(err.Error(), "publish task callback-failed") {
+		t.Fatalf("error = %v, want task publication context", err)
+	}
+	assertCallbackTaskState(t, b, signature.ID, task.StateFailure, wantTaskPublicationFailureMessage)
+}
+
+func TestSendTaskPublishCompensationPreservesBothErrors(t *testing.T) {
+	publishErr := errors.New("broker publish failed")
+	compensationErr := errors.New("persist failure state failed")
+	var baseBackend backend.Backend
+	server, baseBackend := newCallbackPublishTestServer(t, func(_ context.Context, signature *task.Signature) error {
+		assertPendingAtPublish(t, baseBackend, signature)
+		return publishErr
+	})
+	server.backend = &callbackCompensationFailBackend{Backend: baseBackend, err: compensationErr}
+
+	asyncResult, err := server.SendTaskWithContext(context.Background(), task.NewSignature("callback-compensation-failed", "callback"))
+	if asyncResult != nil {
+		t.Fatalf("async result = %#v, want nil on publication failure", asyncResult)
+	}
+	if !errors.Is(err, publishErr) || !errors.Is(err, compensationErr) {
+		t.Fatalf("error = %v, want publication and compensation errors", err)
+	}
+	if !strings.Contains(err.Error(), "publish task callback-compensation-failed") ||
+		!strings.Contains(err.Error(), "converge task callback-compensation-failed") {
+		t.Fatalf("error = %v, want publish and convergence context", err)
+	}
+}
+
+func TestSendTaskRetryAfterPublishFailure(t *testing.T) {
+	publishErr := errors.New("broker publish failed")
+	attempts := 0
+	var b backend.Backend
+	server, b := newCallbackPublishTestServer(t, func(_ context.Context, signature *task.Signature) error {
+		assertPendingAtPublish(t, b, signature)
+		attempts++
+		if attempts == 1 {
+			return publishErr
+		}
+		return nil
+	})
+	signature := task.NewSignature("callback-retry", "callback")
+
+	if asyncResult, err := server.SendTask(signature); asyncResult != nil || !errors.Is(err, publishErr) {
+		t.Fatalf("first send = (%#v, %v), want nil and publication error", asyncResult, err)
+	}
+	assertCallbackTaskState(t, b, signature.ID, task.StateFailure, wantTaskPublicationFailureMessage)
+
+	asyncResult, err := server.SendTask(signature)
+	if err != nil || asyncResult == nil {
+		t.Fatalf("retry send = (%#v, %v), want async result and nil error", asyncResult, err)
+	}
+	assertCallbackTaskState(t, b, signature.ID, task.StatePending, "")
+}
+
+func TestSendTaskAcceptedButPublishReturnedErrorUsesExistingLastWriteSemantics(t *testing.T) {
+	publishErr := errors.New("publish acknowledgement lost")
+	var b backend.Backend
+	server, b := newCallbackPublishTestServer(t, func(_ context.Context, signature *task.Signature) error {
+		assertPendingAtPublish(t, b, signature)
+		if err := b.SetStateSuccess(signature, nil); err != nil {
+			t.Fatalf("simulate worker success: %v", err)
+		}
+		assertCallbackTaskState(t, b, signature.ID, task.StateSuccess, "")
+		return publishErr
+	})
+	signature := task.NewSignature("accepted-before-error", "callback")
+
+	asyncResult, err := server.SendTask(signature)
+	if asyncResult != nil || !errors.Is(err, publishErr) {
+		t.Fatalf("send = (%#v, %v), want nil and ambiguous publication error", asyncResult, err)
+	}
+	assertCallbackTaskState(t, b, signature.ID, task.StateFailure, wantTaskPublicationFailureMessage)
+}
+
+func TestOrdinaryCallbacksUsePublishCompensation(t *testing.T) {
+	tests := []struct {
+		name        string
+		publishErr  error
+		wantState   task.State
+		wantMessage string
+		dispatch    func(*Worker, *task.Signature) error
+	}{
+		{
+			name:      "successful success callback remains pending",
+			wantState: task.StatePending,
+			dispatch: func(worker *Worker, parent *task.Signature) error {
+				return worker.handlerSucceeded(parent, nil)
+			},
+		},
+		{
+			name:      "successful error callback remains pending",
+			wantState: task.StatePending,
+			dispatch: func(worker *Worker, parent *task.Signature) error {
+				worker.errorHandler = func(error) {}
+				return worker.handlerFailed(parent, errors.New("parent task failed"))
+			},
+		},
+		{
+			name:        "failed success callback becomes failed",
+			publishErr:  errors.New("success callback publish failed"),
+			wantState:   task.StateFailure,
+			wantMessage: wantTaskPublicationFailureMessage,
+			dispatch: func(worker *Worker, parent *task.Signature) error {
+				return worker.handlerSucceeded(parent, nil)
+			},
+		},
+		{
+			name:        "failed error callback becomes failed",
+			publishErr:  errors.New("error callback publish failed"),
+			wantState:   task.StateFailure,
+			wantMessage: wantTaskPublicationFailureMessage,
+			dispatch: func(worker *Worker, parent *task.Signature) error {
+				worker.errorHandler = func(error) {}
+				return worker.handlerFailed(parent, errors.New("parent task failed"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var b backend.Backend
+			server, b := newCallbackPublishTestServer(t, func(_ context.Context, signature *task.Signature) error {
+				assertPendingAtPublish(t, b, signature)
+				return tt.publishErr
+			})
+			callback := task.NewSignature("ordinary-callback", "callback")
+			parent := task.NewSignature("parent", "parent")
+			parent.CallbackOnSuccess = []*task.Signature{callback}
+			parent.CallbackOnError = []*task.Signature{callback}
+			worker := &Worker{bindService: server}
+
+			if err := tt.dispatch(worker, parent); err != nil {
+				t.Fatalf("dispatch ordinary callback: %v", err)
+			}
+			assertCallbackTaskState(t, b, callback.ID, tt.wantState, tt.wantMessage)
+		})
+	}
+}

--- a/distributed/callback_publish_compensation_test.go
+++ b/distributed/callback_publish_compensation_test.go
@@ -41,8 +41,70 @@ type callbackCompensationFailBackend struct {
 	err error
 }
 
-func (b *callbackCompensationFailBackend) SetStateFailure(*task.Signature, string) error {
-	return b.err
+type publicationAttemptBackendForTest interface {
+	SetStatePendingAttempt(*task.Signature, string) error
+	FailPendingAttempt(*task.Signature, string, string) (bool, error)
+}
+
+func (b *callbackCompensationFailBackend) SetStateFailure(signature *task.Signature, reason string) error {
+	if reason == taskPublicationFailureMessage {
+		return b.err
+	}
+	return b.Backend.SetStateFailure(signature, reason)
+}
+
+func (b *callbackCompensationFailBackend) SetStatePendingAttempt(signature *task.Signature, attemptID string) error {
+	return b.Backend.(publicationAttemptBackendForTest).SetStatePendingAttempt(signature, attemptID)
+}
+
+func (b *callbackCompensationFailBackend) FailPendingAttempt(*task.Signature, string, string) (bool, error) {
+	return false, b.err
+}
+
+type blockingCallbackCompensationBackend struct {
+	backend.Backend
+	started chan struct{}
+	release chan struct{}
+}
+
+func (b *blockingCallbackCompensationBackend) SetStateFailure(signature *task.Signature, reason string) error {
+	close(b.started)
+	<-b.release
+	return b.Backend.SetStateFailure(signature, reason)
+}
+
+func (b *blockingCallbackCompensationBackend) SetStatePendingAttempt(signature *task.Signature, attemptID string) error {
+	return b.Backend.(publicationAttemptBackendForTest).SetStatePendingAttempt(signature, attemptID)
+}
+
+func (b *blockingCallbackCompensationBackend) FailPendingAttempt(signature *task.Signature, attemptID, reason string) (bool, error) {
+	close(b.started)
+	<-b.release
+	return b.Backend.(publicationAttemptBackendForTest).FailPendingAttempt(signature, attemptID, reason)
+}
+
+type unsupportedCompensationBackend struct {
+	groupTestBackend
+	failureWrites int
+}
+
+func (b *unsupportedCompensationBackend) SetStateFailure(*task.Signature, string) error {
+	b.failureWrites++
+	return nil
+}
+
+type attemptTrackingBackend struct {
+	groupTestBackend
+	pendingAttempts int
+}
+
+func (b *attemptTrackingBackend) SetStatePendingAttempt(*task.Signature, string) error {
+	b.pendingAttempts++
+	return nil
+}
+
+func (*attemptTrackingBackend) FailPendingAttempt(*task.Signature, string, string) (bool, error) {
+	return false, nil
 }
 
 func newCallbackPublishTestServer(t *testing.T, publish func(context.Context, *task.Signature) error) (*Server, backend.Backend) {
@@ -77,7 +139,22 @@ func assertPendingAtPublish(t *testing.T, b backend.Backend, signature *task.Sig
 	assertCallbackTaskState(t, b, signature.ID, task.StatePending, "")
 }
 
-func TestSendTaskPublishFailureConvergesPendingState(t *testing.T) {
+func TestSendTaskSuccessfulPublishLeavesOwnedPendingState(t *testing.T) {
+	var b backend.Backend
+	server, b := newCallbackPublishTestServer(t, func(_ context.Context, signature *task.Signature) error {
+		assertPendingAtPublish(t, b, signature)
+		return nil
+	})
+	signature := task.NewSignature("callback-published", "callback")
+
+	asyncResult, err := server.SendTaskWithContext(context.Background(), signature)
+	if err != nil || asyncResult == nil {
+		t.Fatalf("send = (%#v, %v), want async result and nil error", asyncResult, err)
+	}
+	assertCallbackTaskState(t, b, signature.ID, task.StatePending, "")
+}
+
+func TestSendTaskPublishFailureConvergesOwnedPendingAttempt(t *testing.T) {
 	publishErr := errors.New("broker publish failed")
 	var b backend.Backend
 	server, b := newCallbackPublishTestServer(t, func(_ context.Context, signature *task.Signature) error {
@@ -148,24 +225,142 @@ func TestSendTaskRetryAfterPublishFailure(t *testing.T) {
 	assertCallbackTaskState(t, b, signature.ID, task.StatePending, "")
 }
 
-func TestSendTaskAcceptedButPublishReturnedErrorUsesExistingLastWriteSemantics(t *testing.T) {
+func TestSendTaskPublishFailurePreservesAdvancedState(t *testing.T) {
 	publishErr := errors.New("publish acknowledgement lost")
+	tests := []struct {
+		name       string
+		wantState  task.State
+		wantError  string
+		transition func(backend.Backend, *task.Signature) error
+	}{
+		{name: "received", wantState: task.StateReceived, transition: func(b backend.Backend, signature *task.Signature) error { return b.SetStateReceived(signature) }},
+		{name: "started", wantState: task.StateStarted, transition: func(b backend.Backend, signature *task.Signature) error { return b.SetStateStarted(signature) }},
+		{name: "retry", wantState: task.StateRetry, transition: func(b backend.Backend, signature *task.Signature) error { return b.SetStateRetry(signature) }},
+		{name: "success", wantState: task.StateSuccess, transition: func(b backend.Backend, signature *task.Signature) error { return b.SetStateSuccess(signature, nil) }},
+		{name: "failure", wantState: task.StateFailure, wantError: "worker failed", transition: func(b backend.Backend, signature *task.Signature) error {
+			return b.SetStateFailure(signature, "worker failed")
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var b backend.Backend
+			server, b := newCallbackPublishTestServer(t, func(_ context.Context, signature *task.Signature) error {
+				assertPendingAtPublish(t, b, signature)
+				if err := tt.transition(b, signature); err != nil {
+					t.Fatalf("simulate worker transition: %v", err)
+				}
+				return publishErr
+			})
+			signature := task.NewSignature("accepted-before-error-"+tt.name, "callback")
+
+			asyncResult, err := server.SendTask(signature)
+			if asyncResult != nil || !errors.Is(err, publishErr) {
+				t.Fatalf("send = (%#v, %v), want nil and ambiguous publication error", asyncResult, err)
+			}
+			assertCallbackTaskState(t, b, signature.ID, tt.wantState, tt.wantError)
+		})
+	}
+}
+
+func TestSendTaskAckLostRacePreservesWorkerState(t *testing.T) {
+	publishErr := errors.New("publish acknowledgement lost")
+	server, baseBackend := newCallbackPublishTestServer(t, func(context.Context, *task.Signature) error {
+		return publishErr
+	})
+	blockingBackend := &blockingCallbackCompensationBackend{
+		Backend: baseBackend,
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	server.backend = blockingBackend
+	signature := task.NewSignature("accepted-race", "callback")
+	done := make(chan error, 1)
+	go func() {
+		_, err := server.SendTask(signature)
+		done <- err
+	}()
+
+	<-blockingBackend.started
+	if err := baseBackend.SetStateSuccess(signature, nil); err != nil {
+		t.Fatalf("simulate worker success: %v", err)
+	}
+	close(blockingBackend.release)
+	if err := <-done; !errors.Is(err, publishErr) {
+		t.Fatalf("SendTask error = %v, want publish error", err)
+	}
+	assertCallbackTaskState(t, baseBackend, signature.ID, task.StateSuccess, "")
+}
+
+func TestOldPublishFailureDoesNotClobberNewAttempt(t *testing.T) {
+	publishErr := errors.New("old publish acknowledgement lost")
+	oldPublishStarted := make(chan struct{})
+	releaseOldPublish := make(chan struct{})
+	call := 0
 	var b backend.Backend
 	server, b := newCallbackPublishTestServer(t, func(_ context.Context, signature *task.Signature) error {
 		assertPendingAtPublish(t, b, signature)
-		if err := b.SetStateSuccess(signature, nil); err != nil {
-			t.Fatalf("simulate worker success: %v", err)
+		call++
+		if call == 1 {
+			close(oldPublishStarted)
+			<-releaseOldPublish
+			return publishErr
 		}
-		assertCallbackTaskState(t, b, signature.ID, task.StateSuccess, "")
-		return publishErr
+		return nil
 	})
-	signature := task.NewSignature("accepted-before-error", "callback")
-
-	asyncResult, err := server.SendTask(signature)
-	if asyncResult != nil || !errors.Is(err, publishErr) {
-		t.Fatalf("send = (%#v, %v), want nil and ambiguous publication error", asyncResult, err)
+	oldSignature := task.NewSignature("reused-task-id", "callback")
+	newSignature := task.NewSignature("reused-task-id", "callback")
+	oldDone := make(chan error, 1)
+	go func() {
+		_, err := server.SendTask(oldSignature)
+		oldDone <- err
+	}()
+	<-oldPublishStarted
+	if result, err := server.SendTask(newSignature); err != nil || result == nil {
+		t.Fatalf("new attempt = (%#v, %v), want async result and nil error", result, err)
 	}
-	assertCallbackTaskState(t, b, signature.ID, task.StateFailure, wantTaskPublicationFailureMessage)
+	close(releaseOldPublish)
+	if err := <-oldDone; !errors.Is(err, publishErr) {
+		t.Fatalf("old attempt error = %v, want publish error", err)
+	}
+	assertCallbackTaskState(t, b, newSignature.ID, task.StatePending, "")
+}
+
+func TestSendTaskUnsupportedBackendSkipsUnsafeCompensation(t *testing.T) {
+	publishErr := errors.New("publish failed")
+	b := &unsupportedCompensationBackend{}
+	server := &Server{
+		backend: b,
+		controller: &callbackPublishController{publish: func(context.Context, *task.Signature) error {
+			return publishErr
+		}},
+	}
+	if result, err := server.SendTask(task.NewSignature("third-party", "callback")); result != nil || !errors.Is(err, publishErr) {
+		t.Fatalf("SendTask = (%#v, %v), want nil and publish error", result, err)
+	}
+	if b.failureWrites != 0 {
+		t.Fatalf("unsafe failure writes = %d, want 0", b.failureWrites)
+	}
+}
+
+func TestSendTaskAttemptIDGenerationFailureHasNoSideEffects(t *testing.T) {
+	generationErr := errors.New("attempt ID generation failed")
+	b := &attemptTrackingBackend{}
+	publishes := 0
+	server := &Server{
+		backend: b,
+		controller: &callbackPublishController{publish: func(context.Context, *task.Signature) error {
+			publishes++
+			return nil
+		}},
+		publicationAttemptID: func() (string, error) { return "", generationErr },
+	}
+	if result, err := server.SendTask(task.NewSignature("generation-failure", "callback")); result != nil || !errors.Is(err, generationErr) {
+		t.Fatalf("SendTask = (%#v, %v), want nil and generation error", result, err)
+	}
+	if b.pendingAttempts != 0 || len(b.pendingIDs) != 0 || publishes != 0 {
+		t.Fatalf("generation failure caused side effects: attempts=%d pending=%v publishes=%d", b.pendingAttempts, b.pendingIDs, publishes)
+	}
 }
 
 func TestOrdinaryCallbacksUsePublishCompensation(t *testing.T) {
@@ -229,6 +424,56 @@ func TestOrdinaryCallbacksUsePublishCompensation(t *testing.T) {
 				t.Fatalf("dispatch ordinary callback: %v", err)
 			}
 			assertCallbackTaskState(t, b, callback.ID, tt.wantState, tt.wantMessage)
+		})
+	}
+}
+
+func TestOrdinaryCallbackPublicationErrorsReachErrorHandler(t *testing.T) {
+	publishErr := errors.New("callback publish failed")
+	compensationErr := errors.New("callback compensation failed")
+	parentErr := errors.New("parent task failed")
+	tests := []struct {
+		name     string
+		dispatch func(*Worker, *task.Signature) error
+	}{
+		{name: "success callback", dispatch: func(worker *Worker, parent *task.Signature) error {
+			return worker.handlerSucceeded(parent, nil)
+		}},
+		{name: "error callback", dispatch: func(worker *Worker, parent *task.Signature) error {
+			return worker.handlerFailed(parent, parentErr)
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server, baseBackend := newCallbackPublishTestServer(t, func(context.Context, *task.Signature) error {
+				return publishErr
+			})
+			server.backend = &callbackCompensationFailBackend{Backend: baseBackend, err: compensationErr}
+			callback := task.NewSignature("reported-callback", "callback")
+			callback.Args = []task.Arg{{Type: "string", Value: "sensitive-callback-payload"}}
+			parent := task.NewSignature("reported-parent", "parent")
+			parent.CallbackOnSuccess = []*task.Signature{callback}
+			parent.CallbackOnError = []*task.Signature{callback}
+			worker := &Worker{bindService: server}
+			var reported []error
+			worker.errorHandler = func(err error) { reported = append(reported, err) }
+
+			if err := tt.dispatch(worker, parent); err != nil {
+				t.Fatalf("dispatch returned error: %v", err)
+			}
+			var callbackErr error
+			for _, err := range reported {
+				if errors.Is(err, publishErr) || errors.Is(err, compensationErr) {
+					callbackErr = err
+				}
+				if strings.Contains(err.Error(), "sensitive-callback-payload") {
+					t.Fatalf("error handler received sensitive callback payload: %v", err)
+				}
+			}
+			if callbackErr == nil || !errors.Is(callbackErr, publishErr) || !errors.Is(callbackErr, compensationErr) {
+				t.Fatalf("reported errors = %v, want joined callback publication and compensation errors", reported)
+			}
 		})
 	}
 }

--- a/distributed/service.go
+++ b/distributed/service.go
@@ -35,6 +35,8 @@ const minLockTTLMs = 100
 
 const timedRunSuffixLength = 16
 
+const taskPublicationFailureMessage = "task publication outcome unknown"
+
 // timedTaskLockTTL clamps the user-requested TTL into a Redis-acceptable
 // positive integer.
 func timedTaskLockTTL(d time.Duration) int {
@@ -140,9 +142,20 @@ func (s *Server) SendTaskWithContext(ctx context.Context, signature *task.Signat
 	s.bindDefaultRouter(signature)
 	// 任务发布
 	if err := s.controller.Publish(ctx, signature); err != nil {
-		return nil, errors.Wrap(err, "publish err")
+		return nil, s.withTaskPublicationCompensation(signature, err)
 	}
 	return result.NewAsyncResult(signature, s.backend), nil
+}
+
+func (s *Server) withTaskPublicationCompensation(signature *task.Signature, publishErr error) error {
+	primaryErr := fmt.Errorf("publish task %s: %w", signature.ID, publishErr)
+	if err := s.backend.SetStateFailure(signature, taskPublicationFailureMessage); err != nil {
+		return stderrors.Join(
+			primaryErr,
+			fmt.Errorf("converge task %s after publication failure: %w", signature.ID, err),
+		)
+	}
+	return primaryErr
 }
 
 // SendTask 发送任务

--- a/distributed/service.go
+++ b/distributed/service.go
@@ -2,6 +2,8 @@ package distributed
 
 import (
 	"context"
+	cryptorand "crypto/rand"
+	"encoding/hex"
 	stderrors "errors"
 	"fmt"
 	"sync"
@@ -37,6 +39,8 @@ const timedRunSuffixLength = 16
 
 const taskPublicationFailureMessage = "task publication outcome unknown"
 
+const publicationAttemptIDBytes = 16
+
 // timedTaskLockTTL clamps the user-requested TTL into a Redis-acceptable
 // positive integer.
 func timedTaskLockTTL(d time.Duration) int {
@@ -65,6 +69,9 @@ type Server struct {
 	scheduler         *cron.Cron                 // scheduler 调度器
 	prePublishHandler func(task *task.Signature) // prePublishHandler 预处理器
 	helper            *log.Helper
+	// publicationAttemptID is injectable only for deterministic failure tests.
+	// Production servers use generatePublicationAttemptID.
+	publicationAttemptID func() (string, error)
 }
 
 // GetConfig 获取配置文件
@@ -91,6 +98,21 @@ func (s *Server) bindDefaultRouter(signature *task.Signature) {
 	if signature.Router == "" && s.config != nil {
 		signature.Router = s.config.ConsumeQueue
 	}
+}
+
+func generatePublicationAttemptID() (string, error) {
+	var value [publicationAttemptIDBytes]byte
+	if _, err := cryptorand.Read(value[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(value[:]), nil
+}
+
+func (s *Server) nextPublicationAttemptID() (string, error) {
+	if s.publicationAttemptID != nil {
+		return s.publicationAttemptID()
+	}
+	return generatePublicationAttemptID()
 }
 
 // RegisteredTasks 注册多个任务
@@ -131,8 +153,19 @@ func (s *Server) GetRegisteredTask(name string) (interface{}, bool) {
 
 // SendTaskWithContext 发送任务,可以传入ctx
 func (s *Server) SendTaskWithContext(ctx context.Context, signature *task.Signature) (*result.AsyncResult, error) {
-	// 设置任务状态为pending
-	if err := s.backend.SetStatePending(signature); err != nil {
+	attemptBackend, supportsAttemptCompensation := s.backend.(backend.PublicationAttemptBackend)
+	var attemptID string
+	var err error
+	if supportsAttemptCompensation {
+		attemptID, err = s.nextPublicationAttemptID()
+		if err != nil {
+			return nil, fmt.Errorf("generate publication attempt ID: %w", err)
+		}
+		err = attemptBackend.SetStatePendingAttempt(signature, attemptID)
+	} else {
+		err = s.backend.SetStatePending(signature)
+	}
+	if err != nil {
 		return nil, errors.Wrap(err, "set state pending")
 	}
 	// 是否预处理
@@ -142,14 +175,22 @@ func (s *Server) SendTaskWithContext(ctx context.Context, signature *task.Signat
 	s.bindDefaultRouter(signature)
 	// 任务发布
 	if err := s.controller.Publish(ctx, signature); err != nil {
-		return nil, s.withTaskPublicationCompensation(signature, err)
+		return nil, s.withTaskPublicationCompensation(signature, attemptBackend, attemptID, err)
 	}
 	return result.NewAsyncResult(signature, s.backend), nil
 }
 
-func (s *Server) withTaskPublicationCompensation(signature *task.Signature, publishErr error) error {
+func (s *Server) withTaskPublicationCompensation(
+	signature *task.Signature,
+	attemptBackend backend.PublicationAttemptBackend,
+	attemptID string,
+	publishErr error,
+) error {
 	primaryErr := fmt.Errorf("publish task %s: %w", signature.ID, publishErr)
-	if err := s.backend.SetStateFailure(signature, taskPublicationFailureMessage); err != nil {
+	if attemptBackend == nil {
+		return primaryErr
+	}
+	if _, err := attemptBackend.FailPendingAttempt(signature, attemptID, taskPublicationFailureMessage); err != nil {
 		return stderrors.Join(
 			primaryErr,
 			fmt.Errorf("converge task %s after publication failure: %w", signature.ID, err),

--- a/distributed/worker.go
+++ b/distributed/worker.go
@@ -175,7 +175,9 @@ func (w *Worker) handlerSucceeded(signature *task.Signature, results []*task.Res
 				},
 			)
 		}
-		_, _ = w.bindService.SendTask(success)
+		if _, err := w.bindService.SendTask(success); err != nil {
+			w.reportCallbackPublicationError(signature, success, "success", err)
+		}
 	}
 
 	// 如果没有回调,完成
@@ -247,12 +249,31 @@ func (w *Worker) handlerFailed(signature *task.Signature, err error) error {
 	}
 	for _, _error := range signature.CallbackOnError {
 		_error.Args = append([]task.Arg{{Type: "string", Value: err.Error()}}, _error.Args...)
-		_, _ = w.bindService.SendTask(_error)
+		if _, callbackErr := w.bindService.SendTask(_error); callbackErr != nil {
+			w.reportCallbackPublicationError(signature, _error, "error", callbackErr)
+		}
 	}
 	if signature.StopTaskDeletionOnError {
 		return errors.New("StopTaskDeletionOnError")
 	}
 	return nil
+}
+
+func (w *Worker) reportCallbackPublicationError(parent, callback *task.Signature, kind string, err error) {
+	reported := fmt.Errorf(
+		"publish %s callback %s for task %s: %w",
+		kind,
+		callback.ID,
+		parent.ID,
+		err,
+	)
+	if w.errorHandler != nil {
+		w.errorHandler(reported)
+		return
+	}
+	if w.bindService != nil && w.bindService.helper != nil {
+		w.bindService.helper.Errorf("Callback publication failed: %v", reported)
+	}
 }
 
 func (w *Worker) ConsumeQueue() string {

--- a/specs/126/PRODUCT.md
+++ b/specs/126/PRODUCT.md
@@ -1,0 +1,19 @@
+# Callback publication compensation
+
+## Summary
+
+Single-task publication failures must not leave unreachable tasks pending or overwrite work that a broker already accepted. Compensation is safe only when it still owns the pending publication attempt, and callback dispatch failures must remain observable.
+
+## Behavior
+
+1. A publication attempt identifier is created before any task state is written or any publish is attempted; if identifier creation fails, the send returns that error with no backend or controller side effects.
+2. A task is durably pending before publication. A successful publication returns an asynchronous result and does not mark the task failed.
+3. When publication returns an error, compensation changes the task to failure with the neutral reason `task publication outcome unknown` only if the task is still pending for that exact publication attempt; the publication error remains the primary returned error.
+4. Compensation never overwrites a task that has reached received, started, retry, success, or failure, including when that transition races with compensation.
+5. A newer publication attempt using the same task ID is never changed by compensation from an older attempt.
+6. A backend that does not support attempt-aware atomic compensation keeps the legacy pending-before-publish behavior; on publication failure it returns the publication error without attempting an unsafe state overwrite.
+7. If attempt-aware compensation itself fails, the caller receives one error value that preserves both the publication and compensation causes.
+8. SQL, MongoDB, and Redis backends apply the same attempt-aware pending and conditional-failure behavior without shortening result retention; SQL and MongoDB also preserve an existing task creation timestamp.
+9. Existing task records without publication-attempt metadata never match attempt-aware compensation.
+10. A later pending, received, started, retry, or success transition clears stale failure text while preserving the attempt and retention behavior required by that backend.
+11. Publication or compensation failures from ordinary success and error callbacks are delivered to the worker's configured error handler, or its existing structured error path when no handler is configured; callback arguments and other sensitive payload data are not emitted.

--- a/specs/126/TECH.md
+++ b/specs/126/TECH.md
@@ -1,0 +1,39 @@
+# Callback publication compensation technical specification
+
+## Context
+
+[PRODUCT.md](./PRODUCT.md) defines the observable contract. `distributed/service.go` currently writes `PENDING` before `Controller.Publish`, then uses unconditional `Backend.SetStateFailure` after a publish error. That can overwrite worker progress or a newer send of the same task ID. `distributed/backend/backend.go` has no conditional state primitive. The built-in implementations persist task state in SQL (`backend_db/db.go`), MongoDB (`backend_mongodb/mongo.go`), and Redis (`backend_redis/redis.go`). `distributed/worker.go` currently discards ordinary callback send errors.
+
+The PR description refers to this specification directory, but it was absent before this remediation.
+
+## Proposed changes
+
+- Add an optional `backend.PublicationAttemptBackend` interface without changing the existing `backend.Backend` method set. It atomically records a private publication-attempt identifier with `PENDING` and conditionally changes only the matching `PENDING` attempt to `FAILURE`.
+- Generate a cryptographically random attempt identifier in `Server.SendTaskWithContext` before any backend write. A test-only server hook makes the generation-failure path deterministic without mutable process-global state.
+- Use the optional interface for built-in backends. Third-party backends that implement only `backend.Backend` keep `SetStatePending`; publish errors return without unsafe compensation.
+- Keep attempt metadata backend-private:
+  - SQL stores it in a private column on the status table and performs a conditional `UPDATE` by task ID, state, and attempt identifier.
+  - MongoDB stores a private document field and uses a filtered `UpdateOne`. Its update document keeps `$setOnInsert.create_at` compatible with PR #120 while non-failure updates retain `error: ""`.
+  - Redis stores a private JSON field and uses one Lua script to compare and update state while restoring the key's existing TTL.
+- Legacy pending writes clear private attempt ownership so stale metadata cannot be reused. Reads through `task.Status` continue to ignore backend-private metadata.
+- Route ordinary callback send errors through the worker's existing error handler or structured logger, including an `errors.Join` value returned by send compensation. Log context includes task and callback IDs only, never callback arguments.
+
+## Testing and validation
+
+1. Behavior §1 → `TestSendTaskAttemptIDGenerationFailureHasNoSideEffects` injects identifier generation failure and asserts no pending write or publish.
+2. Behavior §2 → `TestSendTaskSuccessfulPublishLeavesOwnedPendingState` asserts pending-at-publish, a non-nil result, and no failure compensation.
+3. Behavior §3 → `TestSendTaskPublishFailureConvergesOwnedPendingAttempt` asserts the neutral failure reason and wrapped primary publish error; reverting the conditional transition must fail it.
+4. Behavior §4 → `TestSendTaskPublishFailurePreservesAdvancedState` covers received, started, retry, success, and failure before the publish error; `TestSendTaskAckLostRacePreservesWorkerState` races worker completion against compensation under `-race`.
+5. Behavior §5 → `TestOldPublishFailureDoesNotClobberNewAttempt` blocks an old publish, starts a newer send with the same task ID, then releases old compensation and asserts the newer pending state survives.
+6. Behavior §6 → `TestSendTaskUnsupportedBackendSkipsUnsafeCompensation` uses a backend that implements only `backend.Backend` and asserts the primary error plus zero failure writes.
+7. Behavior §7 → `TestSendTaskPublishCompensationPreservesBothErrors` asserts `errors.Is` for both causes and contextual messages.
+8. Behavior §8 → backend conformance tests `TestPublicationAttemptCompensation` in Redis, SQL/SQLite, and live MongoDB assert matching/non-matching CAS behavior; `TestPublicationAttemptCompensationLiveSQL` and `TestPublicationAttemptCompensationRealRedis` exercise configured live services. Redis additionally asserts unchanged TTL; SQL and MongoDB assert unchanged `create_at`, with `TestBuildTaskStatusUpdatePreservesCreateAtOnExistingRows` pinning the MongoDB update shape for the synthetic merge with `origin/pr/120`.
+9. Behavior §9 → each backend's `TestPublicationAttemptCompensationLegacyRecordDoesNotMatch` creates a missing-attempt record and proves conditional failure is a no-op.
+10. Behavior §10 → `TestNonFailureTransitionsClearPreviousError` in SQL, MongoDB, and Redis proves stale error text is cleared; the backend legacy-ownership and retention tests separately pin the required attempt and lifetime semantics.
+11. Behavior §11 → `TestOrdinaryCallbackPublicationErrorsReachErrorHandler` covers success and error callbacks and asserts the handler receives both joined causes without payload text.
+
+Verification runs include focused tests, `go test -race ./distributed/...`, backend integration harnesses (live MongoDB when available, SQL through the repository's SQLite harness, Redis through miniredis and a real Redis container when available), `go vet ./distributed/...`, `git diff --check`, an attempt-CAS mutation, and a synthetic merge with `origin/pr/120`.
+
+## Reconciliation
+
+Reconciled on 2026-07-12 against the implementation and tests in `distributed/service.go`, `distributed/worker.go`, and `distributed/backend/`; the final PR head and synthetic-merge results are verified during the publish gate rather than embedded as drift-prone SHAs here.


### PR DESCRIPTION
## What

- compensate single-task publication errors by converging persisted task state from `PENDING` to `FAILURE`
- preserve both publication and compensation errors when the failure-state write also fails
- clear stale failure text on all non-failure transitions in SQL and MongoDB, matching Redis behavior
- add callback-path regression tests plus Redis, SQLite, and live-Mongo backend conformance tests
- document the behavior and verification contract in `specs/callback-publish-compensation/`

## Why

`SendTaskWithContext` persisted `PENDING` before publishing but returned immediately when `Publish` failed. Ordinary success/error callbacks use that path, so a failed callback publication left an unreachable task permanently pending.

Publication errors can be ambiguous after broker acceptance, so the compensation records the neutral reason `task publication outcome unknown` and retains the existing last-write semantics rather than claiming the task never executed.

## How

The send path keeps pending registration before publication. On publish error it writes terminal failure and returns the wrapped publish error; if compensation also fails, `errors.Join` preserves both causes. Every later `PENDING`, `RECEIVED`, `STARTED`, `RETRY`, or `SUCCESS` transition clears the compensation error text across result backends.

MongoDB PR #120 overlaps the pending update map. Integration must retain both this PR's `error: ""` update and #120's `$setOnInsert.create_at` behavior.

## Tests

- `go test ./distributed -run '^(TestSendTaskPublishFailureConvergesPendingState|TestSendTaskPublishCompensationPreservesBothErrors|TestSendTaskRetryAfterPublishFailure|TestSendTaskAcceptedButPublishReturnedErrorUsesExistingLastWriteSemantics|TestOrdinaryCallbacksUsePublishCompensation)$' -count=100`
- `go test -race ./distributed -count=10`
- `go test -race ./distributed/backend/backend_redis -count=10`
- `go test -race ./distributed/backend/backend_db -count=10`
- `GKIT_MONGODB_URI=<isolated-mongo> go test -race ./distributed/backend/backend_mongodb -count=10`
- `GKIT_MONGODB_URI=<isolated-mongo> go test ./distributed ./distributed/backend/backend_redis ./distributed/backend/backend_db ./distributed/backend/backend_mongodb -count=1`
- `go vet ./distributed/...`
- `git diff --check`

Mutation checks confirmed that moving pending registration after publish, dropping compensation, discarding either error, changing the neutral reason, skipping compensation after an ambiguous accepted publish, or retaining stale backend errors causes the corresponding regression test to fail.
