### PR TITLE
fix(parse_go): parse exact documentation tags

### DIFF
--- a/parser/parse_go/doc_tag_test.go
+++ b/parser/parse_go/doc_tag_test.go
@@ -1,6 +1,37 @@
 package parse_go
 
-import "testing"
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+func parseDocFromGoSource(t *testing.T, source string) *Server {
+	t.Helper()
+	file, err := parser.ParseFile(token.NewFileSet(), "doc_tags.go", source, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parse source: %v", err)
+	}
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+		if fn.Doc == nil {
+			t.Fatal("function has no AST documentation comments")
+		}
+		docs := make([]string, len(fn.Doc.List))
+		for i, comment := range fn.Doc.List {
+			docs[i] = comment.Text
+		}
+		server := &Server{Doc: docs}
+		parseDoc(server)
+		return server
+	}
+	t.Fatal("source has no function declaration")
+	return nil
+}
 
 func TestDocTagValueTrimsAndPreservesColons(t *testing.T) {
 	tests := []struct {
@@ -67,6 +98,92 @@ func TestParseDocAcceptsBlockCommentPrefixes(t *testing.T) {
 	}
 	if server.Router != "/block:route" {
 		t.Fatalf("Router = %q, want /block:route", server.Router)
+	}
+}
+
+func TestParseDocAcceptsMultilineASTBlockComments(t *testing.T) {
+	tests := []struct {
+		name        string
+		source      string
+		method      string
+		serviceName string
+		router      string
+	}{
+		{
+			name: "leading stars",
+			source: `package api
+
+/*
+ * @method: post
+ * @service: UserService
+ * @router: /v1/users:lookup
+ */
+func Handler() {}`,
+			method:      "post",
+			serviceName: "UserService",
+			router:      "/v1/users:lookup",
+		},
+		{
+			name: "without leading stars",
+			source: `package api
+
+/*
+@method: get
+@service: PlainService
+@router: /plain:route
+*/
+func Handler() {}`,
+			method:      "get",
+			serviceName: "PlainService",
+			router:      "/plain:route",
+		},
+		{
+			name:        "CRLF and whitespace",
+			source:      "package api\r\n\r\n/*\r\n\t *   @method:   patch   \r\n\t *\t@service:   CRLFService\t\r\n\t *   @router:   /crlf:route   \r\n\t */\r\nfunc Handler() {}\r\n",
+			method:      "patch",
+			serviceName: "CRLFService",
+			router:      "/crlf:route",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := parseDocFromGoSource(t, tt.source)
+			if server.Method != tt.method || server.ServerName != tt.serviceName || server.Router != tt.router {
+				t.Fatalf(
+					"parsed tags = Method %q, ServerName %q, Router %q; want %q, %q, %q",
+					server.Method,
+					server.ServerName,
+					server.Router,
+					tt.method,
+					tt.serviceName,
+					tt.router,
+				)
+			}
+		})
+	}
+}
+
+func TestParseDocRejectsEmbeddedAndNearMatchTagsInASTBlockComment(t *testing.T) {
+	server := parseDocFromGoSource(t, `package api
+
+/*
+ * prose mentioning @method: delete
+ * prefix @service: WrongService
+ * prose with @router: /wrong
+ * @methodology: put
+ * @service : AlsoWrong
+ * @router : /also-wrong
+ */
+func Handler() {}`)
+
+	if server.Method != "" || server.ServerName != "" || server.Router != "" {
+		t.Fatalf(
+			"near matches parsed as Method=%q ServerName=%q Router=%q, want all empty",
+			server.Method,
+			server.ServerName,
+			server.Router,
+		)
 	}
 }
 

--- a/parser/parse_go/doc_tag_test.go
+++ b/parser/parse_go/doc_tag_test.go
@@ -1,0 +1,95 @@
+package parse_go
+
+import "testing"
+
+func TestDocTagValueTrimsAndPreservesColons(t *testing.T) {
+	tests := []struct {
+		name string
+		doc  string
+		want string
+		ok   bool
+	}{
+		{name: "trimmed", doc: "@method:  post  ", want: "post", ok: true},
+		{name: "later colons", doc: "@router: /v1/users:lookup", want: "/v1/users:lookup", ok: true},
+		{name: "empty", doc: "@service:   ", want: "", ok: true},
+		{name: "missing colon", doc: "@method", want: "", ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := docTagValue(tt.doc)
+			if got != tt.want || ok != tt.ok {
+				t.Fatalf("docTagValue(%q) = (%q, %t), want (%q, %t)", tt.doc, got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}
+
+func TestParseDocAcceptsExactTagsAndRejectsEmbeddedText(t *testing.T) {
+	server := &Server{Doc: []string{
+		"   // @method:  post  ",
+		"\t// @service: UserService ",
+		" // @router: /v1/users:lookup ",
+		"// ordinary text mentioning @method: delete",
+		"// prefix @service: WrongService",
+		"// prose with @router: /wrong",
+		"// @methodology: put",
+		"// @router : /also-wrong",
+	}}
+
+	parseDoc(server)
+
+	if server.Method != "post" {
+		t.Fatalf("Method = %q, want post", server.Method)
+	}
+	if server.ServerName != "UserService" {
+		t.Fatalf("ServerName = %q, want UserService", server.ServerName)
+	}
+	if server.Router != "/v1/users:lookup" {
+		t.Fatalf("Router = %q, want /v1/users:lookup", server.Router)
+	}
+}
+
+func TestParseDocAcceptsBlockCommentPrefixes(t *testing.T) {
+	server := &Server{Doc: []string{
+		" /* @method: patch */ ",
+		"/* @service: BlockService */",
+		"/* @router: /block:route */",
+	}}
+
+	parseDoc(server)
+
+	if server.Method != "patch" {
+		t.Fatalf("Method = %q, want patch", server.Method)
+	}
+	if server.ServerName != "BlockService" {
+		t.Fatalf("ServerName = %q, want BlockService", server.ServerName)
+	}
+	if server.Router != "/block:route" {
+		t.Fatalf("Router = %q, want /block:route", server.Router)
+	}
+}
+
+func TestParseDocAcceptsEmptyValues(t *testing.T) {
+	server := &Server{
+		Method:     "keep-method",
+		ServerName: "keep-service",
+		Router:     "keep-router",
+		Doc: []string{
+			"// @method:   ",
+			"// @service:\t",
+			"// @router: ",
+		},
+	}
+
+	parseDoc(server)
+
+	if server.Method != "" || server.ServerName != "" || server.Router != "" {
+		t.Fatalf(
+			"empty tags parsed as Method=%q ServerName=%q Router=%q, want all empty",
+			server.Method,
+			server.ServerName,
+			server.Router,
+		)
+	}
+}

--- a/parser/parse_go/model.go
+++ b/parser/parse_go/model.go
@@ -48,7 +48,7 @@ type Server struct {
 	OutputParameter string         // OutputParameter: 出参
 	Doc             []string       // Doc: 函数注释信息,可以通过自定义的 parseFunc 去进行解析
 	Notes           []*ast.Comment // Notes: 函数中的注释信息,用于埋点打桩
-
+	signatureErr    error
 }
 
 // CreateServer 创建Server
@@ -224,30 +224,124 @@ func (g *GoParsePB) parseFunc(fn *ast.FuncDecl) {
 	}
 	name = fn.Name.Name
 
-	if fn.Type != nil {
-		t := fn.Type
-		if t.Params != nil && t.Params.List != nil {
-			switch parameter := t.Params.List[0].Type.(type) {
-			case *ast.Ident:
-				inputParameter = parameter.Name
-			}
-		}
-		if t.Results != nil && t.Results.List != nil {
-			switch parameter := t.Results.List[0].Type.(type) {
-			case *ast.Ident:
-				outputParameter = parameter.Name
-			}
-		}
-	}
+	inputParameter, outputParameter, signatureErr := parseRPCSignature(fn.Type)
 	ret := CreateServer(name, int(fn.Pos()), int(fn.End()), tags, inputParameter, outputParameter)
+	ret.signatureErr = signatureErr
 	for _, f := range g.ParseFuncS {
 		f(ret)
 	}
 	g.AddServers(ret)
 }
 
+func parseRPCSignature(fn *ast.FuncType) (string, string, error) {
+	if fn == nil {
+		return "", "", errors.New("request and response types are missing")
+	}
+
+	params := fieldTypes(fn.Params)
+	if len(params) > 0 && isContextType(params[0]) {
+		params = params[1:]
+	}
+	if len(params) == 0 {
+		return "", "", errors.New("request parameter is missing")
+	}
+	if len(params) != 1 {
+		return "", "", errors.New("expected exactly one request parameter, optionally after context.Context")
+	}
+	input, ok := rpcMessageType(params[0])
+	if !ok {
+		return "", "", errors.New("request must resolve to a declared struct message")
+	}
+
+	results := fieldTypes(fn.Results)
+	if len(results) == 0 {
+		return "", "", errors.New("response result is missing")
+	}
+	if len(results) > 2 {
+		return "", "", errors.New("expected one response result and an optional error")
+	}
+	output, ok := rpcMessageType(results[0])
+	if !ok {
+		return "", "", errors.New("response must resolve to a declared struct message")
+	}
+	if len(results) == 2 && !isErrorType(results[1]) {
+		return "", "", errors.New("second result must be error")
+	}
+
+	return input, output, nil
+}
+
+func fieldTypes(fields *ast.FieldList) []ast.Expr {
+	if fields == nil {
+		return nil
+	}
+	var types []ast.Expr
+	for _, field := range fields.List {
+		count := len(field.Names)
+		if count == 0 {
+			count = 1
+		}
+		for i := 0; i < count; i++ {
+			types = append(types, field.Type)
+		}
+	}
+	return types
+}
+
+func isContextType(expr ast.Expr) bool {
+	selector, ok := expr.(*ast.SelectorExpr)
+	if !ok || selector.Sel.Name != "Context" {
+		return false
+	}
+	pkg, ok := selector.X.(*ast.Ident)
+	return ok && pkg.Name == "context"
+}
+
+func isErrorType(expr ast.Expr) bool {
+	ident, ok := expr.(*ast.Ident)
+	return ok && ident.Name == "error" && ident.Obj == nil
+}
+
+func rpcMessageType(expr ast.Expr) (string, bool) {
+	if pointer, ok := expr.(*ast.StarExpr); ok {
+		expr = pointer.X
+	}
+	ident, ok := expr.(*ast.Ident)
+	if !ok || ident.Obj == nil {
+		return "", false
+	}
+	declaration, ok := ident.Obj.Decl.(*ast.TypeSpec)
+	if !ok {
+		return "", false
+	}
+	if _, ok := declaration.Type.(*ast.StructType); !ok {
+		return "", false
+	}
+	return ident.Name, true
+}
+
+func hasRPCDocTags(docs []string) bool {
+	for _, doc := range docs {
+		for _, line := range strings.Split(doc, "\n") {
+			if _, _, ok := rpcDocTag(line); ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isRPCServer(server *Server) bool {
+	return hasRPCDocTags(server.Doc) || server.ServerName != "" || server.Method != "" || server.Router != ""
+}
+
 // checkFormat 简单处理meta信息,将对应func、server中的注释移入
 func (g *GoParsePB) checkFormat() error {
+	for _, serve := range g.Server {
+		if isRPCServer(serve) && serve.signatureErr != nil {
+			return fmt.Errorf("parse_go: function %s has unsupported RPC signature: %w", serve.Name, serve.signatureErr)
+		}
+	}
 	// 之前已经调用过了,就直接返回了
 	if _, ok := g.Metas["ServerName"]; ok {
 		return nil
@@ -337,7 +431,8 @@ func (g *GoParsePB) PackageName() string {
 // Generate 生成pb文件
 func (g *GoParsePB) Generate() string {
 	temp := `syntax = "proto3";
-package {{.PackageName}};
+{{if .Server}}import "google/api/annotations.proto";
+{{end}}package {{.PackageName}};
 
 // message{{range .Message}}
 message {{.Name}}{
@@ -359,11 +454,32 @@ service {{.Metas.ServerName}}{
 		return ""
 	}
 	b := buffer.NewIoBuffer(1024)
-	err = tmpl.Execute(b, g)
+	data := struct {
+		PackageName string
+		Message     []*Message
+		Metas       map[string]string
+		Server      []*Server
+	}{
+		PackageName: g.PackageName(),
+		Message:     g.Message,
+		Metas:       g.Metas,
+		Server:      g.rpcServers(),
+	}
+	err = tmpl.Execute(b, data)
 	if err != nil {
 		return ""
 	}
 	return b.String()
+}
+
+func (g *GoParsePB) rpcServers() []*Server {
+	servers := make([]*Server, 0, len(g.Server))
+	for _, server := range g.Server {
+		if isRPCServer(server) {
+			servers = append(servers, server)
+		}
+	}
+	return servers
 }
 
 // PileDriving 源文件打桩

--- a/parser/parse_go/parse_go.go
+++ b/parser/parse_go/parse_go.go
@@ -85,23 +85,39 @@ func normalizeDocLine(doc string) string {
 	return doc
 }
 
+func rpcDocTag(doc string) (name, value string, ok bool) {
+	doc = normalizeDocLine(doc)
+
+	for _, tag := range []struct {
+		prefix string
+		name   string
+	}{
+		{prefix: "@method:", name: "method"},
+		{prefix: "@service:", name: "service"},
+		{prefix: "@router:", name: "router"},
+	} {
+		if strings.HasPrefix(doc, tag.prefix) {
+			value, ok := docTagValue(doc)
+			return tag.name, value, ok
+		}
+	}
+	return "", "", false
+}
+
 func parseDoc(server *Server) {
 	for _, doc := range server.Doc {
 		for _, line := range strings.Split(doc, "\n") {
-			line = normalizeDocLine(line)
-			switch {
-			case strings.HasPrefix(line, "@method:"):
-				if v, ok := docTagValue(line); ok {
-					server.Method = v
-				}
-			case strings.HasPrefix(line, "@service:"):
-				if v, ok := docTagValue(line); ok {
-					server.ServerName = v
-				}
-			case strings.HasPrefix(line, "@router:"):
-				if v, ok := docTagValue(line); ok {
-					server.Router = v
-				}
+			name, value, ok := rpcDocTag(line)
+			if !ok {
+				continue
+			}
+			switch name {
+			case "method":
+				server.Method = value
+			case "service":
+				server.ServerName = value
+			case "router":
+				server.Router = value
 			}
 		}
 	}

--- a/parser/parse_go/parse_go.go
+++ b/parser/parse_go/parse_go.go
@@ -67,32 +67,35 @@ func parseTag(file *File) {
 	}
 }
 
-// docTagValue returns the part after the first colon, or "" if the doc
-// line doesn't actually contain a colon. The previous implementation did
-// `strings.Split(doc, ":")[1]` which panicked on a malformed line; the
-// panic was then swallowed by a recover that printed to stdout, so the
-// affected field was silently left at its zero value and the generated
-// code went out the door with empty Method / ServerName / Router.
+// docTagValue returns the trimmed part after the first colon.
 func docTagValue(doc string) (string, bool) {
 	parts := strings.SplitN(doc, ":", 2)
 	if len(parts) != 2 {
 		return "", false
 	}
-	return parts[1], true
+	return strings.TrimSpace(parts[1]), true
 }
 
 func parseDoc(server *Server) {
 	for _, doc := range server.Doc {
+		doc = strings.TrimSpace(doc)
 		switch {
-		case strings.Contains(doc, "@method"):
+		case strings.HasPrefix(doc, "//"):
+			doc = strings.TrimSpace(strings.TrimPrefix(doc, "//"))
+		case strings.HasPrefix(doc, "/*"):
+			doc = strings.TrimSpace(strings.TrimPrefix(doc, "/*"))
+			doc = strings.TrimSpace(strings.TrimSuffix(doc, "*/"))
+		}
+		switch {
+		case strings.HasPrefix(doc, "@method:"):
 			if v, ok := docTagValue(doc); ok {
 				server.Method = v
 			}
-		case strings.Contains(doc, "@service"):
+		case strings.HasPrefix(doc, "@service:"):
 			if v, ok := docTagValue(doc); ok {
 				server.ServerName = v
 			}
-		case strings.Contains(doc, "@router"):
+		case strings.HasPrefix(doc, "@router:"):
 			if v, ok := docTagValue(doc); ok {
 				server.Router = v
 			}

--- a/parser/parse_go/parse_go.go
+++ b/parser/parse_go/parse_go.go
@@ -76,28 +76,32 @@ func docTagValue(doc string) (string, bool) {
 	return strings.TrimSpace(parts[1]), true
 }
 
+func normalizeDocLine(doc string) string {
+	doc = strings.TrimSpace(doc)
+	doc = strings.TrimSpace(strings.TrimPrefix(doc, "//"))
+	doc = strings.TrimSpace(strings.TrimPrefix(doc, "/*"))
+	doc = strings.TrimSpace(strings.TrimSuffix(doc, "*/"))
+	doc = strings.TrimSpace(strings.TrimPrefix(doc, "*"))
+	return doc
+}
+
 func parseDoc(server *Server) {
 	for _, doc := range server.Doc {
-		doc = strings.TrimSpace(doc)
-		switch {
-		case strings.HasPrefix(doc, "//"):
-			doc = strings.TrimSpace(strings.TrimPrefix(doc, "//"))
-		case strings.HasPrefix(doc, "/*"):
-			doc = strings.TrimSpace(strings.TrimPrefix(doc, "/*"))
-			doc = strings.TrimSpace(strings.TrimSuffix(doc, "*/"))
-		}
-		switch {
-		case strings.HasPrefix(doc, "@method:"):
-			if v, ok := docTagValue(doc); ok {
-				server.Method = v
-			}
-		case strings.HasPrefix(doc, "@service:"):
-			if v, ok := docTagValue(doc); ok {
-				server.ServerName = v
-			}
-		case strings.HasPrefix(doc, "@router:"):
-			if v, ok := docTagValue(doc); ok {
-				server.Router = v
+		for _, line := range strings.Split(doc, "\n") {
+			line = normalizeDocLine(line)
+			switch {
+			case strings.HasPrefix(line, "@method:"):
+				if v, ok := docTagValue(line); ok {
+					server.Method = v
+				}
+			case strings.HasPrefix(line, "@service:"):
+				if v, ok := docTagValue(line); ok {
+					server.ServerName = v
+				}
+			case strings.HasPrefix(line, "@router:"):
+				if v, ok := docTagValue(line); ok {
+					server.Router = v
+				}
 			}
 		}
 	}

--- a/parser/parse_go/rpc_signature_contract_test.go
+++ b/parser/parse_go/rpc_signature_contract_test.go
@@ -1,0 +1,345 @@
+package parse_go
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseGoRejectsRPCParametersWithoutMessageDeclarations(t *testing.T) {
+	tests := []struct {
+		name         string
+		functionName string
+		detail       string
+		source       string
+	}{
+		{
+			name:         "string request",
+			functionName: "StringRequest",
+			detail:       "request",
+			source: `package fixture
+
+type Response struct{}
+
+// @service:Fixture
+func StringRequest(req string) Response { return Response{} }
+`,
+		},
+		{
+			name:         "int response",
+			functionName: "IntResponse",
+			detail:       "response",
+			source: `package fixture
+
+type Request struct{}
+
+// @service:Fixture
+func IntResponse(req Request) int { return 0 }
+`,
+		},
+		{
+			name:         "bool request",
+			functionName: "BoolRequest",
+			detail:       "request",
+			source: `package fixture
+
+type Response struct{}
+
+// @service:Fixture
+func BoolRequest(req bool) Response { return Response{} }
+`,
+		},
+		{
+			name:         "primitive alias",
+			functionName: "AliasRequest",
+			detail:       "request",
+			source: `package fixture
+
+type Alias = string
+type Response struct{}
+
+// @service:Fixture
+func AliasRequest(req Alias) Response { return Response{} }
+`,
+		},
+		{
+			name:         "defined primitive",
+			functionName: "DefinedRequest",
+			detail:       "request",
+			source: `package fixture
+
+type Identifier string
+type Response struct{}
+
+// @service:Fixture
+func DefinedRequest(req Identifier) Response { return Response{} }
+`,
+		},
+		{
+			name:         "interface request",
+			functionName: "InterfaceRequest",
+			detail:       "request",
+			source: `package fixture
+
+type Contract interface { Call() }
+type Response struct{}
+
+// @service:Fixture
+func InterfaceRequest(req Contract) Response { return Response{} }
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseGo(writeGoFixture(t, tt.source), AddParseFunc(parseDoc), AddParseStruct(parseTag))
+			assertRPCSignatureError(t, err, tt.functionName, tt.detail)
+		})
+	}
+}
+
+func TestParseGoAcceptsValueAndPointerReceiverRPCsDeclaredBeforeMessages(t *testing.T) {
+	path := writeGoFixture(t, `package fixture
+
+import "context"
+
+type Handler struct{}
+
+// @service:Fixture
+// @method:get
+// @router:/value
+func (Handler) Value(req Request) Response { return Response{} }
+
+// @service:Fixture
+// @method:post
+// @router:/pointer
+func (*Handler) Pointer(ctx context.Context, req *Request) (*Response, error) { return nil, nil }
+
+type Request struct{}
+type Response struct{}
+`)
+
+	parsed, err := ParseGo(path, AddParseFunc(parseDoc), AddParseStruct(parseTag))
+	if err != nil {
+		t.Fatalf("ParseGo() error = %v", err)
+	}
+	generated := parsed.(*GoParsePB).Generate()
+	for _, signature := range []string{
+		"rpc Value (Request) returns (Response)",
+		"rpc Pointer (Request) returns (Response)",
+	} {
+		if !strings.Contains(generated, signature) {
+			t.Fatalf("generated proto is missing %q:\n%s", signature, generated)
+		}
+	}
+}
+
+func TestParseGoRejectsRPCSignatureBoundaries(t *testing.T) {
+	tests := []struct {
+		name         string
+		functionName string
+		detail       string
+		source       string
+	}{
+		{
+			name:         "selector request",
+			functionName: "SelectorRequest",
+			detail:       "request",
+			source: `package fixture
+
+import "net/http"
+type Response struct{}
+
+// @service:Fixture
+func SelectorRequest(req http.Request) Response { return Response{} }
+`,
+		},
+		{
+			name:         "variadic request",
+			functionName: "VariadicRequest",
+			detail:       "request",
+			source: `package fixture
+
+type Request struct{}
+type Response struct{}
+
+// @service:Fixture
+func VariadicRequest(req ...Request) Response { return Response{} }
+`,
+		},
+		{
+			name:         "multiple requests",
+			functionName: "MultipleRequests",
+			detail:       "exactly one request",
+			source: `package fixture
+
+type Request struct{}
+type Response struct{}
+
+// @service:Fixture
+func MultipleRequests(first Request, second Request) Response { return Response{} }
+`,
+		},
+		{
+			name:         "non-error second result",
+			functionName: "SecondResult",
+			detail:       "second result",
+			source: `package fixture
+
+type Request struct{}
+type Response struct{}
+
+// @service:Fixture
+func SecondResult(req Request) (Response, string) { return Response{}, "" }
+`,
+		},
+		{
+			name:         "too many results",
+			functionName: "TooManyResults",
+			detail:       "expected one response",
+			source: `package fixture
+
+type Request struct{}
+type Response struct{}
+
+// @service:Fixture
+func TooManyResults(req Request) (Response, error, error) { return Response{}, nil, nil }
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseGo(writeGoFixture(t, tt.source), AddParseFunc(parseDoc), AddParseStruct(parseTag))
+			assertRPCSignatureError(t, err, tt.functionName, tt.detail)
+		})
+	}
+}
+
+func TestParseGoRejectsShadowedErrorResults(t *testing.T) {
+	tests := []struct {
+		name         string
+		functionName string
+		source       string
+	}{
+		{
+			name:         "package type",
+			functionName: "PackageShadow",
+			source: `package fixture
+
+type error string
+type Request struct{}
+type Response struct{}
+
+// @service:Fixture
+func PackageShadow(req Request) (Response, error) { return Response{}, "shadowed" }
+`,
+		},
+		{
+			name:         "type parameter",
+			functionName: "TypeParameterShadow",
+			source: `package fixture
+
+type Request struct{}
+type Response struct{}
+
+// @service:Fixture
+func TypeParameterShadow[error any](req Request) (Response, error) {
+	var shadowed error
+	return Response{}, shadowed
+}
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseGo(writeGoFixture(t, tt.source), AddParseFunc(parseDoc), AddParseStruct(parseTag))
+			assertRPCSignatureError(t, err, tt.functionName, "second result")
+		})
+	}
+}
+
+func TestHasRPCDocTagsClassifiesMultilineLinesExactly(t *testing.T) {
+	if !hasRPCDocTags([]string{`/*
+ * ordinary prose
+ * @router: /v1/items
+ */`}) {
+		t.Fatal("hasRPCDocTags() = false for an exact tag on a later block-comment line")
+	}
+	if hasRPCDocTags([]string{`/*
+ * ordinary prose mentioning @router: /wrong
+ * @router : /near-match
+ */`}) {
+		t.Fatal("hasRPCDocTags() = true for prose or a near-match tag")
+	}
+}
+
+func TestGeneratedRPCProtoCompilesWithProtoc(t *testing.T) {
+	protoc, err := exec.LookPath("protoc")
+	if err != nil {
+		t.Skip("protoc is not installed")
+	}
+
+	parsed, err := ParseGo(writeGoFixture(t, `package fixture
+
+import "context"
+
+type Request struct{}
+type Response struct{}
+
+// @service:Fixture
+// @method:post
+// @router:/compile
+func Compile(ctx context.Context, req *Request) (*Response, error) { return nil, nil }
+`), AddParseFunc(parseDoc), AddParseStruct(parseTag))
+	if err != nil {
+		t.Fatalf("ParseGo() error = %v", err)
+	}
+
+	root := t.TempDir()
+	writeProtoFixture(t, root, "service.proto", parsed.(*GoParsePB).Generate())
+	writeProtoFixture(t, root, "google/api/http.proto", `syntax = "proto3";
+package google.api;
+message HttpRule {
+  string get = 2;
+  string put = 3;
+  string post = 4;
+  string delete = 5;
+  string patch = 6;
+  string body = 7;
+}
+`)
+	writeProtoFixture(t, root, "google/api/annotations.proto", `syntax = "proto3";
+package google.api;
+import "google/api/http.proto";
+import "google/protobuf/descriptor.proto";
+extend google.protobuf.MethodOptions {
+  HttpRule http = 72295728;
+}
+`)
+
+	args := []string{"--proto_path=" + root}
+	include := filepath.Clean(filepath.Join(filepath.Dir(protoc), "..", "include"))
+	if _, statErr := os.Stat(filepath.Join(include, "google/protobuf/descriptor.proto")); statErr == nil {
+		args = append(args, "--proto_path="+include)
+	}
+	args = append(args, "--descriptor_set_out="+filepath.Join(root, "service.pb"), "service.proto")
+	command := exec.Command(protoc, args...)
+	if output, commandErr := command.CombinedOutput(); commandErr != nil {
+		t.Fatalf("protoc failed: %v\n%s\nproto:\n%s", commandErr, output, parsed.(*GoParsePB).Generate())
+	}
+}
+
+func writeProtoFixture(t *testing.T, root, name, contents string) {
+	t.Helper()
+	path := filepath.Join(root, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("create proto fixture directory: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write proto fixture: %v", err)
+	}
+}

--- a/parser/parse_go/rpc_signature_test.go
+++ b/parser/parse_go/rpc_signature_test.go
@@ -1,0 +1,196 @@
+package parse_go
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseGoRejectsTaggedRPCWithoutRequest(t *testing.T) {
+	path := writeGoFixture(t, `package fixture
+
+type Response struct{}
+
+// @service:Fixture
+// @method:get
+// @router:/missing-request
+func MissingRequest() Response { return Response{} }
+`)
+
+	_, err := ParseGo(path, AddParseFunc(parseDoc), AddParseStruct(parseTag))
+	assertRPCSignatureError(t, err, "MissingRequest", "request")
+}
+
+func TestParseGoRejectsTaggedRPCWithoutResponse(t *testing.T) {
+	path := writeGoFixture(t, `package fixture
+
+type Request struct{}
+
+// @service:Fixture
+// @method:post
+// @router:/missing-response
+func MissingResponse(req Request) {}
+`)
+
+	_, err := ParseGo(path, AddParseFunc(parseDoc), AddParseStruct(parseTag))
+	assertRPCSignatureError(t, err, "MissingResponse", "response")
+}
+
+func TestParseGoAcceptsContextPointerRPCAndSkipsHelper(t *testing.T) {
+	path := writeGoFixture(t, `package fixture
+
+import "context"
+
+type Request struct{}
+type Response struct{}
+
+func helper() {}
+
+// @service:Fixture
+// @method:post
+// @router:/register
+func Register(ctx context.Context, req *Request) (*Response, error) { return nil, nil }
+`)
+
+	parsed, err := ParseGo(path, AddParseFunc(parseDoc), AddParseStruct(parseTag))
+	if err != nil {
+		t.Fatalf("ParseGo() error = %v", err)
+	}
+	generated := parsed.(*GoParsePB).Generate()
+	if !strings.Contains(generated, "rpc Register (Request) returns (Response)") {
+		t.Fatalf("generated proto is missing the valid RPC signature:\n%s", generated)
+	}
+	if strings.Contains(generated, "rpc helper") {
+		t.Fatalf("generated proto contains ordinary helper as RPC:\n%s", generated)
+	}
+}
+
+func TestParseGoProseMentionDoesNotCreateRPC(t *testing.T) {
+	path := writeGoFixture(t, `package fixture
+
+// This ordinary helper only mentions @method:post in prose.
+func helper() {}
+`)
+
+	parsed, err := ParseGo(path, AddParseFunc(parseDoc))
+	if err != nil {
+		t.Fatalf("ParseGo() error = %v", err)
+	}
+	generated := parsed.(*GoParsePB).Generate()
+	if strings.Contains(generated, "rpc helper") {
+		t.Fatalf("generated proto contains prose-only helper as RPC:\n%s", generated)
+	}
+}
+
+func TestParseGoCustomParserRPCIsGenerated(t *testing.T) {
+	path := writeGoFixture(t, `package fixture
+
+type Request struct{}
+type Response struct{}
+
+// custom transport metadata
+func Custom(req *Request) (*Response, error) { return nil, nil }
+`)
+	customParser := func(server *Server) {
+		if server.Name == "Custom" {
+			server.ServerName = "Fixture"
+			server.Method = "post"
+			server.Router = "/custom"
+		}
+	}
+
+	parsed, err := ParseGo(path, AddParseFunc(customParser), AddParseStruct(parseTag))
+	if err != nil {
+		t.Fatalf("ParseGo() error = %v", err)
+	}
+	generated := parsed.(*GoParsePB).Generate()
+	if !strings.Contains(generated, "rpc Custom (Request) returns (Response)") {
+		t.Fatalf("generated proto is missing custom-parser RPC:\n%s", generated)
+	}
+}
+
+func TestParseGoRejectsCustomParserRPCInvalidSignatures(t *testing.T) {
+	tests := []struct {
+		name         string
+		functionName string
+		detail       string
+		source       string
+	}{
+		{
+			name:         "missing request",
+			functionName: "CustomMissingRequest",
+			detail:       "request",
+			source: `package fixture
+
+type Response struct{}
+
+// custom transport metadata
+func CustomMissingRequest() Response { return Response{} }
+`,
+		},
+		{
+			name:         "missing response",
+			functionName: "CustomMissingResponse",
+			detail:       "response",
+			source: `package fixture
+
+type Request struct{}
+
+// custom transport metadata
+func CustomMissingResponse(req Request) {}
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := writeGoFixture(t, tt.source)
+			customParser := func(server *Server) {
+				server.ServerName = "Fixture"
+				server.Method = "post"
+				server.Router = "/custom"
+			}
+
+			_, err := ParseGo(path, AddParseFunc(customParser), AddParseStruct(parseTag))
+			assertRPCSignatureError(t, err, tt.functionName, tt.detail)
+		})
+	}
+}
+
+func TestParseGoDemoRPCSignaturesRemainValid(t *testing.T) {
+	parsed, err := ParseGo("../demo/demo.api", AddParseFunc(parseDoc), AddParseStruct(parseTag))
+	if err != nil {
+		t.Fatalf("ParseGo(demo.api) error = %v", err)
+	}
+	generated := parsed.(*GoParsePB).Generate()
+	for _, signature := range []string{
+		"rpc Register (Request) returns (Response)",
+		"rpc Register2 (Request) returns (Response)",
+	} {
+		if !strings.Contains(generated, signature) {
+			t.Fatalf("generated demo proto is missing %q:\n%s", signature, generated)
+		}
+	}
+}
+
+func writeGoFixture(t *testing.T, source string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "fixture.go")
+	if err := os.WriteFile(path, []byte(source), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}
+
+func assertRPCSignatureError(t *testing.T, err error, functionName, detail string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("ParseGo() error = nil, want unsupported RPC signature error")
+	}
+	for _, want := range []string{"unsupported RPC signature", functionName, detail} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("ParseGo() error = %q, want it to contain %q", err, want)
+		}
+	}
+}


### PR DESCRIPTION
## What

- parse only exact documentation tags at the start of a comment
- trim tag values while preserving later colons
- support the comment prefixes emitted by Go's parser
- add behavioral regression tests

## Why

The parser used substring matching, so ordinary prose mentioning `@method`, `@service`, or `@router` could overwrite RPC metadata. Values also retained incidental whitespace, while splitting on every colon would corrupt routes containing a colon.

## How

Normalize the surrounding comment marker, match exact `@name:` prefixes, and split only at the first colon before trimming the value. Embedded text and similar tag names are ignored.

## Tests

- exact line and block-comment tags
- embedded and near-match false positives
- whitespace, empty values, and routes containing later colons
- existing demo generation control
- `go test -race ./parser/parse_go`
- `go vet ./parser/parse_go`
- substring matching, missing trim, and full-split mutations are all killed
