### PR TITLE
fix(codel): reject pre-canceled queue pushes

### DIFF
--- a/container/queue/codel/context_test.go
+++ b/container/queue/codel/context_test.go
@@ -1,0 +1,67 @@
+package codel
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestQueuePushPreCanceledContextDoesNotEnqueue(t *testing.T) {
+	q := NewQueue(SetTarget(1<<60), SetInternal(1<<60))
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := q.Push(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Push error = %v, want context.Canceled", err)
+	}
+	if got := q.Stat().Packets; got != 0 {
+		t.Fatalf("queued packets after pre-canceled Push = %d, want 0", got)
+	}
+
+	result := make(chan error, 1)
+	go func() { result <- q.Push(context.Background()) }()
+	waitForPackets(t, q, 1)
+	q.Pop()
+	if err := awaitPushResult(t, result); err != nil {
+		t.Fatalf("live Push after pre-canceled Push returned %v", err)
+	}
+	if got := q.Stat().Packets; got != 0 {
+		t.Fatalf("queued packets after live Push/Pop = %d, want 0", got)
+	}
+}
+
+func TestQueuePushCanceledAfterEnqueueKeepsDecisionIsolated(t *testing.T) {
+	q := NewQueue(SetTarget(1<<60), SetInternal(1<<60))
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() { result <- q.Push(ctx) }()
+
+	waitForPackets(t, q, 1)
+	cancel()
+	if err := awaitPushResult(t, result); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Push error = %v, want context.Canceled", err)
+	}
+	if got := q.Stat().Packets; got != 1 {
+		t.Fatalf("queued packets after post-enqueue cancellation = %d, want 1", got)
+	}
+
+	// The canceled caller has left, but its buffered one-shot decision must let
+	// Pop drain the request without blocking.
+	popWithWatchdog(t, q)
+	if got := q.Stat().Packets; got != 0 {
+		t.Fatalf("queued packets after draining canceled request = %d, want 0", got)
+	}
+}
+
+func waitForPackets(t *testing.T, q *Queue, want int64) {
+	t.Helper()
+	deadline := time.Now().Add(250 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if q.Stat().Packets == want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("queued packets = %d, want %d", q.Stat().Packets, want)
+}

--- a/container/queue/codel/queue.go
+++ b/container/queue/codel/queue.go
@@ -76,6 +76,10 @@ func (q *Queue) Stat() Stat {
 // Push 请求进入CoDel Queue
 // 如果返回错误为nil，则在完成请求处理后，调用方必须调用q.Done()
 func (q *Queue) Push(ctx context.Context) (err error) {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	r := packet{
 		ch: make(chan bool, 1),
 		ts: time.Now().UnixNano() / int64(time.Millisecond),


### PR DESCRIPTION
## What

- reject an already canceled context before creating or enqueueing a CoDel packet
- preserve queue capacity for live requests
- add regression coverage for cancellation before and after enqueue

## Why

`Push` enqueued first and only then selected on `ctx.Done`. Repeated pre-canceled calls returned `context.Canceled` to callers but left hidden packets in the queue; 2,048 such calls filled the queue and caused the next live request to be rejected.

## How

Check `ctx.Err()` before packet construction and enqueue. Cancellation after enqueue keeps the existing one-shot decision behavior so `Pop` can still drain that packet without blocking.

## Tests

- pre-canceled push leaves `Stat().Packets` at zero
- a live push/pop succeeds afterward
- post-enqueue cancellation remains drainable
- `go test -race ./container/queue/codel`
- `go vet ./container/queue/codel`
- deleting the precheck restores the queue-balance failure
