### PR TITLE
test(mongodb): skip live tests without GKIT_MONGODB_URI

### DIFF
--- a/distributed/backend/backend_mongodb/mongo_test.go
+++ b/distributed/backend/backend_mongodb/mongo_test.go
@@ -2,6 +2,7 @@ package backend_mongodb
 
 import (
 	"context"
+	"os"
 	"strconv"
 	"testing"
 	"time"
@@ -13,25 +14,43 @@ import (
 	"github.com/songzhibin97/gkit/distributed/backend"
 	"github.com/songzhibin97/gkit/distributed/task"
 	"go.mongodb.org/mongo-driver/mongo"
+	moption "go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/mongo/readpref"
 )
 
-func InitBackend() backend.Backend {
-	client, err := mongo.NewClient()
-	if err != nil {
-		return nil
+// initLiveBackend returns a MongoDB-backed backend for live tests.
+// It skips the calling test unless GKIT_MONGODB_URI points to a reachable server.
+func initLiveBackend(t *testing.T) backend.Backend {
+	t.Helper()
+	uri := os.Getenv("GKIT_MONGODB_URI")
+	if uri == "" {
+		t.Skip("GKIT_MONGODB_URI is not set")
 	}
-	err = client.Connect(context.Background())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	client, err := mongo.Connect(ctx, moption.Client().ApplyURI(uri).SetServerSelectionTimeout(5*time.Second))
 	if err != nil {
-		return nil
+		t.Skipf("connect MongoDB %q: %v", uri, err)
 	}
+	if err := client.Ping(ctx, readpref.Primary()); err != nil {
+		disconnectCtx, disconnectCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer disconnectCancel()
+		_ = client.Disconnect(disconnectCtx)
+		t.Skipf("ping MongoDB %q: %v", uri, err)
+	}
+	t.Cleanup(func() {
+		disconnectCtx, disconnectCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer disconnectCancel()
+		if err := client.Disconnect(disconnectCtx); err != nil {
+			t.Errorf("disconnect MongoDB client: %v", err)
+		}
+	})
 	return NewBackendMongoDB(client, -1)
 }
 
 func TestGroupTaskOver(t *testing.T) {
-	_backend := InitBackend()
-	if _backend == nil {
-		t.Skip()
-	}
+	_backend := initLiveBackend(t)
 	g := generator.NewSnowflake(time.Now().Local(), 1)
 	ids := make([]string, 0, 3)
 	for i := 0; i < 3; i++ {
@@ -96,10 +115,7 @@ func TestGroupTaskOver(t *testing.T) {
 }
 
 func TestGetStatus(t *testing.T) {
-	_backend := InitBackend()
-	if _backend == nil {
-		t.Skip()
-	}
+	_backend := initLiveBackend(t)
 	task1 := task.Signature{
 		ID:      "task1",
 		GroupID: "group",
@@ -137,10 +153,7 @@ func TestGetStatus(t *testing.T) {
 }
 
 func TestResult(t *testing.T) {
-	_backend := InitBackend()
-	if _backend == nil {
-		t.Skip()
-	}
+	_backend := initLiveBackend(t)
 	task1 := task.Signature{
 		ID:      "task1",
 		GroupID: "group",


### PR DESCRIPTION
## What
Guard the legacy live tests in `distributed/backend/backend_mongodb/mongo_test.go` (`TestGroupTaskOver`, `TestGetStatus`, `TestResult`) behind the `GKIT_MONGODB_URI` environment variable. The old `InitBackend` helper is replaced by `initLiveBackend(t)`, which skips when the variable is unset, and otherwise connects with a 5s server-selection timeout, pings, and skips with the reason if the server is unreachable. A `t.Cleanup` disconnects the client after each test.

## Why
`InitBackend` unconditionally dialed `localhost:27017`. Without a local MongoDB, `mongo.Connect` succeeds lazily and the first operation blocks in driver server selection, so the whole package hit the 300s `go test` timeout and failed — breaking CI and local full-suite runs even though the offline tests are healthy.

## How
Test-only change; no production code touched. Follows the env-guard convention already used by the package's other integration tests (`GKIT_MONGODB_URI` in retention/pending-error tests).

## Testing
- Without MongoDB: `go test -race -count=1 ./distributed/backend/backend_mongodb/... -timeout 120s` now passes in ~2-3s (live tests skip, offline tests all run); previously the package burned the full 300s timeout and failed.
- With an unreachable URI: each live test skips within ~5s and logs the ping error.