### PR TITLE
fix(parse_go): require method and router tags for RPC servers

### DIFF
--- a/parser/parse_go/model.go
+++ b/parser/parse_go/model.go
@@ -352,8 +352,17 @@ func isRPCServer(server *Server) bool {
 // checkFormat 简单处理meta信息,将对应func、server中的注释移入
 func (g *GoParsePB) checkFormat() error {
 	for _, serve := range g.Server {
-		if isRPCServer(serve) && serve.signatureErr != nil {
+		if !isRPCServer(serve) {
+			continue
+		}
+		if serve.signatureErr != nil {
 			return fmt.Errorf("parse_go: function %s has unsupported RPC signature: %w", serve.Name, serve.signatureErr)
+		}
+		if serve.Method == "" {
+			return fmt.Errorf("parse_go: function %s is missing the @method tag required to generate its RPC", serve.Name)
+		}
+		if serve.Router == "" {
+			return fmt.Errorf("parse_go: function %s is missing the @router tag required to generate its RPC", serve.Name)
 		}
 	}
 	// 之前已经调用过了,就直接返回了
@@ -379,9 +388,6 @@ func (g *GoParsePB) checkFormat() error {
 		if serve.ServerName != "" {
 			g.Metas["ServerName"] = serve.ServerName
 		}
-		//if serve.Router == "" || serve.Method == "" {
-		//	return errors.New("server router or method is empty")
-		//}
 		//if _, ok := serverHashSet[serve.Router+serve.Method]; ok {
 		//	return errors.New("server router method repeat")
 		//}

--- a/parser/parse_go/rpc_signature_test.go
+++ b/parser/parse_go/rpc_signature_test.go
@@ -37,6 +37,36 @@ func MissingResponse(req Request) {}
 	assertRPCSignatureError(t, err, "MissingResponse", "response")
 }
 
+func TestParseGoRejectsTaggedRPCWithoutMethodTag(t *testing.T) {
+	path := writeGoFixture(t, `package fixture
+
+type Request struct{}
+type Response struct{}
+
+// @service:Fixture
+// @router:/missing-method
+func MissingMethod(req Request) Response { return Response{} }
+`)
+
+	_, err := ParseGo(path, AddParseFunc(parseDoc), AddParseStruct(parseTag))
+	assertMissingRPCTagError(t, err, "MissingMethod", "@method")
+}
+
+func TestParseGoRejectsTaggedRPCWithoutRouterTag(t *testing.T) {
+	path := writeGoFixture(t, `package fixture
+
+type Request struct{}
+type Response struct{}
+
+// @service:Fixture
+// @method:post
+func MissingRouter(req Request) Response { return Response{} }
+`)
+
+	_, err := ParseGo(path, AddParseFunc(parseDoc), AddParseStruct(parseTag))
+	assertMissingRPCTagError(t, err, "MissingRouter", "@router")
+}
+
 func TestParseGoAcceptsContextPointerRPCAndSkipsHelper(t *testing.T) {
 	path := writeGoFixture(t, `package fixture
 
@@ -181,6 +211,18 @@ func writeGoFixture(t *testing.T, source string) string {
 		t.Fatalf("write fixture: %v", err)
 	}
 	return path
+}
+
+func assertMissingRPCTagError(t *testing.T, err error, functionName, tagName string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("ParseGo() error = nil, want missing %s tag error", tagName)
+	}
+	for _, want := range []string{functionName, tagName} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("ParseGo() error = %q, want it to contain %q", err, want)
+		}
+	}
 }
 
 func assertRPCSignatureError(t *testing.T, err error, functionName, detail string) {


### PR DESCRIPTION
## What
`ParseGo` now returns an error when a function classified as an RPC server (via `isRPCServer`, introduced in #149) is missing the `@method` or `@router` tag. The error names the function and the missing tag, e.g. `parse_go: function MissingMethod is missing the @method tag required to generate its RPC`.

## Why
The original method/router validation in `checkFormat` was commented out because it rejected ordinary non-RPC functions and message-only files. But the generation template unconditionally renders `{{.Method}} : "{{.Router}}"`, so an RPC missing either tag silently produced `option (google.api.http) = { : "/path" };`, which protoc rejects with `Expected identifier, got: :`. Users got a broken .proto instead of an actionable parse error.

## How
Scope the check to RPC servers only: in `checkFormat`, skip servers where `isRPCServer` is false, then validate `Method` and `Router` after the existing signature check. The superseded commented-out check is removed; the other commented-out validations (duplicate router/method, input/output message existence) are intentionally left untouched as out of scope.

## Testing
- Two new regression tests (valid signature + `@service` but missing `@method` / `@router` → error), confirmed failing before the fix (`ParseGo() error = nil`, generated proto rejected by protoc 34.0).
- `go test -race -count=1 ./parser/... -timeout 300s` and `go vet ./parser/...` pass; existing protoc-compile tests confirm fully-tagged RPCs still generate valid proto.