### PR TITLE
docs(singleflight): clarify Forget semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ func ExampleShutdown() {
 
 ### singleflight
 
-Merge back to source
+Merge back to source. `Forget` follows `golang.org/x/sync/singleflight.Group.Forget` v0.11.0 pinned in `go.mod` (reconciled 2026-07-12).
 ```go
 package main
 
@@ -364,7 +364,8 @@ func main() {
 	// result.Val is the fetched resource
 	cache(result.Val)
 	
-	// try to cancel
+	// Forget only removes singleflight's association with this key; it does not
+	// cancel fn. A later call with the same key executes independently.
 	f.Forget("test2")
 }
 ```

--- a/README_zh.md
+++ b/README_zh.md
@@ -312,7 +312,7 @@ func ExampleShutdown()  {
 
 ### singleflight
 
-归并回源
+归并回源。`Forget` 语义以 `go.mod` 固定的 `golang.org/x/sync/singleflight.Group.Forget` v0.11.0 为准（核对日期：2026-07-12）。
 ```go
 package main
 
@@ -361,7 +361,8 @@ func main() {
 	// result.Val就是获取到的资源
 	cache(result.Val)
 	
-	// 尽力取消
+	// Forget 仅移除 singleflight 对该 key 的关联，不会取消 fn；
+	// 后续同 key 调用会独立执行。
 	f.Forget("test2")
 }
 ```

--- a/cache/singleflight/example_test.go
+++ b/cache/singleflight/example_test.go
@@ -40,6 +40,7 @@ func ExampleNewSingleFlight() {
 	}
 	cache(result.Val)
 
-	// 尽力取消
+	// Forget 仅移除 singleflight 对该 key 的关联，不会取消 fn；
+	// 后续同 key 调用会独立执行。
 	singleFlight.Forget("test2")
 }

--- a/cache/singleflight/singleflight.go
+++ b/cache/singleflight/singleflight.go
@@ -10,7 +10,8 @@ type SingleFlight interface {
 	// DoChan 异步调用单飞
 	DoChan(key string, fn func() (interface{}, error)) <-chan singleflight.Result
 
-	// Forget 可以取消已经下发未执行的任务
+	// Forget 让 singleflight 忘记 key，使未来的同 key 调用不再等待当前调用。
+	// 当前调用的 fn 不会被取消，仍会继续执行并返回给它原有的调用者。
 	Forget(key string)
 }
 

--- a/cache/singleflight/singleflight_test.go
+++ b/cache/singleflight/singleflight_test.go
@@ -42,6 +42,87 @@ func TestDoErr(t *testing.T) {
 	}
 }
 
+func TestForgetStartsNewCallWithoutCancelingOldCall(t *testing.T) {
+	type result struct {
+		value  interface{}
+		err    error
+		shared bool
+	}
+
+	g := NewSingleFlight()
+	oldStarted := make(chan struct{})
+	releaseOld := make(chan struct{})
+	var releaseOldOnce sync.Once
+	releaseOldCall := func() {
+		releaseOldOnce.Do(func() { close(releaseOld) })
+	}
+	t.Cleanup(releaseOldCall)
+	oldDone := make(chan result, 1)
+	go func() {
+		value, err, shared := g.Do("key", func() (interface{}, error) {
+			close(oldStarted)
+			<-releaseOld
+			return "old", nil
+		})
+		oldDone <- result{value: value, err: err, shared: shared}
+	}()
+	waitForSignal(t, oldStarted, "old call to start")
+
+	g.Forget("key")
+
+	newStarted := make(chan struct{})
+	newDone := make(chan result, 1)
+	go func() {
+		value, err, shared := g.Do("key", func() (interface{}, error) {
+			close(newStarted)
+			return "new", nil
+		})
+		newDone <- result{value: value, err: err, shared: shared}
+	}()
+	waitForSignal(t, newStarted, "new call to start independently")
+
+	newResult := waitForResult(t, newDone, "new call to finish")
+	if newResult.value != "new" || newResult.err != nil || newResult.shared {
+		t.Fatalf("new call = (%v, %v, shared=%t), want (new, nil, shared=false)", newResult.value, newResult.err, newResult.shared)
+	}
+	select {
+	case oldResult := <-oldDone:
+		t.Fatalf("old call finished before release: (%v, %v, shared=%t)", oldResult.value, oldResult.err, oldResult.shared)
+	default:
+	}
+
+	releaseOldCall()
+	oldResult := waitForResult(t, oldDone, "old call to finish after release")
+	if oldResult.value != "old" || oldResult.err != nil {
+		t.Fatalf("old call = (%v, %v), want (old, nil)", oldResult.value, oldResult.err)
+	}
+}
+
+func waitForSignal(t *testing.T, ch <-chan struct{}, operation string) {
+	t.Helper()
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
+	select {
+	case <-ch:
+	case <-timer.C:
+		t.Fatalf("timed out waiting for %s", operation)
+	}
+}
+
+func waitForResult[T any](t *testing.T, ch <-chan T, operation string) T {
+	t.Helper()
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
+	select {
+	case result := <-ch:
+		return result
+	case <-timer.C:
+		t.Fatalf("timed out waiting for %s", operation)
+		var zero T
+		return zero
+	}
+}
+
 func TestDoDupSuppress(t *testing.T) {
 	g := NewSingleFlight()
 	var wg1, wg2 sync.WaitGroup


### PR DESCRIPTION
## What

- correct the `SingleFlight.Forget` contract documentation
- add a deterministic behavioral test for old and future calls

## Why

The interface comment said `Forget` cancels a dispatched task. The upstream implementation does not cancel the running function; it only removes the key so future calls start independently. Callers relying on the old comment could assume work had stopped when it was still executing.

## How

Document the upstream semantics directly. The test blocks the old function, calls `Forget`, proves a new same-key function starts and finishes independently, then releases and verifies the old function still completes with its original result.

## Tests

- `go test -race ./cache/singleflight -count=100`
- `go vet ./cache/singleflight`
- removing `Forget` or forgetting a different key makes the controlled new-call assertion time out

Production singleflight behavior is unchanged.
