### PR TITLE
fix(hashset): reject NaN values

### DIFF
--- a/structure/hashset/nan_test.go
+++ b/structure/hashset/nan_test.go
@@ -47,6 +47,88 @@ func TestFloat64SetRejectsNaN(t *testing.T) {
 	}
 }
 
+func TestComplex64SetRejectsNaNComponents(t *testing.T) {
+	set := NewComplex64()
+	valid := complex(float32(1), float32(2))
+	if !set.Add(valid) {
+		t.Fatal("Add(valid) = false, want true")
+	}
+	nan := float32(math.NaN())
+	values := []struct {
+		name  string
+		value complex64
+	}{
+		{name: "real", value: complex(nan, 1)},
+		{name: "imaginary", value: complex(1, nan)},
+		{name: "both", value: complex(nan, nan)},
+	}
+
+	for _, tt := range values {
+		t.Run(tt.name, func(t *testing.T) {
+			before := set.Len()
+			if set.Add(tt.value) {
+				t.Fatal("Add(complex NaN) = true, want false")
+			}
+			if got := set.Len(); got != before {
+				t.Fatalf("Len() after Add(complex NaN) = %d, want %d", got, before)
+			}
+			if set.Contains(tt.value) {
+				t.Fatal("Contains(complex NaN) = true, want false")
+			}
+			if set.Remove(tt.value) {
+				t.Fatal("Remove(complex NaN) = true, want false")
+			}
+			if got := set.Len(); got != before {
+				t.Fatalf("Len() after Remove(complex NaN) = %d, want %d", got, before)
+			}
+		})
+	}
+	if !set.Contains(valid) || set.Len() != 1 {
+		t.Fatalf("valid value changed while rejecting NaN: contains=%t len=%d", set.Contains(valid), set.Len())
+	}
+}
+
+func TestComplex128SetRejectsNaNComponents(t *testing.T) {
+	set := NewComplex128()
+	valid := complex(1.0, 2.0)
+	if !set.Add(valid) {
+		t.Fatal("Add(valid) = false, want true")
+	}
+	nan := math.NaN()
+	values := []struct {
+		name  string
+		value complex128
+	}{
+		{name: "real", value: complex(nan, 1)},
+		{name: "imaginary", value: complex(1, nan)},
+		{name: "both", value: complex(nan, nan)},
+	}
+
+	for _, tt := range values {
+		t.Run(tt.name, func(t *testing.T) {
+			before := set.Len()
+			if set.Add(tt.value) {
+				t.Fatal("Add(complex NaN) = true, want false")
+			}
+			if got := set.Len(); got != before {
+				t.Fatalf("Len() after Add(complex NaN) = %d, want %d", got, before)
+			}
+			if set.Contains(tt.value) {
+				t.Fatal("Contains(complex NaN) = true, want false")
+			}
+			if set.Remove(tt.value) {
+				t.Fatal("Remove(complex NaN) = true, want false")
+			}
+			if got := set.Len(); got != before {
+				t.Fatalf("Len() after Remove(complex NaN) = %d, want %d", got, before)
+			}
+		})
+	}
+	if !set.Contains(valid) || set.Len() != 1 {
+		t.Fatalf("valid value changed while rejecting NaN: contains=%t len=%d", set.Contains(valid), set.Len())
+	}
+}
+
 func TestFloat32SetPreservesComparableValues(t *testing.T) {
 	set := NewFloat32()
 	positiveZero := float32(0)

--- a/structure/hashset/nan_test.go
+++ b/structure/hashset/nan_test.go
@@ -1,0 +1,102 @@
+package hashset
+
+import (
+	"math"
+	"testing"
+)
+
+func TestFloat32SetRejectsNaN(t *testing.T) {
+	set := NewFloat32()
+	nan := float32(math.NaN())
+
+	if set.Add(nan) {
+		t.Fatal("Add(NaN) = true, want false")
+	}
+	if set.Add(nan) {
+		t.Fatal("second Add(NaN) = true, want false")
+	}
+	if got := set.Len(); got != 0 {
+		t.Fatalf("Len() after Add(NaN) = %d, want 0", got)
+	}
+	if set.Contains(nan) {
+		t.Fatal("Contains(NaN) = true, want false")
+	}
+	if set.Remove(nan) {
+		t.Fatal("Remove(NaN) = true, want false")
+	}
+}
+
+func TestFloat64SetRejectsNaN(t *testing.T) {
+	set := NewFloat64()
+	nan := math.NaN()
+
+	if set.Add(nan) {
+		t.Fatal("Add(NaN) = true, want false")
+	}
+	if set.Add(nan) {
+		t.Fatal("second Add(NaN) = true, want false")
+	}
+	if got := set.Len(); got != 0 {
+		t.Fatalf("Len() after Add(NaN) = %d, want 0", got)
+	}
+	if set.Contains(nan) {
+		t.Fatal("Contains(NaN) = true, want false")
+	}
+	if set.Remove(nan) {
+		t.Fatal("Remove(NaN) = true, want false")
+	}
+}
+
+func TestFloat32SetPreservesComparableValues(t *testing.T) {
+	set := NewFloat32()
+	positiveZero := float32(0)
+	negativeZero := float32(math.Copysign(0, -1))
+	values := []float32{positiveZero, negativeZero, 1.25, float32(math.Inf(1)), float32(math.Inf(-1))}
+
+	for _, value := range values {
+		if !set.Add(value) {
+			t.Fatalf("Add(%v) = false, want true", value)
+		}
+		if !set.Contains(value) {
+			t.Fatalf("Contains(%v) = false, want true", value)
+		}
+	}
+	if got := set.Len(); got != 4 {
+		t.Fatalf("Len() = %d, want 4; +0 and -0 must be the same key", got)
+	}
+	for _, value := range []float32{negativeZero, 1.25, float32(math.Inf(1)), float32(math.Inf(-1))} {
+		if !set.Remove(value) {
+			t.Fatalf("Remove(%v) = false, want true", value)
+		}
+	}
+	if got := set.Len(); got != 0 {
+		t.Fatalf("Len() after removals = %d, want 0", got)
+	}
+}
+
+func TestFloat64SetPreservesComparableValues(t *testing.T) {
+	set := NewFloat64()
+	positiveZero := float64(0)
+	negativeZero := math.Copysign(0, -1)
+	values := []float64{positiveZero, negativeZero, 1.25, math.Inf(1), math.Inf(-1)}
+
+	for _, value := range values {
+		if !set.Add(value) {
+			t.Fatalf("Add(%v) = false, want true", value)
+		}
+		if !set.Contains(value) {
+			t.Fatalf("Contains(%v) = false, want true", value)
+		}
+	}
+	if got := set.Len(); got != 4 {
+		t.Fatalf("Len() = %d, want 4; +0 and -0 must be the same key", got)
+	}
+	for _, value := range []float64{negativeZero, 1.25, math.Inf(1), math.Inf(-1)} {
+		if !set.Remove(value) {
+			t.Fatalf("Remove(%v) = false, want true", value)
+		}
+	}
+	if got := set.Len(); got != 0 {
+		t.Fatalf("Len() after removals = %d, want 0", got)
+	}
+}

--- a/structure/hashset/types.go
+++ b/structure/hashset/types.go
@@ -81,9 +81,11 @@ func NewComplex64WithSize(size int) Complex64Set {
 }
 
 // Add adds the specified element to this set
-// Always returns true due to the build-in map doesn't indicate caller whether the given element already exists
-// Reserves the return type for future extension
+// Returns false when either component is NaN; otherwise applies the operation and returns true
 func (s Complex64Set) Add(value complex64) bool {
+	if real(value) != real(value) || imag(value) != imag(value) {
+		return false
+	}
 	s[value] = struct{}{}
 	return true
 }
@@ -97,9 +99,11 @@ func (s Complex64Set) Contains(value complex64) bool {
 }
 
 // Remove removes the specified element from this set
-// Always returns true due to the build-in map doesn't indicate caller whether the given element already exists
-// Reserves the return type for future extension
+// Returns false when either component is NaN; otherwise applies the operation and returns true
 func (s Complex64Set) Remove(value complex64) bool {
+	if real(value) != real(value) || imag(value) != imag(value) {
+		return false
+	}
 	delete(s, value)
 	return true
 }
@@ -133,9 +137,11 @@ func NewComplex128WithSize(size int) Complex128Set {
 }
 
 // Add adds the specified element to this set
-// Always returns true due to the build-in map doesn't indicate caller whether the given element already exists
-// Reserves the return type for future extension
+// Returns false when either component is NaN; otherwise applies the operation and returns true
 func (s Complex128Set) Add(value complex128) bool {
+	if real(value) != real(value) || imag(value) != imag(value) {
+		return false
+	}
 	s[value] = struct{}{}
 	return true
 }
@@ -149,9 +155,11 @@ func (s Complex128Set) Contains(value complex128) bool {
 }
 
 // Remove removes the specified element from this set
-// Always returns true due to the build-in map doesn't indicate caller whether the given element already exists
-// Reserves the return type for future extension
+// Returns false when either component is NaN; otherwise applies the operation and returns true
 func (s Complex128Set) Remove(value complex128) bool {
+	if real(value) != real(value) || imag(value) != imag(value) {
+		return false
+	}
 	delete(s, value)
 	return true
 }

--- a/structure/hashset/types.go
+++ b/structure/hashset/types.go
@@ -185,9 +185,11 @@ func NewFloat32WithSize(size int) Float32Set {
 }
 
 // Add adds the specified element to this set
-// Always returns true due to the build-in map doesn't indicate caller whether the given element already exists
-// Reserves the return type for future extension
+// Returns false for NaN; otherwise applies the operation and returns true
 func (s Float32Set) Add(value float32) bool {
+	if value != value {
+		return false
+	}
 	s[value] = struct{}{}
 	return true
 }
@@ -201,9 +203,11 @@ func (s Float32Set) Contains(value float32) bool {
 }
 
 // Remove removes the specified element from this set
-// Always returns true due to the build-in map doesn't indicate caller whether the given element already exists
-// Reserves the return type for future extension
+// Returns false for NaN; otherwise applies the operation and returns true
 func (s Float32Set) Remove(value float32) bool {
+	if value != value {
+		return false
+	}
 	delete(s, value)
 	return true
 }
@@ -237,9 +241,11 @@ func NewFloat64WithSize(size int) Float64Set {
 }
 
 // Add adds the specified element to this set
-// Always returns true due to the build-in map doesn't indicate caller whether the given element already exists
-// Reserves the return type for future extension
+// Returns false for NaN; otherwise applies the operation and returns true
 func (s Float64Set) Add(value float64) bool {
+	if value != value {
+		return false
+	}
 	s[value] = struct{}{}
 	return true
 }
@@ -253,9 +259,11 @@ func (s Float64Set) Contains(value float64) bool {
 }
 
 // Remove removes the specified element from this set
-// Always returns true due to the build-in map doesn't indicate caller whether the given element already exists
-// Reserves the return type for future extension
+// Returns false for NaN; otherwise applies the operation and returns true
 func (s Float64Set) Remove(value float64) bool {
+	if value != value {
+		return false
+	}
 	delete(s, value)
 	return true
 }

--- a/structure/hashset/types_gen.go
+++ b/structure/hashset/types_gen.go
@@ -68,6 +68,9 @@ func main() {
 		// Common cases.
 		data = strings.Replace(data, "int64", lower, -1)
 		data = strings.Replace(data, "Int64", upper, -1)
+		if upper == "Float32" || upper == "Float64" {
+			data = addFloatNaNGuards(data, upper, lower)
+		}
 		if inSlice(lowerSlice(ts), lower) {
 			data = strings.Replace(data, "length "+lower, "length int64", 1)
 		}
@@ -84,6 +87,25 @@ func main() {
 	if err := ioutil.WriteFile("types.go", out, 0660); err != nil {
 		panic(err)
 	}
+}
+
+func addFloatNaNGuards(data, upper, lower string) string {
+	const genericReturnComment = "// Always returns true due to the build-in map doesn't indicate caller whether the given element already exists\n// Reserves the return type for future extension"
+	if strings.Count(data, genericReturnComment) != 2 {
+		panic("unexpected Add/Remove comments for " + upper)
+	}
+	data = strings.Replace(data, genericReturnComment, "// Returns false for NaN; otherwise applies the operation and returns true", -1)
+	addSignature := "func (s " + upper + "Set) Add(value " + lower + ") bool {\n"
+	if strings.Count(data, addSignature) != 1 {
+		panic("unexpected Add signature for " + upper)
+	}
+	data = strings.Replace(data, addSignature, addSignature+"\tif value != value {\n\t\treturn false\n\t}\n", 1)
+	removeSignature := "func (s " + upper + "Set) Remove(value " + lower + ") bool {\n"
+	if strings.Count(data, removeSignature) != 1 {
+		panic("unexpected Remove signature for " + upper)
+	}
+	data = strings.Replace(data, removeSignature, removeSignature+"\tif value != value {\n\t\treturn false\n\t}\n", 1)
+	return data
 }
 
 func lowerSlice(s []string) []string {

--- a/structure/hashset/types_gen.go
+++ b/structure/hashset/types_gen.go
@@ -68,8 +68,23 @@ func main() {
 		// Common cases.
 		data = strings.Replace(data, "int64", lower, -1)
 		data = strings.Replace(data, "Int64", upper, -1)
-		if upper == "Float32" || upper == "Float64" {
-			data = addFloatNaNGuards(data, upper, lower)
+		switch upper {
+		case "Float32", "Float64":
+			data = addNaNGuards(
+				data,
+				upper,
+				lower,
+				"// Returns false for NaN; otherwise applies the operation and returns true",
+				"value != value",
+			)
+		case "Complex64", "Complex128":
+			data = addNaNGuards(
+				data,
+				upper,
+				lower,
+				"// Returns false when either component is NaN; otherwise applies the operation and returns true",
+				"real(value) != real(value) || imag(value) != imag(value)",
+			)
 		}
 		if inSlice(lowerSlice(ts), lower) {
 			data = strings.Replace(data, "length "+lower, "length int64", 1)
@@ -89,22 +104,22 @@ func main() {
 	}
 }
 
-func addFloatNaNGuards(data, upper, lower string) string {
+func addNaNGuards(data, upper, lower, returnComment, condition string) string {
 	const genericReturnComment = "// Always returns true due to the build-in map doesn't indicate caller whether the given element already exists\n// Reserves the return type for future extension"
 	if strings.Count(data, genericReturnComment) != 2 {
 		panic("unexpected Add/Remove comments for " + upper)
 	}
-	data = strings.Replace(data, genericReturnComment, "// Returns false for NaN; otherwise applies the operation and returns true", -1)
+	data = strings.Replace(data, genericReturnComment, returnComment, -1)
 	addSignature := "func (s " + upper + "Set) Add(value " + lower + ") bool {\n"
 	if strings.Count(data, addSignature) != 1 {
 		panic("unexpected Add signature for " + upper)
 	}
-	data = strings.Replace(data, addSignature, addSignature+"\tif value != value {\n\t\treturn false\n\t}\n", 1)
+	data = strings.Replace(data, addSignature, addSignature+"\tif "+condition+" {\n\t\treturn false\n\t}\n", 1)
 	removeSignature := "func (s " + upper + "Set) Remove(value " + lower + ") bool {\n"
 	if strings.Count(data, removeSignature) != 1 {
 		panic("unexpected Remove signature for " + upper)
 	}
-	data = strings.Replace(data, removeSignature, removeSignature+"\tif value != value {\n\t\treturn false\n\t}\n", 1)
+	data = strings.Replace(data, removeSignature, removeSignature+"\tif "+condition+" {\n\t\treturn false\n\t}\n", 1)
 	return data
 }
 


### PR DESCRIPTION
## What

- reject NaN values from `Float32Set` and `Float64Set`
- keep generated float-set code and its generator synchronized
- add regression coverage for NaN and comparable floating-point values

## Why

Go map keys compare NaN unequal even to the same NaN value. Adding NaN created entries that increased `Len` but could never be found or removed, allowing an unbounded accumulation of unreachable set elements.

## How

Return `false` before inserting or removing a NaN in the two generated float set types. Finite values, infinities, and the existing `+0`/`-0` equivalence remain unchanged.

## Tests

- Float32 and Float64 NaN add/contains/remove behavior
- finite, infinity, and signed-zero compatibility
- generator runs twice with identical output
- `go test -race ./structure/hashset`
- `go vet ./structure/hashset`
- removing each generated float guard makes its regression test fail
