### PR TITLE
test(middleware): assert Chain execution order

### DIFF
--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -2,58 +2,63 @@ package middleware
 
 import (
 	"context"
-	"fmt"
+	"errors"
+	"reflect"
 	"testing"
 )
 
-var (
-	ctx = context.Background()
-	req = struct{}{}
-)
+func TestChainOrderAndResult(t *testing.T) {
+	var events []string
+	wantResponse := &struct{ value string }{value: "response"}
+	wantErr := errors.New("endpoint error")
+	wantContext := context.WithValue(context.Background(), struct{}{}, "context")
+	wantRequest := &struct{ value string }{value: "request"}
 
-func TestChain(t *testing.T) {
-	e := Chain(
-		annotate("first"),
-		annotate("second"),
-		annotate("third"),
-	)(myEndpoint)
-
-	if _, err := e(ctx, req); err != nil {
-		panic(err)
+	endpoint := func(ctx context.Context, request interface{}) (interface{}, error) {
+		if ctx != wantContext {
+			t.Fatalf("endpoint context = %v, want original context", ctx)
+		}
+		if request != wantRequest {
+			t.Fatalf("endpoint request = %v, want original request", request)
+		}
+		events = append(events, "endpoint")
+		return wantResponse, wantErr
 	}
-	// Output:
-	// first pre
-	// second pre
-	// third pre
-	// my endpoint!
-	// third post
-	// second post
-	// first post
+
+	chained := Chain(
+		recordEvents(&events, "first"),
+		recordEvents(&events, "second"),
+		recordEvents(&events, "third"),
+	)(endpoint)
+
+	gotResponse, gotErr := chained(wantContext, wantRequest)
+	if gotResponse != wantResponse {
+		t.Fatalf("response = %v, want original response %v", gotResponse, wantResponse)
+	}
+	if gotErr != wantErr {
+		t.Fatalf("error = %v, want original error %v", gotErr, wantErr)
+	}
+	wantEvents := []string{
+		"first pre",
+		"second pre",
+		"third pre",
+		"endpoint",
+		"third post",
+		"second post",
+		"first post",
+	}
+	if !reflect.DeepEqual(events, wantEvents) {
+		t.Fatalf("events = %v, want %v", events, wantEvents)
+	}
 }
 
-func ExampleChain() {
-	e := Chain(
-		annotate("first"),
-		annotate("second"),
-		annotate("third"),
-	)(myEndpoint)
-
-	if _, err := e(ctx, req); err != nil {
-		panic(err)
-	}
-}
-
-func annotate(s string) MiddleWare {
+func recordEvents(events *[]string, name string) MiddleWare {
 	return func(next Endpoint) Endpoint {
 		return func(ctx context.Context, request interface{}) (interface{}, error) {
-			fmt.Println(s, "pre")
-			defer fmt.Println(s, "post")
-			return next(ctx, request)
+			*events = append(*events, name+" pre")
+			response, err := next(ctx, request)
+			*events = append(*events, name+" post")
+			return response, err
 		}
 	}
-}
-
-func myEndpoint(context.Context, interface{}) (interface{}, error) {
-	fmt.Println("my endpoint!")
-	return struct{}{}, nil
 }


### PR DESCRIPTION
## What

- replace output-only middleware examples with deterministic assertions
- verify nested pre/post execution order
- verify context, request, response, and error identity are preserved

## Why

The existing `// Output` block was inside a normal test, where it had no effect, and the example had no expected output. Reversing the Chain wrapping loop changed middleware order but the package tests still passed.

## How

Record middleware and endpoint events in a slice and compare the complete sequence. The endpoint returns unique response and error objects so the test also proves transparent propagation.

## Tests

- `go test -race ./middleware -count=100`
- `go vet ./middleware`
- mutation check: changing the wrapping loop to forward order fails the exact event assertion

This is a tests-only change; production middleware code is unchanged.
