### PR TITLE
fix(controller): close #103 reliable-delivery validation gaps

### DIFF
--- a/distributed/controller/controller_redis/reliable_consumer.go
+++ b/distributed/controller/controller_redis/reliable_consumer.go
@@ -5,11 +5,11 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/binary"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"time"
-
-	json "github.com/json-iterator/go"
 
 	"github.com/songzhibin97/gkit/distributed/task"
 )
@@ -23,8 +23,21 @@ func (c *ControllerRedis) consumeReliableDelivery(
 	var signature task.Signature
 	decoder := json.NewDecoder(bytes.NewReader(delivery.payload))
 	decoder.UseNumber()
-	if err := decoder.Decode(&signature); err != nil {
-		decodeErr := fmt.Errorf("decode queued task: %w", err)
+	validationErr := decoder.Decode(&signature)
+	if validationErr == nil {
+		var trailing interface{}
+		validationErr = decoder.Decode(&trailing)
+		switch validationErr {
+		case io.EOF:
+			validationErr = nil
+		case nil:
+			validationErr = errors.New("unexpected additional JSON value")
+		default:
+			validationErr = fmt.Errorf("trailing content: %w", validationErr)
+		}
+	}
+	if validationErr != nil {
+		decodeErr := fmt.Errorf("decode queued task: %w", validationErr)
 		if c.deliveryMustRelease(attemptCtx) {
 			return errors.Join(decodeErr, c.releaseReliableDelivery(queue, delivery))
 		}

--- a/distributed/controller/controller_redis/reliable_consumer_test.go
+++ b/distributed/controller/controller_redis/reliable_consumer_test.go
@@ -1,12 +1,14 @@
 package controller_redis
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"errors"
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -24,9 +26,11 @@ type reliableTestProcessor struct {
 	returned chan struct{}
 	err      error
 	once     sync.Once
+	calls    atomic.Int32
 }
 
 func (p *reliableTestProcessor) Process(*task.Signature) error {
+	p.calls.Add(1)
 	p.once.Do(func() { close(p.started) })
 	if p.release != nil {
 		<-p.release
@@ -468,21 +472,122 @@ func TestProcessorErrorDefersDelivery(t *testing.T) {
 	}
 }
 
-func TestMalformedPayloadRemainsRecoverable(t *testing.T) {
-	const queue = "queue:{reliable}"
-	c, client := newReliableTestController(t, queue)
-	body := []byte("{not-json")
-	if err := client.RPush(context.Background(), queue, body).Err(); err != nil {
-		t.Fatalf("enqueue malformed task: %v", err)
+func TestQueuedPayloadValidationPreservesMalformedBytes(t *testing.T) {
+	valid := reliableTaskBody(t, "payload-validation")
+	tests := []struct {
+		name      string
+		body      []byte
+		malformed bool
+	}{
+		{name: "invalid first byte", body: append([]byte("!"), valid...), malformed: true},
+		{name: "invalid trailing byte", body: append(append([]byte(nil), valid...), '!'), malformed: true},
+		{name: "second JSON value", body: append(append([]byte(nil), valid...), valid...), malformed: true},
+		{name: "trailing whitespace", body: append(append([]byte(nil), valid...), []byte(" \n\t\r  ")...)},
 	}
-	processor := &reliableTestProcessor{started: make(chan struct{})}
-	_, err := c.StartConsuming(1, processor)
-	if err == nil {
-		t.Fatal("StartConsuming error = nil, want decode failure")
-	}
-	prefix := reliableTaggedPrefix(queue, "reliable")
-	durable := client.LLen(context.Background(), queue).Val() + client.HLen(context.Background(), prefix+":inflight").Val()
-	if durable != 1 {
-		t.Fatalf("durable copies after decode failure = %d, want 1", durable)
+
+	for index, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			queue := fmt.Sprintf("queue:{payload-validation-%d}", index)
+			c, client := newReliableTestController(t, queue)
+			if err := client.RPush(context.Background(), queue, tt.body).Err(); err != nil {
+				t.Fatalf("enqueue payload: %v", err)
+			}
+			processor := &reliableTestProcessor{started: make(chan struct{})}
+			result := make(chan reliableConsumeResult, 1)
+			go func() {
+				retry, err := c.StartConsuming(1, processor)
+				result <- reliableConsumeResult{retry: retry, err: err}
+			}()
+
+			keys := deriveReliableQueueKeys(queue)
+			if tt.malformed {
+				select {
+				case outcome := <-result:
+					if outcome.err == nil || !strings.Contains(outcome.err.Error(), "decode queued task") {
+						t.Fatalf("StartConsuming error = %v, want contextual decode failure", outcome.err)
+					}
+				case <-processor.started:
+					c.StopConsuming()
+					<-result
+					t.Fatal("processor ran for malformed queued payload")
+				case <-time.After(3 * time.Second):
+					c.StopConsuming()
+					t.Fatal("malformed queued payload did not stop the consume attempt")
+				}
+				if got := processor.calls.Load(); got != 0 {
+					t.Fatalf("processor calls = %d, want 0", got)
+				}
+				if got := client.ZCard(context.Background(), keys.outcomes).Val(); got != 0 {
+					t.Fatalf("ack outcomes = %d, want 0", got)
+				}
+				ready, err := client.LRange(context.Background(), queue, 0, -1).Result()
+				if err != nil {
+					t.Fatalf("read ready queue: %v", err)
+				}
+				inflight, err := client.HGetAll(context.Background(), keys.inflight).Result()
+				if err != nil {
+					t.Fatalf("read inflight reservations: %v", err)
+				}
+				if copies := len(ready) + len(inflight); copies != 1 {
+					t.Fatalf("ready + inflight copies = %d, want exactly 1", copies)
+				}
+				var recovered []byte
+				if len(ready) == 1 {
+					recovered = []byte(ready[0])
+				}
+				for _, envelope := range inflight {
+					_, payload, err := decodeReliableEnvelope([]byte(envelope))
+					if err != nil {
+						t.Fatalf("decode retained envelope: %v", err)
+					}
+					recovered = payload
+				}
+				if !bytes.Equal(recovered, tt.body) {
+					t.Fatalf("retained payload = %q, want exact bytes %q", recovered, tt.body)
+				}
+				if got := client.ZCard(context.Background(), keys.visibility).Val(); got != int64(len(inflight)) {
+					t.Fatalf("visibility entries = %d, want %d", got, len(inflight))
+				}
+				if got := client.ZCard(context.Background(), keys.repairBacklog).Val(); got != 0 {
+					t.Fatalf("repair backlog entries = %d, want 0", got)
+				}
+				return
+			}
+
+			select {
+			case <-processor.started:
+			case outcome := <-result:
+				t.Fatalf("StartConsuming returned before valid payload processing: %v", outcome.err)
+			case <-time.After(3 * time.Second):
+				c.StopConsuming()
+				t.Fatal("processor did not receive valid payload with trailing whitespace")
+			}
+			deadline := time.Now().Add(3 * time.Second)
+			for client.ZCard(context.Background(), keys.outcomes).Val() != 1 && time.Now().Before(deadline) {
+				time.Sleep(time.Millisecond)
+			}
+			if got := client.ZCard(context.Background(), keys.outcomes).Val(); got != 1 {
+				c.StopConsuming()
+				t.Fatalf("ack outcomes = %d, want 1", got)
+			}
+			c.StopConsuming()
+			select {
+			case outcome := <-result:
+				if !errors.Is(outcome.err, context.Canceled) {
+					t.Fatalf("StartConsuming error = %v, want context.Canceled after stop", outcome.err)
+				}
+			case <-time.After(3 * time.Second):
+				t.Fatal("consumer did not stop")
+			}
+			if got := processor.calls.Load(); got != 1 {
+				t.Fatalf("processor calls = %d, want 1", got)
+			}
+			if ready := client.LLen(context.Background(), queue).Val(); ready != 0 {
+				t.Fatalf("ready tasks after valid processing = %d, want 0", ready)
+			}
+			if inflight := client.HLen(context.Background(), keys.inflight).Val(); inflight != 0 {
+				t.Fatalf("inflight tasks after valid processing = %d, want 0", inflight)
+			}
+		})
 	}
 }

--- a/distributed/controller/controller_redis/reliable_consumer_test.go
+++ b/distributed/controller/controller_redis/reliable_consumer_test.go
@@ -524,29 +524,45 @@ func TestQueuedPayloadValidationPreservesMalformedBytes(t *testing.T) {
 				if err != nil {
 					t.Fatalf("read ready queue: %v", err)
 				}
+				if len(ready) != 0 {
+					t.Fatalf("ready tasks after malformed deferral = %d, want 0", len(ready))
+				}
 				inflight, err := client.HGetAll(context.Background(), keys.inflight).Result()
 				if err != nil {
 					t.Fatalf("read inflight reservations: %v", err)
 				}
-				if copies := len(ready) + len(inflight); copies != 1 {
-					t.Fatalf("ready + inflight copies = %d, want exactly 1", copies)
+				if len(inflight) != 1 {
+					t.Fatalf("inflight reservations after malformed deferral = %d, want 1", len(inflight))
 				}
-				var recovered []byte
-				if len(ready) == 1 {
-					recovered = []byte(ready[0])
-				}
-				for _, envelope := range inflight {
-					_, payload, err := decodeReliableEnvelope([]byte(envelope))
+				var deferredToken string
+				for token, envelope := range inflight {
+					failures, payload, err := decodeReliableEnvelope([]byte(envelope))
 					if err != nil {
 						t.Fatalf("decode retained envelope: %v", err)
 					}
-					recovered = payload
+					if failures != 1 {
+						t.Fatalf("deferred failure count = %d, want 1", failures)
+					}
+					if !bytes.Equal(payload, tt.body) {
+						t.Fatalf("retained payload = %q, want exact bytes %q", payload, tt.body)
+					}
+					deferredToken = token
 				}
-				if !bytes.Equal(recovered, tt.body) {
-					t.Fatalf("retained payload = %q, want exact bytes %q", recovered, tt.body)
+				visibility, err := client.ZRangeWithScores(context.Background(), keys.visibility, 0, -1).Result()
+				if err != nil {
+					t.Fatalf("read deferred visibility: %v", err)
 				}
-				if got := client.ZCard(context.Background(), keys.visibility).Val(); got != int64(len(inflight)) {
-					t.Fatalf("visibility entries = %d, want %d", got, len(inflight))
+				if len(visibility) != 1 || fmt.Sprint(visibility[0].Member) != deferredToken {
+					t.Fatalf("visibility = %#v, want one entry for deferred token %q", visibility, deferredToken)
+				}
+				redisNow, err := client.Time(context.Background()).Result()
+				if err != nil {
+					t.Fatalf("read Redis time: %v", err)
+				}
+				remaining := time.Duration(int64(visibility[0].Score)-redisNow.UnixMilli()) * time.Millisecond
+				wantDelay := reliableRetryDelay(0, tt.body)
+				if remaining <= 0 || remaining > wantDelay || wantDelay-remaining > 500*time.Millisecond {
+					t.Fatalf("deferred visibility remaining = %v, want future deadline within 500ms of %v", remaining, wantDelay)
 				}
 				if got := client.ZCard(context.Background(), keys.repairBacklog).Val(); got != 0 {
 					t.Fatalf("repair backlog entries = %d, want 0", got)

--- a/distributed/controller/controller_redis/reliable_queue_test.go
+++ b/distributed/controller/controller_redis/reliable_queue_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -25,19 +26,6 @@ func newReliableTestQueue(t *testing.T, queue string, lease time.Duration, sourc
 type failingTokenReader struct{ err error }
 
 func (r failingTokenReader) Read([]byte) (int, error) { return 0, r.err }
-
-type fixedTokenReader struct {
-	token [16]byte
-	reads atomic.Int32
-}
-
-func (r *fixedTokenReader) Read(p []byte) (int, error) {
-	r.reads.Add(1)
-	for index := range p {
-		p[index] = r.token[index%len(r.token)]
-	}
-	return len(p), nil
-}
 
 type loseScriptResponseHook struct {
 	hash  string
@@ -388,6 +376,90 @@ func TestPermanentFailuresUseBoundedBackoff(t *testing.T) {
 	}
 }
 
+type reliableQueueState struct {
+	ready               []string
+	inflight            map[string]string
+	visibility          []redis.Z
+	outcomes            []redis.Z
+	repairCursor        string
+	repairCursorPresent bool
+	repairBacklog       []redis.Z
+}
+
+func snapshotReliableQueueState(t *testing.T, client redis.UniversalClient, keys reliableQueueKeys) reliableQueueState {
+	t.Helper()
+	ctx := context.Background()
+	ready, err := client.LRange(ctx, keys.ready, 0, -1).Result()
+	if err != nil {
+		t.Fatalf("snapshot ready queue: %v", err)
+	}
+	inflight, err := client.HGetAll(ctx, keys.inflight).Result()
+	if err != nil {
+		t.Fatalf("snapshot inflight reservations: %v", err)
+	}
+	visibility, err := client.ZRangeWithScores(ctx, keys.visibility, 0, -1).Result()
+	if err != nil {
+		t.Fatalf("snapshot visibility: %v", err)
+	}
+	outcomes, err := client.ZRangeWithScores(ctx, keys.outcomes, 0, -1).Result()
+	if err != nil {
+		t.Fatalf("snapshot acknowledgement outcomes: %v", err)
+	}
+	repairCursor, err := client.Get(ctx, keys.repairCursor).Result()
+	repairCursorPresent := true
+	if errors.Is(err, redis.Nil) {
+		repairCursor = ""
+		repairCursorPresent = false
+	} else if err != nil {
+		t.Fatalf("snapshot repair cursor: %v", err)
+	}
+	repairBacklog, err := client.ZRangeWithScores(ctx, keys.repairBacklog, 0, -1).Result()
+	if err != nil {
+		t.Fatalf("snapshot repair backlog: %v", err)
+	}
+	return reliableQueueState{
+		ready:               ready,
+		inflight:            inflight,
+		visibility:          visibility,
+		outcomes:            outcomes,
+		repairCursor:        repairCursor,
+		repairCursorPresent: repairCursorPresent,
+		repairBacklog:       repairBacklog,
+	}
+}
+
+func reliableCollisionCandidates() ([]byte, []string) {
+	entropy := make([]byte, 0, maxDeliveryTokenAttempts*16)
+	tokens := make([]string, 0, maxDeliveryTokenAttempts)
+	for value := byte(1); value <= maxDeliveryTokenAttempts; value++ {
+		candidate := bytes.Repeat([]byte{value}, 16)
+		entropy = append(entropy, candidate...)
+		tokens = append(tokens, fmt.Sprintf("%x", candidate))
+	}
+	return entropy, tokens
+}
+
+func seedReliableCollisionCandidates(t *testing.T, client redis.UniversalClient, keys reliableQueueKeys, tokens []string) {
+	t.Helper()
+	if len(tokens) != maxDeliveryTokenAttempts {
+		t.Fatalf("collision token count = %d, want %d", len(tokens), maxDeliveryTokenAttempts)
+	}
+	ctx := context.Background()
+	future := float64(time.Now().Add(time.Hour).UnixMilli())
+	if err := client.HSet(ctx, keys.inflight, tokens[0], "0000000000:collision-reservation").Err(); err != nil {
+		t.Fatalf("seed inflight collision: %v", err)
+	}
+	if err := client.ZAdd(ctx, keys.visibility, &redis.Z{Score: future, Member: tokens[1]}).Err(); err != nil {
+		t.Fatalf("seed visibility-only collision: %v", err)
+	}
+	if err := client.ZAdd(ctx, keys.outcomes, &redis.Z{Score: future, Member: tokens[2]}).Err(); err != nil {
+		t.Fatalf("seed unexpired outcome collision: %v", err)
+	}
+	if err := client.ZAdd(ctx, keys.repairBacklog, &redis.Z{Score: 0, Member: tokens[3]}).Err(); err != nil {
+		t.Fatalf("seed repair-backlog collision: %v", err)
+	}
+}
+
 func TestDeliveryTokenGenerationIsBounded(t *testing.T) {
 	t.Run("entropy failure", func(t *testing.T) {
 		queue := "queue:{entropy}"
@@ -396,68 +468,54 @@ func TestDeliveryTokenGenerationIsBounded(t *testing.T) {
 		if err := client.RPush(context.Background(), queue, "task").Err(); err != nil {
 			t.Fatalf("enqueue: %v", err)
 		}
+		before := snapshotReliableQueueState(t, client, q.keys)
 		if _, err := q.claim(context.Background()); !errors.Is(err, ErrDeliveryTokenUnavailable) || !errors.Is(err, wantErr) {
 			t.Fatalf("claim error = %v, want token and source errors", err)
 		}
-		if client.LLen(context.Background(), queue).Val() != 1 || client.HLen(context.Background(), q.keys.inflight).Val() != 0 {
-			t.Fatal("entropy failure mutated task")
+		if after := snapshotReliableQueueState(t, client, q.keys); !reflect.DeepEqual(after, before) {
+			t.Fatalf("entropy failure mutated queue state\nbefore: %#v\nafter:  %#v", before, after)
 		}
 	})
 
-	t.Run("collision exhaustion", func(t *testing.T) {
-		queue := "queue:{collision}"
-		reader := &fixedTokenReader{}
+	t.Run("claim collisions across all reservation indexes", func(t *testing.T) {
+		queue := "queue:{claim-collision-indexes}"
+		entropy, tokens := reliableCollisionCandidates()
+		reader := bytes.NewReader(entropy)
 		q, client := newReliableTestQueue(t, queue, time.Second, reader)
-		if err := client.RPush(context.Background(), queue, "first").Err(); err != nil {
-			t.Fatalf("enqueue first: %v", err)
+		if err := client.RPush(context.Background(), queue, "claim-ready-task").Err(); err != nil {
+			t.Fatalf("enqueue ready task: %v", err)
 		}
-		first, err := q.claim(context.Background())
-		if err != nil || first == nil {
-			t.Fatalf("first claim = (%v, %v)", first, err)
-		}
-		if err := client.RPush(context.Background(), queue, "second").Err(); err != nil {
-			t.Fatalf("enqueue second: %v", err)
-		}
+		seedReliableCollisionCandidates(t, client, q.keys, tokens)
+		before := snapshotReliableQueueState(t, client, q.keys)
 		if _, err := q.claim(context.Background()); !errors.Is(err, ErrDeliveryTokenCollision) {
 			t.Fatalf("collision claim error = %v, want ErrDeliveryTokenCollision", err)
 		}
-		if got := reader.reads.Load(); got != 5 {
-			t.Fatalf("token reads = %d, want initial claim + 4 bounded collision attempts", got)
+		if remaining := reader.Len(); remaining != 0 {
+			t.Fatalf("unused token entropy bytes = %d, want 0 after four bounded attempts", remaining)
 		}
-		if got := client.LIndex(context.Background(), queue, 0).Val(); got != "second" {
-			t.Fatalf("collision changed ready task to %q", got)
-		}
-		if got := client.HGet(context.Background(), q.keys.inflight, first.token).Val(); got == "" {
-			t.Fatal("collision overwrote existing reservation")
+		if after := snapshotReliableQueueState(t, client, q.keys); !reflect.DeepEqual(after, before) {
+			t.Fatalf("claim collision exhaustion mutated queue state\nbefore: %#v\nafter:  %#v", before, after)
 		}
 	})
 
-	t.Run("deferred retry collision preserves reservation", func(t *testing.T) {
-		queue := "queue:{defer-collision}"
-		reader := &fixedTokenReader{}
+	t.Run("defer collisions across all reservation indexes", func(t *testing.T) {
+		queue := "queue:{defer-collision-indexes}"
+		entropy, tokens := reliableCollisionCandidates()
+		reader := bytes.NewReader(entropy)
 		q, client := newReliableTestQueue(t, queue, time.Second, reader)
-		if err := client.RPush(context.Background(), queue, "deferred-task").Err(); err != nil {
-			t.Fatalf("enqueue: %v", err)
-		}
-		delivery, err := q.claim(context.Background())
-		if err != nil || delivery == nil {
-			t.Fatalf("claim = (%v, %v)", delivery, err)
-		}
-		envelopeBefore := client.HGet(context.Background(), q.keys.inflight, delivery.token).Val()
-		scoreBefore := client.ZScore(context.Background(), q.keys.visibility, delivery.token).Val()
-
+		delivery := &reliableDelivery{token: "original-delivery", payload: []byte("deferred-task")}
+		seedReservedPayloadAt(t, client, q.keys, delivery.token, delivery.payload, time.Now().Add(time.Hour).UnixMilli())
+		seedReliableCollisionCandidates(t, client, q.keys, tokens)
+		before := snapshotReliableQueueState(t, client, q.keys)
 		next, err := q.deferRetry(context.Background(), delivery)
 		if !errors.Is(err, ErrDeliveryTokenCollision) || next != nil {
 			t.Fatalf("defer collision = (%v, %v), want (nil, ErrDeliveryTokenCollision)", next, err)
 		}
-		if got := reader.reads.Load(); got != 5 {
-			t.Fatalf("token reads = %d, want initial claim + 4 bounded defer attempts", got)
+		if remaining := reader.Len(); remaining != 0 {
+			t.Fatalf("unused token entropy bytes = %d, want 0 after four bounded attempts", remaining)
 		}
-		if envelopeAfter := client.HGet(context.Background(), q.keys.inflight, delivery.token).Val(); envelopeAfter != envelopeBefore {
-			t.Fatalf("defer collision changed reservation envelope from %q to %q", envelopeBefore, envelopeAfter)
-		}
-		if scoreAfter := client.ZScore(context.Background(), q.keys.visibility, delivery.token).Val(); scoreAfter != scoreBefore {
-			t.Fatalf("defer collision changed visibility score from %v to %v", scoreBefore, scoreAfter)
+		if after := snapshotReliableQueueState(t, client, q.keys); !reflect.DeepEqual(after, before) {
+			t.Fatalf("defer collision exhaustion mutated queue state\nbefore: %#v\nafter:  %#v", before, after)
 		}
 	})
 }

--- a/distributed/controller/controller_redis/reliable_queue_test.go
+++ b/distributed/controller/controller_redis/reliable_queue_test.go
@@ -384,6 +384,7 @@ type reliableQueueState struct {
 	repairCursor        string
 	repairCursorPresent bool
 	repairBacklog       []redis.Z
+	pttls               map[string]time.Duration
 }
 
 func snapshotReliableQueueState(t *testing.T, client redis.UniversalClient, keys reliableQueueKeys) reliableQueueState {
@@ -417,6 +418,14 @@ func snapshotReliableQueueState(t *testing.T, client redis.UniversalClient, keys
 	if err != nil {
 		t.Fatalf("snapshot repair backlog: %v", err)
 	}
+	readPTTL := func(name, key string) time.Duration {
+		t.Helper()
+		pttl, err := client.PTTL(ctx, key).Result()
+		if err != nil {
+			t.Fatalf("snapshot %s PTTL: %v", name, err)
+		}
+		return pttl
+	}
 	return reliableQueueState{
 		ready:               ready,
 		inflight:            inflight,
@@ -425,6 +434,43 @@ func snapshotReliableQueueState(t *testing.T, client redis.UniversalClient, keys
 		repairCursor:        repairCursor,
 		repairCursorPresent: repairCursorPresent,
 		repairBacklog:       repairBacklog,
+		pttls: map[string]time.Duration{
+			"ready":          readPTTL("ready", keys.ready),
+			"inflight":       readPTTL("inflight", keys.inflight),
+			"visibility":     readPTTL("visibility", keys.visibility),
+			"outcomes":       readPTTL("acknowledgement outcomes", keys.outcomes),
+			"repair cursor":  readPTTL("repair cursor", keys.repairCursor),
+			"repair backlog": readPTTL("repair backlog", keys.repairBacklog),
+		},
+	}
+}
+
+func assertReliableQueueStateUnchanged(t *testing.T, before, after reliableQueueState) {
+	t.Helper()
+	beforePTTLs := before.pttls
+	afterPTTLs := after.pttls
+	before.pttls = nil
+	after.pttls = nil
+	if !reflect.DeepEqual(after, before) {
+		t.Fatalf("queue values mutated\nbefore: %#v\nafter:  %#v", before, after)
+	}
+	if len(afterPTTLs) != len(beforePTTLs) {
+		t.Fatalf("PTTL snapshot key count changed from %d to %d", len(beforePTTLs), len(afterPTTLs))
+	}
+	for name, beforePTTL := range beforePTTLs {
+		afterPTTL, ok := afterPTTLs[name]
+		if !ok {
+			t.Fatalf("PTTL snapshot lost key %q", name)
+		}
+		if beforePTTL < 0 {
+			if afterPTTL != beforePTTL {
+				t.Fatalf("%s PTTL changed from %v to %v", name, beforePTTL, afterPTTL)
+			}
+			continue
+		}
+		if afterPTTL <= 0 || afterPTTL > beforePTTL || beforePTTL-afterPTTL > 2*time.Second {
+			t.Fatalf("%s PTTL changed from %v to %v beyond monotonic 2s tolerance", name, beforePTTL, afterPTTL)
+		}
 	}
 }
 
@@ -445,15 +491,20 @@ func seedReliableCollisionCandidates(t *testing.T, client redis.UniversalClient,
 		t.Fatalf("collision token count = %d, want %d", len(tokens), maxDeliveryTokenAttempts)
 	}
 	ctx := context.Background()
-	future := float64(time.Now().Add(time.Hour).UnixMilli())
+	now := time.Now()
+	visibilityDeadline := float64(now.Add(time.Hour).UnixMilli())
+	outcomeDeadline := float64(now.Add(ackOutcomeRetention).UnixMilli())
 	if err := client.HSet(ctx, keys.inflight, tokens[0], "0000000000:collision-reservation").Err(); err != nil {
 		t.Fatalf("seed inflight collision: %v", err)
 	}
-	if err := client.ZAdd(ctx, keys.visibility, &redis.Z{Score: future, Member: tokens[1]}).Err(); err != nil {
+	if err := client.ZAdd(ctx, keys.visibility, &redis.Z{Score: visibilityDeadline, Member: tokens[1]}).Err(); err != nil {
 		t.Fatalf("seed visibility-only collision: %v", err)
 	}
-	if err := client.ZAdd(ctx, keys.outcomes, &redis.Z{Score: future, Member: tokens[2]}).Err(); err != nil {
+	if err := client.ZAdd(ctx, keys.outcomes, &redis.Z{Score: outcomeDeadline, Member: tokens[2]}).Err(); err != nil {
 		t.Fatalf("seed unexpired outcome collision: %v", err)
+	}
+	if set, err := client.PExpire(ctx, keys.outcomes, ackOutcomeKeyTTL).Result(); err != nil || !set {
+		t.Fatalf("seed acknowledgement outcome TTL = %v, %v", set, err)
 	}
 	if err := client.ZAdd(ctx, keys.repairBacklog, &redis.Z{Score: 0, Member: tokens[3]}).Err(); err != nil {
 		t.Fatalf("seed repair-backlog collision: %v", err)
@@ -472,9 +523,7 @@ func TestDeliveryTokenGenerationIsBounded(t *testing.T) {
 		if _, err := q.claim(context.Background()); !errors.Is(err, ErrDeliveryTokenUnavailable) || !errors.Is(err, wantErr) {
 			t.Fatalf("claim error = %v, want token and source errors", err)
 		}
-		if after := snapshotReliableQueueState(t, client, q.keys); !reflect.DeepEqual(after, before) {
-			t.Fatalf("entropy failure mutated queue state\nbefore: %#v\nafter:  %#v", before, after)
-		}
+		assertReliableQueueStateUnchanged(t, before, snapshotReliableQueueState(t, client, q.keys))
 	})
 
 	t.Run("claim collisions across all reservation indexes", func(t *testing.T) {
@@ -487,15 +536,16 @@ func TestDeliveryTokenGenerationIsBounded(t *testing.T) {
 		}
 		seedReliableCollisionCandidates(t, client, q.keys, tokens)
 		before := snapshotReliableQueueState(t, client, q.keys)
+		if outcomePTTL := before.pttls["outcomes"]; outcomePTTL <= ackOutcomeRetention || outcomePTTL > ackOutcomeKeyTTL {
+			t.Fatalf("seeded outcome PTTL = %v, want (%v, %v]", outcomePTTL, ackOutcomeRetention, ackOutcomeKeyTTL)
+		}
 		if _, err := q.claim(context.Background()); !errors.Is(err, ErrDeliveryTokenCollision) {
 			t.Fatalf("collision claim error = %v, want ErrDeliveryTokenCollision", err)
 		}
 		if remaining := reader.Len(); remaining != 0 {
 			t.Fatalf("unused token entropy bytes = %d, want 0 after four bounded attempts", remaining)
 		}
-		if after := snapshotReliableQueueState(t, client, q.keys); !reflect.DeepEqual(after, before) {
-			t.Fatalf("claim collision exhaustion mutated queue state\nbefore: %#v\nafter:  %#v", before, after)
-		}
+		assertReliableQueueStateUnchanged(t, before, snapshotReliableQueueState(t, client, q.keys))
 	})
 
 	t.Run("defer collisions across all reservation indexes", func(t *testing.T) {
@@ -507,6 +557,9 @@ func TestDeliveryTokenGenerationIsBounded(t *testing.T) {
 		seedReservedPayloadAt(t, client, q.keys, delivery.token, delivery.payload, time.Now().Add(time.Hour).UnixMilli())
 		seedReliableCollisionCandidates(t, client, q.keys, tokens)
 		before := snapshotReliableQueueState(t, client, q.keys)
+		if outcomePTTL := before.pttls["outcomes"]; outcomePTTL <= ackOutcomeRetention || outcomePTTL > ackOutcomeKeyTTL {
+			t.Fatalf("seeded outcome PTTL = %v, want (%v, %v]", outcomePTTL, ackOutcomeRetention, ackOutcomeKeyTTL)
+		}
 		next, err := q.deferRetry(context.Background(), delivery)
 		if !errors.Is(err, ErrDeliveryTokenCollision) || next != nil {
 			t.Fatalf("defer collision = (%v, %v), want (nil, ErrDeliveryTokenCollision)", next, err)
@@ -514,9 +567,7 @@ func TestDeliveryTokenGenerationIsBounded(t *testing.T) {
 		if remaining := reader.Len(); remaining != 0 {
 			t.Fatalf("unused token entropy bytes = %d, want 0 after four bounded attempts", remaining)
 		}
-		if after := snapshotReliableQueueState(t, client, q.keys); !reflect.DeepEqual(after, before) {
-			t.Fatalf("defer collision exhaustion mutated queue state\nbefore: %#v\nafter:  %#v", before, after)
-		}
+		assertReliableQueueStateUnchanged(t, before, snapshotReliableQueueState(t, client, q.keys))
 	})
 }
 

--- a/specs/103/TECH.md
+++ b/specs/103/TECH.md
@@ -28,6 +28,8 @@ Acknowledgement outcomes score at Redis `TIME + 24h`. One acknowledgement remove
 
 Processing and decode failures move the envelope to a fresh reservation. The retained failure count increments and selects deterministic SHA-256 jitter over an exponentially increasing base, saturated at 60 seconds. Pre-processing cancellation uses immediate release instead.
 
+Queued payload validation decodes exactly one `Signature`, then requires a second decoder call to return `io.EOF`. Trailing JSON whitespace is accepted; trailing invalid bytes or another JSON value use the same decode-failure deferral path without invoking the processor or acknowledging the delivery.
+
 Tokens contain 128 random bits. Claim, reclaim, and deferred retry make at most four generation attempts. Every moving transition verifies the candidate is absent from inflight, visibility, acknowledgement-outcome, and repair-backlog state before writing; exhaustion leaves the original ready item or reservation byte-for-byte intact.
 
 ### Shutdown and idle polling
@@ -53,11 +55,11 @@ Each PRODUCT behavior has one primary regression test:
 | 9 | `TestStopJoinsHeartbeatAndOwnedDeliveries` | Skip the renewal join and begin ACK/return while the renew hook is blocked. |
 | 10 | `TestReliableLuaRedis7AckOutcomeUsesRedisTimeAndBoundedCleanup` | Use a non-24-hour score, client time, or unbounded/absent expired-outcome cleanup. |
 | 11 | `TestLegacyQueueAndClusterKeyCompatibility` | Change queue names, derive another slot, or key the bounded cache by full queue name. |
-| 12 | `TestMalformedPayloadRemainsRecoverable` | Acknowledge or delete bytes after decode failure. |
+| 12 | `TestQueuedPayloadValidationPreservesMalformedBytes` | Skip the required EOF check, or acknowledge/delete bytes after an initial or trailing decode failure. |
 | 13 | `TestLuaFailureBoundariesRetainRecoverableCopyOrAck` | Move a destructive write before its destination copy or remove ACK evidence. |
 | 14 | `TestPermanentFailuresUseBoundedBackoff` | Return a fixed one-second delay, reset the persisted count, or remove saturation. |
 | 15 | `TestIdleClaimRequestsAreBounded` | Keep a fixed tight poll interval, omit the cap/reset, or exceed the 1.2-second discovery bound. |
-| 16 | `TestDeliveryTokenGenerationIsBounded` | Remove claim/defer collision prevalidation, retry forever, or overwrite a reservation. |
+| 16 | `TestDeliveryTokenGenerationIsBounded` | Remove any claim/defer inflight, visibility, outcome, or repair-backlog collision guard; retry forever; or mutate ready/reserved state on exhaustion. |
 
 Behavior 15 is measured by Redis command-hook timestamps and real wall-clock deadlines in the test; it is not a fake-clock proof. The remaining unit tests use miniredis, deterministic token readers, and command hooks. Lua semantics, acknowledgement retention/cleanup, failpoint boundaries, stale-backlog repair, and Redis server time run against Redis 7. Cluster compatibility runs against three Redis 7 masters.
 

--- a/specs/103/TECH.md
+++ b/specs/103/TECH.md
@@ -28,9 +28,9 @@ Acknowledgement outcomes score at Redis `TIME + 24h`. One acknowledgement remove
 
 Processing and decode failures move the envelope to a fresh reservation. The retained failure count increments and selects deterministic SHA-256 jitter over an exponentially increasing base, saturated at 60 seconds. Pre-processing cancellation uses immediate release instead.
 
-Queued payload validation decodes exactly one `Signature`, then requires a second decoder call to return `io.EOF`. Trailing JSON whitespace is accepted; trailing invalid bytes or another JSON value use the same decode-failure deferral path without invoking the processor or acknowledging the delivery.
+Queued payload validation decodes exactly one `Signature`, then requires a second decoder call to return `io.EOF`. Trailing JSON whitespace is accepted; trailing invalid bytes or another JSON value use the same decode-failure deferral path without invoking the processor or acknowledging the delivery. That path increments the retained failure count and leaves the exact bytes under a future visibility deadline rather than releasing them directly to ready.
 
-Tokens contain 128 random bits. Claim, reclaim, and deferred retry make at most four generation attempts. Every moving transition verifies the candidate is absent from inflight, visibility, acknowledgement-outcome, and repair-backlog state before writing; exhaustion leaves the original ready item or reservation byte-for-byte intact.
+Tokens contain 128 random bits. Claim, reclaim, and deferred retry make at most four generation attempts. Every moving transition verifies the candidate is absent from inflight, visibility, acknowledgement-outcome, and repair-backlog state before writing; exhaustion leaves the original ready item or reservation byte-for-byte intact. Collision exits also preserve every related key's TTL or persistent/missing state, including the 24-hour outcome retention backed by its 25-hour key TTL.
 
 ### Shutdown and idle polling
 
@@ -55,11 +55,11 @@ Each PRODUCT behavior has one primary regression test:
 | 9 | `TestStopJoinsHeartbeatAndOwnedDeliveries` | Skip the renewal join and begin ACK/return while the renew hook is blocked. |
 | 10 | `TestReliableLuaRedis7AckOutcomeUsesRedisTimeAndBoundedCleanup` | Use a non-24-hour score, client time, or unbounded/absent expired-outcome cleanup. |
 | 11 | `TestLegacyQueueAndClusterKeyCompatibility` | Change queue names, derive another slot, or key the bounded cache by full queue name. |
-| 12 | `TestQueuedPayloadValidationPreservesMalformedBytes` | Skip the required EOF check, or acknowledge/delete bytes after an initial or trailing decode failure. |
+| 12 | `TestQueuedPayloadValidationPreservesMalformedBytes` | Skip the required EOF check; release malformed bytes directly to ready instead of retaining failure/backoff state; or acknowledge/delete them. |
 | 13 | `TestLuaFailureBoundariesRetainRecoverableCopyOrAck` | Move a destructive write before its destination copy or remove ACK evidence. |
 | 14 | `TestPermanentFailuresUseBoundedBackoff` | Return a fixed one-second delay, reset the persisted count, or remove saturation. |
 | 15 | `TestIdleClaimRequestsAreBounded` | Keep a fixed tight poll interval, omit the cap/reset, or exceed the 1.2-second discovery bound. |
-| 16 | `TestDeliveryTokenGenerationIsBounded` | Remove any claim/defer inflight, visibility, outcome, or repair-backlog collision guard; retry forever; or mutate ready/reserved state on exhaustion. |
+| 16 | `TestDeliveryTokenGenerationIsBounded` | Remove any claim/defer inflight, visibility, outcome, or repair-backlog collision guard; retry forever; mutate values; or change any related PTTL/persistent state before returning collision. |
 
 Behavior 15 is measured by Redis command-hook timestamps and real wall-clock deadlines in the test; it is not a fake-clock proof. The remaining unit tests use miniredis, deterministic token readers, and command hooks. Lua semantics, acknowledgement retention/cleanup, failpoint boundaries, stale-backlog repair, and Redis server time run against Redis 7. Cluster compatibility runs against three Redis 7 masters.
 


### PR DESCRIPTION
## What

- Reject trailing tokens or bytes after a decoded Redis task while allowing trailing whitespace.
- Expand malformed-payload recovery coverage and prove decode failures enter the deferred backoff path with the exact raw payload retained.
- Cover bounded delivery-token collisions across inflight, visibility, acknowledgement outcomes, and repair backlog state for both claim and defer, including key TTL preservation.
- Keep specs/103 behavior-to-test traceability aligned.

## Why

PR #105 delivered durable claim, ACK, and reclaim semantics, but Behavior 12 still allowed a valid JSON prefix with malformed trailing data to be processed and acknowledged. Behavior 16 also lacked regression proof for acknowledgement-outcome and repair-backlog token collisions and their TTL invariants.

Closes #103

## How

- Decode a second JSON value and require io.EOF before invoking the Processor.
- Reuse and assert the existing malformed-payload defer path so the exact raw payload remains recoverable with backoff.
- Seed deterministic candidate tokens into one occupied Redis state at a time and snapshot every related key, value, score, cursor, and TTL before and after bounded failure.

## Tests

- go test -race ./distributed/controller/controller_redis -count=10
- focused Behavior 12 and 16 race tests -count=100
- go vet ./distributed/...
- Redis 7.4.7 standalone live and Lua failpoint tests
- Redis 7.4.7 three-master Cluster live and slot tests
- Negative controls killed: EOF, malformed direct-release, claim/defer outcome and backlog guards, and claim/defer acknowledgement-outcome TTL shortening