### PR TITLE
fix(restrictor): reject pre-canceled rate waits

### DIFF
--- a/restrictor/ratelimite/ratelimite.go
+++ b/restrictor/ratelimite/ratelimite.go
@@ -35,6 +35,9 @@ func NewRateLimit(bucket *ratelimit.Bucket) (restrictor.AllowFunc, restrictor.Wa
 			if n < 0 {
 				return restrictor.ErrInvalidTokenCount
 			}
+			if err := ctx.Err(); err != nil {
+				return err
+			}
 			var maxWait time.Duration
 			if d, ok := ctx.Deadline(); ok {
 				maxWait = time.Until(d)

--- a/restrictor/ratelimite/ratelimite_extra_test.go
+++ b/restrictor/ratelimite/ratelimite_extra_test.go
@@ -68,3 +68,30 @@ func TestWait_RespectsCtxCancel(t *testing.T) {
 		t.Fatalf("wait took %v — did not honour ctx.Done", elapsed)
 	}
 }
+
+func TestWait_PreCanceledContextDoesNotConsumeToken(t *testing.T) {
+	b := ratelimit.NewBucket(time.Hour, 1)
+	allow, wait := NewRateLimit(b)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := wait(ctx, 1)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("wait err = %v, want context.Canceled", err)
+	}
+	if !allow(time.Now(), 1) {
+		t.Error("pre-cancelled wait consumed the immediately available token")
+	}
+}
+
+func TestWait_ValidContextConsumesImmediateToken(t *testing.T) {
+	b := ratelimit.NewBucket(time.Hour, 1)
+	allow, wait := NewRateLimit(b)
+
+	if err := wait(context.Background(), 1); err != nil {
+		t.Fatalf("wait err = %v, want nil", err)
+	}
+	if allow(time.Now(), 1) {
+		t.Error("valid wait did not consume the immediately available token")
+	}
+}


### PR DESCRIPTION
## What

- reject an already canceled context before reserving bucket tokens
- preserve immediately available capacity when a wait cannot proceed
- add regression and valid-context control tests

## Why

The juju rate-limit adapter checked deadlines but not `ctx.Err()` before reserving. When a token was immediately available, a pre-canceled wait returned `nil` and consumed that token instead of returning `context.Canceled` without side effects.

## How

Return the existing context error before calculating a wait duration or calling the bucket. Valid contexts and cancellation while already waiting keep their existing behavior.

## Tests

- pre-canceled wait returns `context.Canceled` and preserves the token
- valid wait still consumes an immediately available token
- waiting-context cancellation remains covered
- `go test -race ./restrictor/ratelimite`
- `go vet ./restrictor/ratelimite`
- removing the precheck makes both the error and token-balance assertions fail
