### PR TITLE
fix(metadata): normalize merged client keys

### DIFF
--- a/internal/metadata/merge_normalization_test.go
+++ b/internal/metadata/merge_normalization_test.go
@@ -1,0 +1,57 @@
+package metadata
+
+import (
+	"context"
+	"testing"
+)
+
+func TestMergeToClientContextNormalizesKeys(t *testing.T) {
+	ctx := MergeToClientContext(context.Background(), Metadata{
+		"X-Request-ID": "request-1",
+	})
+	md, ok := FromClientContext(ctx)
+	if !ok {
+		t.Fatal("merged metadata is missing from client context")
+	}
+
+	for _, key := range []string{"x-request-id", "X-REQUEST-ID", "X-Request-Id"} {
+		if got := md.GetValue(key); got != "request-1" {
+			t.Fatalf("GetValue(%q) = %q, want %q", key, got, "request-1")
+		}
+	}
+	if _, exists := md["X-Request-ID"]; exists {
+		t.Fatal("merged metadata retained a non-normalized key")
+	}
+}
+
+func TestMergeToClientContextOverwritesExistingNormalizedKey(t *testing.T) {
+	base := NewMetadata(map[string]string{"x-request-id": "old"})
+	ctx := NewClientContext(context.Background(), base)
+	ctx = MergeToClientContext(ctx, Metadata{"X-Request-ID": "new"})
+
+	md, ok := FromClientContext(ctx)
+	if !ok {
+		t.Fatal("merged metadata is missing from client context")
+	}
+	if got := md.GetValue("x-request-id"); got != "new" {
+		t.Fatalf("GetValue() = %q, want merged value %q", got, "new")
+	}
+	if len(md) != 1 {
+		t.Fatalf("merged metadata has %d entries, want one normalized key", len(md))
+	}
+}
+
+func TestMergeToClientContextIgnoresEmptyKeyOrValue(t *testing.T) {
+	ctx := MergeToClientContext(context.Background(), Metadata{
+		"":            "value",
+		"EMPTY-VALUE": "",
+	})
+	md, ok := FromClientContext(ctx)
+	if !ok {
+		t.Fatal("merged metadata is missing from client context")
+	}
+
+	if len(md) != 0 {
+		t.Fatalf("merged metadata = %#v, want empty key and value ignored", md)
+	}
+}

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -101,7 +101,7 @@ func MergeToClientContext(ctx context.Context, cmd Metadata) context.Context {
 	md, _ := FromClientContext(ctx)
 	md = md.Clone()
 	for k, v := range cmd {
-		md[k] = v
+		md.Set(k, v)
 	}
 	return NewClientContext(ctx, md)
 }


### PR DESCRIPTION
## What

- normalize keys merged into client metadata
- preserve the existing empty-key and empty-value filtering contract
- add regression coverage for case-insensitive lookup and overwrite behavior

## Why

`MergeToClientContext` wrote directly to the metadata map, bypassing the normalization used by every other construction and append path. An uppercase key could be present in the raw map but remain inaccessible through `GetValue`, which always performs a lowercase lookup.

## How

Route merged entries through the existing `Metadata.Set` method. This keeps merge behavior aligned with `NewMetadata` and `AppendToClientContext` without changing the public API.

## Tests

- `go test -race ./internal/metadata -run '^TestMergeToClientContext' -count=100`
- `go test -race ./internal/metadata -count=1`
- `go vet ./internal/metadata`
- `git diff --check`
- mutation check: restoring direct map assignment makes all three regression tests fail
