### PR TITLE
fix(clock): align mock ticker lifecycle semantics

### DIFF
--- a/internal/clock/mock_ticker_test.go
+++ b/internal/clock/mock_ticker_test.go
@@ -1,0 +1,134 @@
+package clock
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMockTickerRejectsNonPositivePeriodSynchronously(t *testing.T) {
+	for _, period := range []time.Duration{0, -time.Nanosecond} {
+		t.Run(period.String(), func(t *testing.T) {
+			want := capturePanic(t, func() { time.NewTicker(period) })
+			require.Equal(t, want, capturePanic(t, func() { NewRealTicker(period) }))
+			require.Equal(t, want, capturePanic(t, func() { NewMockTicker(period) }))
+		})
+	}
+}
+
+func TestMockTickerEmitsForPositivePeriod(t *testing.T) {
+	mockClock := NewMockClock()
+	SetClock(mockClock)
+	t.Cleanup(func() { SetClock(NewRealClock()) })
+
+	period := time.Second
+	ticker := NewMockTicker(period)
+	t.Cleanup(ticker.Stop)
+
+	mockClock.Sleep(period)
+	ticker.check()
+
+	select {
+	case tick := <-ticker.C():
+		require.Equal(t, mockClock.Now(), tick)
+	case <-time.After(time.Second):
+		t.Fatal("positive-period mock ticker did not emit")
+	}
+}
+
+func TestMockTickerStopIsIdempotentAndTerminates(t *testing.T) {
+	ticker := NewMockTicker(time.Hour)
+
+	ticker.Stop()
+	ticker.Stop()
+
+	select {
+	case <-ticker.done:
+	case <-time.After(time.Second):
+		t.Fatal("mock ticker background loop did not terminate")
+	}
+
+	select {
+	case tick := <-ticker.C():
+		t.Fatalf("stopped mock ticker emitted an unexpected tick: %v", tick)
+	case <-time.After(5 * time.Millisecond):
+	}
+}
+
+func TestMockTickerStopIsSafeConcurrently(t *testing.T) {
+	ticker := NewMockTicker(time.Hour)
+
+	const callers = 100
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(callers)
+	for i := 0; i < callers; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			ticker.Stop()
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+
+	select {
+	case <-ticker.done:
+	case <-time.After(time.Second):
+		t.Fatal("mock ticker background loop did not terminate")
+	}
+}
+
+func TestMockTickerStopWaitsForPendingCheck(t *testing.T) {
+	mockClock := NewMockClock()
+	SetClock(mockClock)
+	t.Cleanup(func() { SetClock(NewRealClock()) })
+
+	ticker := NewMockTicker(time.Second)
+	ticker.lock.Lock()
+	mockClock.Sleep(time.Second)
+
+	stopReturned := make(chan struct{})
+	go func() {
+		ticker.Stop()
+		close(stopReturned)
+	}()
+
+	select {
+	case <-ticker.stop:
+	case <-time.After(time.Second):
+		ticker.lock.Unlock()
+		t.Fatal("Stop did not signal the background loop")
+	}
+
+	returnedBeforePendingCheck := false
+	select {
+	case <-stopReturned:
+		returnedBeforePendingCheck = true
+	default:
+	}
+	ticker.lock.Unlock()
+
+	require.False(t, returnedBeforePendingCheck, "Stop returned before the pending check completed")
+	select {
+	case <-stopReturned:
+	case <-time.After(time.Second):
+		t.Fatal("Stop did not return after the pending check completed")
+	}
+}
+
+func capturePanic(t *testing.T, f func()) (value any) {
+	t.Helper()
+	defer func() {
+		value = recover()
+		if value == nil {
+			t.Fatal("expected a synchronous panic")
+		}
+	}()
+	f()
+	return fmt.Errorf("unreachable")
+}

--- a/internal/clock/time.go
+++ b/internal/clock/time.go
@@ -142,19 +142,26 @@ func (t *RealTicker) Stop() {
 // MockTicker 测试使用的 Ticker 对象
 // MockTicker 和 MockClock 一般搭配使用
 type MockTicker struct {
-	lock   sync.Mutex
-	period time.Duration
-	c      chan time.Time
-	last   time.Time
-	stop   chan struct{}
+	lock     sync.Mutex
+	stopOnce sync.Once
+	period   time.Duration
+	c        chan time.Time
+	last     time.Time
+	stop     chan struct{}
+	done     chan struct{}
 }
 
 func NewMockTicker(d time.Duration) *MockTicker {
+	if d <= 0 {
+		panic("non-positive interval for NewTicker")
+	}
+
 	t := &MockTicker{
 		period: d,
 		c:      make(chan time.Time, 1),
 		last:   Now(),
 		stop:   make(chan struct{}),
+		done:   make(chan struct{}),
 	}
 
 	go t.checkLoop()
@@ -167,7 +174,10 @@ func (t *MockTicker) C() <-chan time.Time {
 }
 
 func (t *MockTicker) Stop() {
-	close(t.stop)
+	t.stopOnce.Do(func() {
+		close(t.stop)
+	})
+	<-t.done
 }
 
 func (t *MockTicker) check() {
@@ -188,6 +198,9 @@ func (t *MockTicker) check() {
 
 func (t *MockTicker) checkLoop() {
 	ticker := time.NewTicker(time.Microsecond)
+	defer ticker.Stop()
+	defer close(t.done)
+
 	for {
 		select {
 		case <-t.stop:


### PR DESCRIPTION
## What

- reject zero and negative `MockTicker` periods synchronously, matching `time.NewTicker`
- make repeated and concurrent `Stop` calls safe
- wait for the background loop and its real timer to exit before `Stop` returns
- add regression tests for invalid periods, concurrent shutdown, and a check already in progress

## Why

Non-positive periods caused the mock ticker loop to panic asynchronously and exit, while duplicate `Stop` calls panicked by closing the same channel twice. `Stop` could also return while a pending check and timer goroutine were still active.

## How

The constructor validates the period before starting the loop. Shutdown uses `sync.Once` to close the stop signal exactly once, and every caller waits on a completion channel closed only after the loop stops its timer and exits.

## Tests

- `go test -race ./internal/clock -count=100`
- `go vet ./internal/clock`
- `git diff --check`
- mutation checks: removing period validation, `sync.Once`, or the completion wait makes the corresponding regression test fail

The full repository run was additionally attempted. The scoped package passed; unrelated existing gates remain blocked by the MongoDB service dependency, a Redis controller `context canceled` failure, and the open arm64 assembly vet issue.
