### PR TITLE
fix(tools): guard nil binding targets at mappingByPtr entrypoint

### DIFF
--- a/tools/bind/form_mapping.go
+++ b/tools/bind/form_mapping.go
@@ -75,8 +75,13 @@ func (form formSource) TrySet(value reflect.Value, field reflect.StructField, ta
 }
 
 func mappingByPtr(ptr interface{}, setter setter, tag string) error {
+	v := reflect.ValueOf(ptr)
+	// untyped nil 或顶层 typed-nil 指针无法寻址赋值, 统一拒绝。
+	if !v.IsValid() || (v.Kind() == reflect.Ptr && v.IsNil()) {
+		return errUnknownType
+	}
 	// emptyField 空的结构体字段
-	_, err := mapping(reflect.ValueOf(ptr), emptyField, setter, tag, newMappingState())
+	_, err := mapping(v, emptyField, setter, tag, newMappingState())
 	return err
 }
 

--- a/tools/bind/nil_target_test.go
+++ b/tools/bind/nil_target_test.go
@@ -1,7 +1,10 @@
 package bind
 
 import (
+	"bytes"
 	"errors"
+	"mime/multipart"
+	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"reflect"
@@ -103,5 +106,59 @@ func TestFormBindingsRejectInvalidOrUnsettableTargets(t *testing.T) {
 				t.Fatalf("bind error = %v, want existing map conversion error", err)
 			}
 		})
+	}
+}
+
+func TestMappingByPtrBindingsRejectNilTargets(t *testing.T) {
+	type targetStruct struct {
+		Name string `form:"name" header:"name"`
+	}
+	var typedNil *targetStruct
+
+	binders := []struct {
+		name string
+		bind func(interface{}) error
+	}{
+		{
+			name: "header",
+			bind: func(target interface{}) error {
+				request := httptest.NewRequest(http.MethodGet, "/", nil)
+				request.Header.Set("name", "value")
+				return Header.Bind(request, target)
+			},
+		},
+		{
+			name: "form-multipart",
+			bind: func(target interface{}) error {
+				body := &bytes.Buffer{}
+				writer := multipart.NewWriter(body)
+				if err := writer.WriteField("name", "value"); err != nil {
+					t.Fatalf("write multipart field: %v", err)
+				}
+				if err := writer.Close(); err != nil {
+					t.Fatalf("close multipart writer: %v", err)
+				}
+				request := httptest.NewRequest(http.MethodPost, "/", body)
+				request.Header.Set("Content-Type", writer.FormDataContentType())
+				return FormMultipart.Bind(request, target)
+			},
+		},
+	}
+	invalid := []struct {
+		name   string
+		target interface{}
+	}{
+		{name: "untyped-nil", target: nil},
+		{name: "typed-nil-pointer", target: typedNil},
+	}
+
+	for _, binder := range binders {
+		for _, invalidTarget := range invalid {
+			t.Run(binder.name+"/"+invalidTarget.name, func(t *testing.T) {
+				if err := binder.bind(invalidTarget.target); !errors.Is(err, errUnknownType) {
+					t.Fatalf("bind error = %v, want %v", err, errUnknownType)
+				}
+			})
+		}
 	}
 }


### PR DESCRIPTION
## What
Guard the shared `mappingByPtr` entrypoint in `tools/bind` against untyped-nil and top-level typed-nil pointer targets, returning `errUnknownType` instead of panicking.

## Why
#108 added nil-target guards in `mapFormByTag`, covering uri/form/query. But `Header.Bind` and `FormMultipart.Bind` call `mappingByPtr` directly and bypass that guard. With a typed-nil pointer target and a request carrying a matching header/form field, `mapping` allocates a fresh value for the top-level nil pointer and then calls `value.Set(vPtr)` on the unaddressable `reflect.ValueOf(ptr)` root, panicking with `reflect: reflect.Value.Set using unaddressable value`.

## How
Add the guard once at `mappingByPtr` (the common entrypoint for all binders) rather than patching each binder: reject `!v.IsValid()` and top-level `Ptr` + `IsNil()` with `errUnknownType`, matching existing `mapFormByTag` semantics. The `mapFormByTag` guard is kept; whichever runs first rejects, with no double effect.

**Behavior change**: `Header.Bind` previously treated an untyped-nil target as a silent no-op returning `nil`, and a typed-nil target with no matching header also returned `nil` silently; both now return `errUnknownType`, aligned with form/uri/query.

## Testing
- New `TestMappingByPtrBindingsRejectNilTargets` covers {Header.Bind, FormMultipart.Bind} × {untyped-nil, typed-nil} with requests carrying matching headers/fields. Before the fix: typed-nil panics, untyped-nil returns nil; after: all return `errUnknownType`.
- `go test -race -count=1 ./tools/bind/... -timeout 120s` passes; `go vet ./tools/bind/...` clean.
