### PR TITLE
fix(restrictor): reject negative token counts

### DIFF
--- a/restrictor/limiter.go
+++ b/restrictor/limiter.go
@@ -2,13 +2,18 @@ package restrictor
 
 import (
 	"context"
+	"errors"
 	"time"
 )
+
+// ErrInvalidTokenCount reports a request for a negative number of tokens.
+var ErrInvalidTokenCount = errors.New("restrictor: invalid token count")
 
 type Allow interface {
 	// Allow AllowN(time.Now(),1)
 	Allow() bool
-	// AllowN 截止到某一时刻，目前桶中数目是否至少为 n 个，满足则返回 true，同时从桶中消费 n 个 token
+	// AllowN 截止到某一时刻，目前桶中数目是否至少为 n 个，满足则返回 true，同时从桶中消费 n 个 token。
+	// n 小于 0 时返回 false。
 	AllowN(now time.Time, n int) bool
 }
 
@@ -17,6 +22,7 @@ type Wait interface {
 	Wait(ctx context.Context) error
 	// WaitN 如果此时桶内 Token 数组不足 (小于 N)，那么 Wait 方法将会阻塞一段时间，直至 Token 满足条件。如果充足则直接返回
 	// 我们可以设置 context 的 Deadline 或者 Timeout，来决定此次 Wait 的最长时间。
+	// n 小于 0 时返回 ErrInvalidTokenCount。
 	WaitN(ctx context.Context, n int) error
 }
 
@@ -28,6 +34,9 @@ func (a AllowFunc) Allow() bool {
 }
 
 func (a AllowFunc) AllowN(now time.Time, n int) bool {
+	if n < 0 {
+		return false
+	}
 	return a(now, n)
 }
 
@@ -39,5 +48,8 @@ func (w WaitFunc) Wait(ctx context.Context) error {
 }
 
 func (w WaitFunc) WaitN(ctx context.Context, n int) error {
+	if n < 0 {
+		return ErrInvalidTokenCount
+	}
 	return w(ctx, n)
 }

--- a/restrictor/limiter_test.go
+++ b/restrictor/limiter_test.go
@@ -1,0 +1,67 @@
+package restrictor
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestAllowFuncRejectsNegativeCount(t *testing.T) {
+	called := false
+	allow := AllowFunc(func(time.Time, int) bool {
+		called = true
+		return true
+	})
+
+	if allow.AllowN(time.Now(), -1) {
+		t.Fatal("AllowN(-1) = true, want false")
+	}
+	if called {
+		t.Fatal("AllowN(-1) called the wrapped limiter")
+	}
+}
+
+func TestWaitFuncRejectsNegativeCount(t *testing.T) {
+	called := false
+	wait := WaitFunc(func(context.Context, int) error {
+		called = true
+		return nil
+	})
+
+	if err := wait.WaitN(context.Background(), -1); !errors.Is(err, ErrInvalidTokenCount) {
+		t.Fatalf("WaitN(-1) error = %v, want ErrInvalidTokenCount", err)
+	}
+	if called {
+		t.Fatal("WaitN(-1) called the wrapped limiter")
+	}
+}
+
+func TestFuncAdaptersPreserveZeroCount(t *testing.T) {
+	allowCalls := 0
+	allow := AllowFunc(func(_ time.Time, n int) bool {
+		allowCalls++
+		return n == 0
+	})
+	if !allow.AllowN(time.Now(), 0) {
+		t.Fatal("AllowN(0) = false, want true")
+	}
+	if allowCalls != 1 {
+		t.Fatalf("AllowN(0) calls = %d, want 1", allowCalls)
+	}
+
+	waitCalls := 0
+	wait := WaitFunc(func(_ context.Context, n int) error {
+		waitCalls++
+		if n != 0 {
+			t.Fatalf("WaitN forwarded n = %d, want 0", n)
+		}
+		return nil
+	})
+	if err := wait.WaitN(context.Background(), 0); err != nil {
+		t.Fatalf("WaitN(0) error = %v, want nil", err)
+	}
+	if waitCalls != 1 {
+		t.Fatalf("WaitN(0) calls = %d, want 1", waitCalls)
+	}
+}

--- a/restrictor/rate/negative_token_test.go
+++ b/restrictor/rate/negative_token_test.go
@@ -1,0 +1,57 @@
+package rate
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/songzhibin97/gkit/restrictor"
+	xrate "golang.org/x/time/rate"
+)
+
+func TestNewRateRejectsNegativeAllowWithoutMintingTokens(t *testing.T) {
+	limiter := xrate.NewLimiter(0, 1)
+	allow, _ := NewRate(limiter)
+	now := time.Now()
+
+	if !allow(now, 1) {
+		t.Fatal("initial AllowN(1) = false, want true")
+	}
+	negativeAllowed := allow(now, -1)
+	if allow(now, 1) {
+		t.Error("AllowN(1) succeeded after negative request minted a token")
+	}
+	if negativeAllowed {
+		t.Error("direct AllowFunc(-1) = true, want false")
+	}
+	if !allow(now, 0) {
+		t.Fatal("AllowN(0) = false, want true")
+	}
+	if allow(now, 1) {
+		t.Fatal("AllowN(0) consumed or minted a token")
+	}
+}
+
+func TestNewRateRejectsNegativeWaitWithoutMintingTokens(t *testing.T) {
+	limiter := xrate.NewLimiter(0, 1)
+	allow, wait := NewRate(limiter)
+	now := time.Now()
+
+	if !allow(now, 1) {
+		t.Fatal("initial AllowN(1) = false, want true")
+	}
+	err := wait(context.Background(), -1)
+	if allow(now, 1) {
+		t.Error("AllowN(1) succeeded after negative wait minted a token")
+	}
+	if !errors.Is(err, restrictor.ErrInvalidTokenCount) {
+		t.Errorf("direct WaitFunc(-1) error = %v, want ErrInvalidTokenCount", err)
+	}
+	if err := wait(context.Background(), 0); err != nil {
+		t.Fatalf("WaitN(0) error = %v, want nil", err)
+	}
+	if allow(now, 1) {
+		t.Fatal("WaitN(0) consumed or minted a token")
+	}
+}

--- a/restrictor/rate/rate.go
+++ b/restrictor/rate/rate.go
@@ -13,8 +13,14 @@ import (
 // NewRate 返回limiter对应的 restrictor.AllowFunc, restrictor.WaitFunc
 func NewRate(limiter *rate.Limiter) (restrictor.AllowFunc, restrictor.WaitFunc) {
 	return func(now time.Time, n int) bool {
+			if n < 0 {
+				return false
+			}
 			return limiter.AllowN(now, n)
 		}, func(ctx context.Context, n int) error {
+			if n < 0 {
+				return restrictor.ErrInvalidTokenCount
+			}
 			return limiter.WaitN(ctx, n)
 		}
 }

--- a/restrictor/ratelimite/negative_token_test.go
+++ b/restrictor/ratelimite/negative_token_test.go
@@ -1,0 +1,32 @@
+package ratelimite
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/juju/ratelimit"
+	"github.com/songzhibin97/gkit/restrictor"
+)
+
+func TestNewRateLimitRejectsNegativeCounts(t *testing.T) {
+	bucket := ratelimit.NewBucket(time.Hour, 2)
+	allow, wait := NewRateLimit(bucket)
+
+	if allow(time.Now(), -1) {
+		t.Fatal("direct AllowFunc(-1) = true, want false")
+	}
+	if err := wait(context.Background(), -1); !errors.Is(err, restrictor.ErrInvalidTokenCount) {
+		t.Fatalf("direct WaitFunc(-1) error = %v, want ErrInvalidTokenCount", err)
+	}
+	if !allow(time.Now(), 0) {
+		t.Fatal("AllowN(0) = false, want true")
+	}
+	if err := wait(context.Background(), 0); err != nil {
+		t.Fatalf("WaitN(0) error = %v, want nil", err)
+	}
+	if !allow(time.Now(), 2) {
+		t.Fatal("zero or negative requests consumed bucket tokens")
+	}
+}

--- a/restrictor/ratelimite/ratelimite.go
+++ b/restrictor/ratelimite/ratelimite.go
@@ -35,6 +35,9 @@ func NewRateLimit(bucket *ratelimit.Bucket) (restrictor.AllowFunc, restrictor.Wa
 			if n < 0 {
 				return restrictor.ErrInvalidTokenCount
 			}
+			if err := ctx.Err(); err != nil {
+				return err
+			}
 			var maxWait time.Duration
 			if d, ok := ctx.Deadline(); ok {
 				maxWait = time.Until(d)

--- a/restrictor/ratelimite/ratelimite.go
+++ b/restrictor/ratelimite/ratelimite.go
@@ -20,6 +20,9 @@ const defaultWaitWhenNoDeadline = 100 * time.Millisecond
 
 func NewRateLimit(bucket *ratelimit.Bucket) (restrictor.AllowFunc, restrictor.WaitFunc) {
 	return func(now time.Time, n int) bool {
+			if n < 0 {
+				return false
+			}
 			// TakeMaxDuration(n, 0) returns (0, true) only when n tokens are
 			// immediately available; on false it does NOT consume tokens.
 			// The previous TakeAvailable(n) >= n check consumed up to n
@@ -29,6 +32,9 @@ func NewRateLimit(bucket *ratelimit.Bucket) (restrictor.AllowFunc, restrictor.Wa
 			return ok
 		},
 		func(ctx context.Context, n int) error {
+			if n < 0 {
+				return restrictor.ErrInvalidTokenCount
+			}
 			var maxWait time.Duration
 			if d, ok := ctx.Deadline(); ok {
 				maxWait = time.Until(d)

--- a/restrictor/ratelimite/ratelimite_extra_test.go
+++ b/restrictor/ratelimite/ratelimite_extra_test.go
@@ -68,3 +68,30 @@ func TestWait_RespectsCtxCancel(t *testing.T) {
 		t.Fatalf("wait took %v — did not honour ctx.Done", elapsed)
 	}
 }
+
+func TestWait_PreCanceledContextDoesNotConsumeToken(t *testing.T) {
+	b := ratelimit.NewBucket(time.Hour, 1)
+	allow, wait := NewRateLimit(b)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := wait(ctx, 1)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("wait err = %v, want context.Canceled", err)
+	}
+	if !allow(time.Now(), 1) {
+		t.Error("pre-cancelled wait consumed the immediately available token")
+	}
+}
+
+func TestWait_ValidContextConsumesImmediateToken(t *testing.T) {
+	b := ratelimit.NewBucket(time.Hour, 1)
+	allow, wait := NewRateLimit(b)
+
+	if err := wait(context.Background(), 1); err != nil {
+		t.Fatalf("wait err = %v, want nil", err)
+	}
+	if allow(time.Now(), 1) {
+		t.Error("valid wait did not consume the immediately available token")
+	}
+}


### PR DESCRIPTION
## What

- define a shared error for negative token requests
- reject negative counts in both limiter interfaces and both backend adapters
- preserve zero-count success without consuming or creating capacity
- add regression coverage for method calls and direct adapter-function calls

## Why

The x/time rate limiter accepts negative reservations. Passing a negative count through the adapter could mint capacity: an empty limiter became able to grant future positive tokens. Guarding only the interface methods would still allow callers to invoke the returned function values directly.

## How

Return `false` from negative allow requests and `ErrInvalidTokenCount` from negative waits before entering either backend. Apply the same check to `AllowFunc`/`WaitFunc` methods and the x/time and juju adapter closures.

## Tests

- negative allow and wait calls cannot mint tokens
- all six public or directly callable entry points reject negative counts
- zero-count behavior remains compatible
- `go test -race ./restrictor/...`
- `go vet ./restrictor/...`
- each entry-point guard was removed independently and its regression test failed
