### PR TITLE
fix(skipset): reject NaN values

### DIFF
--- a/structure/skipset/float_nan_test.go
+++ b/structure/skipset/float_nan_test.go
@@ -1,0 +1,187 @@
+// Copyright 2021 ByteDance Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package skipset
+
+import (
+	"math"
+	"sync"
+	"testing"
+)
+
+type floatSetContract struct {
+	add      func(float64) bool
+	contains func(float64) bool
+	remove   func(float64) bool
+	length   func() int
+	rangeAll func() []float64
+}
+
+func floatSetCases() []struct {
+	name       string
+	descending bool
+	newSet     func() floatSetContract
+} {
+	return []struct {
+		name       string
+		descending bool
+		newSet     func() floatSetContract
+	}{
+		{"float32 ascending", false, func() floatSetContract {
+			s := NewFloat32()
+			return float32SetContract(s.Add, s.Contains, s.Remove, s.Len, s.Range)
+		}},
+		{"float32 descending", true, func() floatSetContract {
+			s := NewFloat32Desc()
+			return float32SetContract(s.Add, s.Contains, s.Remove, s.Len, s.Range)
+		}},
+		{"float64 ascending", false, func() floatSetContract {
+			s := NewFloat64()
+			return float64SetContract(s.Add, s.Contains, s.Remove, s.Len, s.Range)
+		}},
+		{"float64 descending", true, func() floatSetContract {
+			s := NewFloat64Desc()
+			return float64SetContract(s.Add, s.Contains, s.Remove, s.Len, s.Range)
+		}},
+	}
+}
+
+func TestFloatSetsRejectNaN(t *testing.T) {
+	for _, tc := range floatSetCases() {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s := tc.newSet()
+			nan := math.NaN()
+
+			if s.add(nan) {
+				t.Fatal("Add(NaN) = true, want false")
+			}
+			if s.length() != 0 {
+				t.Fatalf("Len() = %d after Add(NaN), want 0", s.length())
+			}
+			if s.contains(nan) {
+				t.Fatal("Contains(NaN) = true, want false")
+			}
+			if s.remove(nan) {
+				t.Fatal("Remove(NaN) = true, want false")
+			}
+			for _, value := range s.rangeAll() {
+				if math.IsNaN(value) {
+					t.Fatal("Range returned NaN")
+				}
+			}
+
+			const goroutines = 32
+			results := make([]bool, goroutines)
+			var wg sync.WaitGroup
+			wg.Add(goroutines)
+			for i := range results {
+				go func(i int) {
+					defer wg.Done()
+					results[i] = s.add(nan)
+				}(i)
+			}
+			wg.Wait()
+			for i, added := range results {
+				if added {
+					t.Fatalf("concurrent Add(NaN) call %d = true, want false", i)
+				}
+			}
+			if s.length() != 0 {
+				t.Fatalf("Len() = %d after concurrent Add(NaN), want 0", s.length())
+			}
+		})
+	}
+}
+
+func TestFloatSetsOrderSpecialValues(t *testing.T) {
+	for _, tc := range floatSetCases() {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s := tc.newSet()
+			for _, value := range []float64{1, math.Inf(-1), math.Copysign(0, -1), math.Inf(1), -1} {
+				if !s.add(value) {
+					t.Fatalf("Add(%v) = false, want true", value)
+				}
+			}
+			if s.add(0) {
+				t.Fatal("Add(+0) = true after adding -0, want false")
+			}
+
+			want := []float64{math.Inf(-1), -1, 0, 1, math.Inf(1)}
+			if tc.descending {
+				want = []float64{math.Inf(1), 1, 0, -1, math.Inf(-1)}
+			}
+			assertFloatValues(t, s.rangeAll(), want)
+		})
+	}
+}
+
+func float32SetContract(
+	add func(float32) bool,
+	contains func(float32) bool,
+	remove func(float32) bool,
+	length func() int,
+	rangeFn func(func(float32) bool),
+) floatSetContract {
+	return floatSetContract{
+		add:      func(value float64) bool { return add(float32(value)) },
+		contains: func(value float64) bool { return contains(float32(value)) },
+		remove:   func(value float64) bool { return remove(float32(value)) },
+		length:   length,
+		rangeAll: func() (values []float64) {
+			rangeFn(func(value float32) bool {
+				values = append(values, float64(value))
+				return true
+			})
+			return values
+		},
+	}
+}
+
+func float64SetContract(
+	add func(float64) bool,
+	contains func(float64) bool,
+	remove func(float64) bool,
+	length func() int,
+	rangeFn func(func(float64) bool),
+) floatSetContract {
+	return floatSetContract{
+		add:      add,
+		contains: contains,
+		remove:   remove,
+		length:   length,
+		rangeAll: func() (values []float64) {
+			rangeFn(func(value float64) bool {
+				values = append(values, value)
+				return true
+			})
+			return values
+		},
+	}
+}
+
+func assertFloatValues(t *testing.T, got, want []float64) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("Range returned %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("Range returned %v, want %v", got, want)
+		}
+	}
+}

--- a/structure/skipset/types.go
+++ b/structure/skipset/types.go
@@ -717,6 +717,9 @@ func unlockFloat32(preds [maxLevel]*float32Node, highestLevel int) {
 //
 // If the value is in the skip set but not fully linked, this process will wait until it is.
 func (s *Float32Set) Add(value float32) bool {
+	if value != value {
+		return false // NaN is unordered and violates skip-list ordering.
+	}
 	level := s.randomLevel()
 	var preds, succs [maxLevel]*float32Node
 	for {
@@ -1006,6 +1009,9 @@ func unlockFloat32Desc(preds [maxLevel]*float32NodeDesc, highestLevel int) {
 //
 // If the value is in the skip set but not fully linked, this process will wait until it is.
 func (s *Float32SetDesc) Add(value float32) bool {
+	if value != value {
+		return false // NaN is unordered and violates skip-list ordering.
+	}
 	level := s.randomLevel()
 	var preds, succs [maxLevel]*float32NodeDesc
 	for {
@@ -1295,6 +1301,9 @@ func unlockFloat64(preds [maxLevel]*float64Node, highestLevel int) {
 //
 // If the value is in the skip set but not fully linked, this process will wait until it is.
 func (s *Float64Set) Add(value float64) bool {
+	if value != value {
+		return false // NaN is unordered and violates skip-list ordering.
+	}
 	level := s.randomLevel()
 	var preds, succs [maxLevel]*float64Node
 	for {
@@ -1584,6 +1593,9 @@ func unlockFloat64Desc(preds [maxLevel]*float64NodeDesc, highestLevel int) {
 //
 // If the value is in the skip set but not fully linked, this process will wait until it is.
 func (s *Float64SetDesc) Add(value float64) bool {
+	if value != value {
+		return false // NaN is unordered and violates skip-list ordering.
+	}
 	level := s.randomLevel()
 	var preds, succs [maxLevel]*float64NodeDesc
 	for {

--- a/structure/skipset/types_gen.go
+++ b/structure/skipset/types_gen.go
@@ -64,6 +64,11 @@ func main() {
 		// Step 4-2. Replace all cases
 		dataDesc := replace(data, upper, true)
 		dataAsc := replace(data, upper, false)
+		if upper == "Float32" || upper == "Float64" {
+			const rejectNaN = "if value != value {\n\treturn false // NaN is unordered and violates skip-list ordering.\n}"
+			dataAsc = addLineAfter(dataAsc, "func (s *"+upper+"Set) Add", rejectNaN)
+			dataDesc = addLineAfter(dataDesc, "func (s *"+upper+"SetDesc) Add", rejectNaN)
+		}
 		w.WriteString(dataAsc)
 		w.WriteString("\r\n")
 		w.WriteString(dataDesc)


### PR DESCRIPTION
## What

- reject NaN values from Float32 and Float64 skip sets in both sort directions
- keep the generated implementations and generator synchronized
- add concurrent rejection and floating-point ordering regression tests

## Why

NaN is neither less than nor equal to any value. The skip-list comparisons therefore allowed every NaN insertion, could never find or remove those nodes, and let NaN act as a comparison barrier that broke the ordering of ordinary values.

## How

Generate an early `false` return from the four float `Add` methods when the value is NaN. Other floating-point values and the existing signed-zero equivalence keep their current ordering.

## Tests

- Float32/Float64 ascending and descending NaN rejection
- 32 concurrent NaN adds under the race detector
- finite, infinity, and signed-zero order controls
- generator runs twice with identical output
- wasm and linux/arm64 compile gates
- all four generated guards were independently mutation tested
