### PR TITLE
fix(parse_go): preserve UTF-8 when removing code

### DIFF
--- a/parser/parse_go/clean_code_utf8_test.go
+++ b/parser/parse_go/clean_code_utf8_test.go
@@ -1,0 +1,108 @@
+package parse_go
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestPileDismantlePreservesUTF8AroundRemovedLine(t *testing.T) {
+	const source = `package fixture
+
+func 示例() {
+	println("保留前")
+	// 删除代码
+	println("保留后")
+}
+`
+	const want = `package fixture
+
+func 示例() {
+	println("保留前")
+	println("保留后")
+}
+`
+
+	path := filepath.Join(t.TempDir(), "fixture.go")
+	if err := os.WriteFile(path, []byte(source), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	g := &GoParsePB{FilePath: path}
+	if err := g.PileDismantle("// 删除代码"); err != nil {
+		t.Fatalf("PileDismantle() error = %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	if !utf8.Valid(got) {
+		t.Fatalf("PileDismantle() produced invalid UTF-8: %q", got)
+	}
+	if string(got) != want {
+		t.Fatalf("PileDismantle() result:\n%s\nwant:\n%s", got, want)
+	}
+	for _, adjacent := range []string{"示例", "保留前", "保留后"} {
+		if !strings.Contains(string(got), adjacent) {
+			t.Fatalf("PileDismantle() removed adjacent Chinese text %q", adjacent)
+		}
+	}
+}
+
+func TestCleanCodeRemovesUTF8LineAtBoundaries(t *testing.T) {
+	tests := []struct {
+		name      string
+		clearCode string
+		source    string
+		want      string
+	}{
+		{
+			name:      "first line",
+			clearCode: "// 删除代码",
+			source:    "// 删除代码\n保留中文\n",
+			want:      "保留中文\n",
+		},
+		{
+			name:      "middle line",
+			clearCode: "// 删除代码",
+			source:    "保留前\n\t// 删除代码\n保留后\n",
+			want:      "保留前\n保留后\n",
+		},
+		{
+			name:      "CRLF middle line",
+			clearCode: "// 删除代码",
+			source:    "保留前\r\n\t// 删除代码\r\n保留后\r\n",
+			want:      "保留前\r\n保留后\r\n",
+		},
+		{
+			name:      "EOF after preserved Chinese",
+			clearCode: "target",
+			source:    "保留中文\ntarget",
+			want:      "保留中文\n",
+		},
+		{
+			name:      "single line EOF",
+			clearCode: "target",
+			source:    "target",
+			want:      "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := cleanCode(tt.clearCode, tt.source)
+			if err != nil {
+				t.Fatalf("cleanCode() error = %v", err)
+			}
+			if !utf8.Valid(got) {
+				t.Fatalf("cleanCode() produced invalid UTF-8: %q", got)
+			}
+			if string(got) != tt.want {
+				t.Fatalf("cleanCode() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/parser/parse_go/model.go
+++ b/parser/parse_go/model.go
@@ -522,15 +522,20 @@ func (g *GoParsePB) pileDismantle(srcData []byte, clearCode string) ([]byte, err
 // cleanCode: 清除桩内内容
 func cleanCode(clearCode string, srcData string) ([]byte, error) {
 	bf := make([]rune, 0, 1024)
+	lineStart := 0
 	for i, v := range srcData {
 		if v == '\n' {
 			if strings.TrimSpace(string(bf)) == clearCode {
-				return append([]byte(srcData[:i-len(bf)]), []byte(srcData[i+1:])...), nil
+				return append([]byte(srcData[:lineStart]), []byte(srcData[i+1:])...), nil
 			}
 			bf = (bf)[:0]
+			lineStart = i + 1
 			continue
 		}
 		bf = append(bf, v)
+	}
+	if lineStart < len(srcData) && strings.TrimSpace(string(bf)) == clearCode {
+		return []byte(srcData[:lineStart]), nil
 	}
 	return []byte(srcData), errors.New("未找到内容")
 }


### PR DESCRIPTION
## What

- remove matching source lines using byte-accurate line offsets
- handle a matching final line without a trailing newline
- add UTF-8, CRLF, boundary, and end-to-end regression tests

## Why

`cleanCode` iterated source by byte offset but subtracted the number of runes collected for the line. When the target line contained multibyte characters, slicing started in the middle of UTF-8 and corrupted the file. A target on the final line was also missed when the file had no trailing newline.

## How

Track the starting byte offset of each line and slice only at byte boundaries. After iteration, inspect the remaining final line before reporting that no match exists.

## Tests

- first, middle, CRLF, final-without-newline, and single-line targets
- valid UTF-8 and exact preservation of adjacent Chinese text
- `PileDismantle` through a temporary file, without touching repository fixtures
- `go test -race ./parser/parse_go`
- old rune-length and missing-EOF-handler mutations are both killed
