### PR TITLE
fix(syncx): make RWMutex padding portable to wasm

### DIFF
--- a/sys/syncx/rwmutex.go
+++ b/sys/syncx/rwmutex.go
@@ -5,12 +5,10 @@ import (
 	"runtime"
 	"sync"
 	"unsafe"
-
-	"golang.org/x/sys/cpu"
 )
 
 const (
-	cacheLineSize = unsafe.Sizeof(cpu.CacheLinePad{})
+	cacheLineSize = 128
 )
 
 var (
@@ -22,7 +20,7 @@ type RWMutex []rwMutexShard
 
 type rwMutexShard struct {
 	sync.RWMutex
-	_pad [cacheLineSize - unsafe.Sizeof(sync.RWMutex{})]byte
+	_pad [cacheLineSize - unsafe.Sizeof(sync.RWMutex{})%cacheLineSize]byte
 }
 
 func init() {

--- a/sys/syncx/rwmutex_layout_test.go
+++ b/sys/syncx/rwmutex_layout_test.go
@@ -1,0 +1,19 @@
+package syncx
+
+import (
+	"sync"
+	"testing"
+	"unsafe"
+)
+
+func TestRWMutexShardPadding(t *testing.T) {
+	const alignment = uintptr(128)
+
+	shardSize := unsafe.Sizeof(rwMutexShard{})
+	if shardSize < unsafe.Sizeof(sync.RWMutex{}) {
+		t.Fatalf("shard size %d is smaller than sync.RWMutex", shardSize)
+	}
+	if shardSize%alignment != 0 {
+		t.Fatalf("shard size %d is not a multiple of %d", shardSize, alignment)
+	}
+}


### PR DESCRIPTION
## What

- make the sharded `RWMutex` cache-line padding compile on wasm targets
- keep every shard size aligned to a conservative 128-byte boundary
- add a regression test for the resulting layout

## Why

On `js/wasm` and `wasip1/wasm`, `x/sys/cpu.CacheLinePad` has size zero. Subtracting the native `sync.RWMutex` size from that value produced a negative array length at compile time, so the package could not be built for either wasm target.

## How

Use the same fixed 128-byte modulo-padding strategy already used by the package's pool implementation. This avoids negative constant arithmetic across architectures and keeps adjacent shards separated without changing the public API.

## Tests

- `GOOS=js GOARCH=wasm go test -c ./sys/syncx`
- `GOOS=wasip1 GOARCH=wasm go test -c ./sys/syncx`
- cross-compile checks for linux, darwin, and windows on amd64 and arm64
- `go test -race ./sys/syncx -count=1`
- `go test -race ./sys/syncx -run '^TestRWMutexShardPadding$' -count=100`
- `go vet ./sys/syncx`
- mutation checks restore the old wasm compile failure and detect a broken 120-byte shard layout
