### PR TITLE
fix(overload): isolate BBR context keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -1168,15 +1168,14 @@ func main() {
 	middle := bbr.NewLimiter()
 
 	// in the middleware 
-	// The ctx carries these two configurable valid data
-	// You can get the limiter type via the ctx.Set
+	// The ctx carries these two configurable values through the typed helpers.
 
 	// Configure to get the limiter type, you can get different limiter according to different api
-	ctx := context.WithValue(context.TODO(), bbr.LimitKey, "key")
+	ctx := bbr.WithLimitKey(context.TODO(), "key")
 
 	// Configurable to report success or not
 	// must be of type overload.
-	ctx = context.WithValue(ctx, bbr.LimitOp, overload.Success)
+	ctx = bbr.WithLimitOp(ctx, overload.Success)
 
 	_ = middle
 }

--- a/overload/bbr/context_key_test.go
+++ b/overload/bbr/context_key_test.go
@@ -1,0 +1,114 @@
+package bbr
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/songzhibin97/gkit/internal/stat"
+	"github.com/songzhibin97/gkit/overload"
+)
+
+func TestMiddlewareLegacyContextValues(t *testing.T) {
+	g := NewGroup()
+	const key = "legacy"
+	called := false
+	wrapped := newLimiterWithGroup(g)(func(context.Context, interface{}) (interface{}, error) {
+		called = true
+		if got := atomic.LoadInt64(&g.Get(key).(*BBR).inFlight); got != 1 {
+			t.Fatalf("legacy limiter inFlight = %d, want 1 while endpoint runs", got)
+		}
+		return nil, nil
+	})
+	ctx := context.WithValue(context.Background(), LimitKey, key)
+	ctx = context.WithValue(ctx, LimitOp, overload.Drop)
+
+	if _, err := wrapped(ctx, nil); err != nil {
+		t.Fatalf("wrapped endpoint: %v", err)
+	}
+	if !called {
+		t.Fatal("wrapped endpoint was not called")
+	}
+	limiter := g.Get(key).(*BBR)
+	if got := limiter.passStat.Reduce(stat.Count); got != 0 {
+		t.Fatalf("legacy Drop pass count = %v, want 0", got)
+	}
+}
+
+func TestMiddlewareWrongLegacyTypesFallBackWithoutPanic(t *testing.T) {
+	g := NewGroup()
+	called := false
+	wrapped := newLimiterWithGroup(g)(func(context.Context, interface{}) (interface{}, error) {
+		called = true
+		if got := atomic.LoadInt64(&g.Get("default").(*BBR).inFlight); got != 1 {
+			t.Fatalf("default limiter inFlight = %d, want 1 while endpoint runs", got)
+		}
+		return nil, nil
+	})
+	ctx := context.WithValue(context.Background(), LimitKey, 42)
+	ctx = context.WithValue(ctx, LimitOp, "drop")
+
+	var panicValue interface{}
+	var err error
+	func() {
+		defer func() { panicValue = recover() }()
+		_, err = wrapped(ctx, nil)
+	}()
+	if panicValue != nil {
+		t.Fatalf("middleware panicked on colliding legacy keys: %v", panicValue)
+	}
+	if err != nil {
+		t.Fatalf("wrapped endpoint: %v", err)
+	}
+	if !called {
+		t.Fatal("wrapped endpoint was not called")
+	}
+}
+
+func TestMiddlewareTypedContextHelpers(t *testing.T) {
+	g := NewGroup()
+	const key = "typed"
+	wrapped := newLimiterWithGroup(g)(func(context.Context, interface{}) (interface{}, error) {
+		if got := atomic.LoadInt64(&g.Get(key).(*BBR).inFlight); got != 1 {
+			t.Fatalf("typed limiter inFlight = %d, want 1 while endpoint runs", got)
+		}
+		return nil, nil
+	})
+	ctx := WithLimitKey(context.Background(), key)
+	ctx = WithLimitOp(ctx, overload.Drop)
+
+	if _, err := wrapped(ctx, nil); err != nil {
+		t.Fatalf("wrapped endpoint: %v", err)
+	}
+	limiter := g.Get(key).(*BBR)
+	if got := limiter.passStat.Reduce(stat.Count); got != 0 {
+		t.Fatalf("typed Drop pass count = %v, want 0", got)
+	}
+}
+
+func TestMiddlewareTypedContextTakesPriorityOverLegacy(t *testing.T) {
+	g := NewGroup()
+	const typedKey = "typed-priority"
+	const legacyKey = "legacy-shadowed"
+	wrapped := newLimiterWithGroup(g)(func(context.Context, interface{}) (interface{}, error) {
+		if got := atomic.LoadInt64(&g.Get(typedKey).(*BBR).inFlight); got != 1 {
+			t.Fatalf("typed limiter inFlight = %d, want 1 while endpoint runs", got)
+		}
+		if got := atomic.LoadInt64(&g.Get(legacyKey).(*BBR).inFlight); got != 0 {
+			t.Fatalf("legacy limiter inFlight = %d, want 0 when typed key is present", got)
+		}
+		return nil, nil
+	})
+	ctx := context.WithValue(context.Background(), LimitKey, legacyKey)
+	ctx = context.WithValue(ctx, LimitOp, overload.Success)
+	ctx = WithLimitKey(ctx, typedKey)
+	ctx = WithLimitOp(ctx, overload.Drop)
+
+	if _, err := wrapped(ctx, nil); err != nil {
+		t.Fatalf("wrapped endpoint: %v", err)
+	}
+	typedLimiter := g.Get(typedKey).(*BBR)
+	if got := typedLimiter.passStat.Reduce(stat.Count); got != 0 {
+		t.Fatalf("typed Drop pass count = %v, want 0", got)
+	}
+}

--- a/overload/bbr/example_test.go
+++ b/overload/bbr/example_test.go
@@ -25,14 +25,14 @@ func ExampleNewLimiter() {
 
 	// 在middleware中
 	// ctx中携带这两个可配置的有效数据
-	// 可以通过 ctx.Set
+	// 使用 WithLimitKey 和 WithLimitOp 设置
 
 	// 配置获取限制器类型,可以根据不同api获取不同的限制器
-	ctx := context.WithValue(context.TODO(), LimitKey, "key")
+	ctx := WithLimitKey(context.TODO(), "key")
 
 	// 可配置成功是否上报
 	// 必须是 overload.Op 类型
-	ctx = context.WithValue(ctx, LimitOp, overload.Success)
+	ctx = WithLimitOp(ctx, overload.Success)
 
 	_ = middle
 }

--- a/overload/bbr/middle.go
+++ b/overload/bbr/middle.go
@@ -9,9 +9,32 @@ import (
 )
 
 const (
+	// LimitKey is the legacy string context key for selecting a limiter.
+	//
+	// Deprecated: use WithLimitKey.
 	LimitKey = "LimitKey"
-	LimitOp  = "LimitLoad"
+	// LimitOp is the legacy string context key for selecting the completion op.
+	//
+	// Deprecated: use WithLimitOp.
+	LimitOp = "LimitLoad"
 )
+
+type contextKey uint8
+
+const (
+	limitKeyContextKey contextKey = iota
+	limitOpContextKey
+)
+
+// WithLimitKey returns a child context that selects the named limiter.
+func WithLimitKey(ctx context.Context, key string) context.Context {
+	return context.WithValue(ctx, limitKeyContextKey, key)
+}
+
+// WithLimitOp returns a child context that reports op when the endpoint returns.
+func WithLimitOp(ctx context.Context, op overload.Op) context.Context {
+	return context.WithValue(ctx, limitOpContextKey, op)
+}
 
 func NewLimiter(options ...options.Option) middleware.MiddleWare {
 	return newLimiterWithGroup(NewGroup(options...))
@@ -25,11 +48,15 @@ func newLimiterWithGroup(g *Group) middleware.MiddleWare {
 		return func(ctx context.Context, i interface{}) (resp interface{}, err error) {
 			defaultKey := "default"
 			defaultOp := overload.Success
-			if v := ctx.Value(LimitKey); v != nil {
-				defaultKey = v.(string)
+			if v, ok := ctx.Value(limitKeyContextKey).(string); ok {
+				defaultKey = v
+			} else if v, ok := ctx.Value(LimitKey).(string); ok {
+				defaultKey = v
 			}
-			if v := ctx.Value(LimitOp); v != nil {
-				defaultOp = v.(overload.Op)
+			if v, ok := ctx.Value(limitOpContextKey).(overload.Op); ok {
+				defaultOp = v
+			} else if v, ok := ctx.Value(LimitOp).(overload.Op); ok {
+				defaultOp = v
 			}
 			limiter := g.Get(defaultKey)
 			f, allowErr := limiter.Allow(ctx)


### PR DESCRIPTION
## What

- add typed context helpers for selecting BBR limiters and completion operations
- keep the legacy exported string keys as deprecated compatibility fallbacks
- prevent colliding context values of the wrong type from panicking middleware
- update examples and regression coverage

## Why

The middleware used exported plain-string context keys and forced type assertions. Any unrelated package using the same string could inject a different value type and crash the request path.

## How

Store new values under private typed keys through `WithLimitKey` and `WithLimitOp`. Prefer those values, then safely read the legacy keys with comma-ok assertions. The legacy constants remain source compatible and are marked with Go-recognized deprecation paragraphs.

## Tests

- typed helper behavior and typed-over-legacy precedence
- legacy key compatibility
- wrong-type legacy collisions fall back without panic
- `go test -race ./overload/bbr`
- `go vet ./overload/bbr`
- typed reads, unsafe legacy assertions, and both precedence paths were mutation tested
