### PR TITLE
fix(proto): reject typed-nil unmarshal targets

### DIFF
--- a/coding/proto/proto.go
+++ b/coding/proto/proto.go
@@ -2,6 +2,7 @@ package proto
 
 import (
 	"fmt"
+	"reflect"
 
 	"github.com/songzhibin97/gkit/coding"
 	"google.golang.org/protobuf/proto"
@@ -27,6 +28,9 @@ func (c code) Unmarshal(data []byte, v interface{}) error {
 	m, ok := v.(proto.Message)
 	if !ok {
 		return fmt.Errorf("proto: Unmarshal expects proto.Message, got %T", v)
+	}
+	if rv := reflect.ValueOf(m); rv.Kind() == reflect.Ptr && rv.IsNil() {
+		return fmt.Errorf("proto: unmarshal target is a nil %T", v)
 	}
 	return proto.Unmarshal(data, m)
 }

--- a/coding/proto/typed_nil_test.go
+++ b/coding/proto/typed_nil_test.go
@@ -1,0 +1,52 @@
+package proto
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/songzhibin97/gkit/coding"
+	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+func TestRegisteredCodeUnmarshalRejectsTypedNilMessage(t *testing.T) {
+	codec := coding.GetCode(Name)
+	if codec == nil {
+		t.Fatal("registered proto codec is nil")
+	}
+
+	var target *emptypb.Empty
+	err, panicValue := unmarshalWithoutPanicking(codec, nil, target)
+	if panicValue != nil {
+		t.Fatalf("Unmarshal() panicked for typed-nil proto.Message: %v", panicValue)
+	}
+	if err == nil {
+		t.Fatal("Unmarshal() error = nil, want typed-nil target error")
+	}
+	if want := "proto: unmarshal target is a nil *emptypb.Empty"; !strings.Contains(err.Error(), want) {
+		t.Fatalf("Unmarshal() error = %q, want it to contain %q", err, want)
+	}
+}
+
+func TestRegisteredCodeNonNilRoundTrip(t *testing.T) {
+	codec := coding.GetCode(Name)
+	want := wrapperspb.String("decoded")
+	data, err := codec.Marshal(want)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	got := new(wrapperspb.StringValue)
+	if err := codec.Unmarshal(data, got); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if got.Value != want.Value {
+		t.Fatalf("round trip value = %q, want %q", got.Value, want.Value)
+	}
+}
+
+func unmarshalWithoutPanicking(codec coding.Code, data []byte, target interface{}) (err error, panicValue interface{}) {
+	defer func() { panicValue = recover() }()
+	err = codec.Unmarshal(data, target)
+	return err, nil
+}


### PR DESCRIPTION
## What

- return an error when protobuf decoding receives a typed-nil message target
- keep normal round trips and marshal behavior unchanged
- add regression coverage through the registered codec interface

## Why

A typed-nil pointer satisfies the `proto.Message` interface, so the existing type assertion succeeded and `proto.Unmarshal` panicked while dereferencing the nil target. The codec exposes an error-returning API and should report an invalid destination instead of crashing the caller.

## How

After the existing interface assertion, use reflection to reject only a nil pointer message before calling the protobuf runtime. Non-pointer and non-nil messages follow the original path; marshal is untouched.

## Tests

- typed-nil unmarshal returns a descriptive error without panic
- non-nil protobuf round trip
- wrong-type and typed-nil marshal compatibility checked during review
- `go test -race ./coding/proto ./coding/...`
- `go vet ./coding/proto`
- deleting the guard restores the nil dereference and fails the regression test
