### PR TITLE
fix(mongodb): normalize duplicate group takeover errors to the shared sentinel

### DIFF
--- a/distributed/backend/backend_mongodb/group_takeover_regression_test.go
+++ b/distributed/backend/backend_mongodb/group_takeover_regression_test.go
@@ -1,0 +1,58 @@
+package backend_mongodb
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/songzhibin97/gkit/distributed/backend"
+	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
+)
+
+// TestGroupTakeOverDuplicateKeyError runs against the driver's mock deployment,
+// so it needs no real MongoDB. It pins the cross-backend contract from PR #99:
+// a duplicate group takeover must surface backend.ErrGroupAlreadyExists so
+// callers such as durable chord replays can tolerate it with errors.Is.
+func TestGroupTakeOverDuplicateKeyError(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+	defer mt.Close()
+
+	mt.Run("duplicate key maps to shared sentinel", func(mt *mtest.T) {
+		// A negative retention keeps the constructor free of MongoDB I/O.
+		b, err := NewBackendMongoDBE(mt.Client, -1)
+		if err != nil {
+			mt.Fatalf("NewBackendMongoDBE() error = %v", err)
+		}
+		mt.AddMockResponses(mtest.CreateWriteErrorsResponse(mtest.WriteError{
+			Index:   0,
+			Code:    11000,
+			Message: "E11000 duplicate key error collection: gkit.groups index: _id_ dup key",
+		}))
+		err = b.GroupTakeOver("group-1", "group", "task-1")
+		if !errors.Is(err, backend.ErrGroupAlreadyExists) {
+			mt.Fatalf("duplicate GroupTakeOver error = %v, want backend.ErrGroupAlreadyExists", err)
+		}
+		if want := `take over group "group-1"`; !strings.Contains(err.Error(), want) {
+			mt.Fatalf("duplicate GroupTakeOver error = %v, want message containing %q", err, want)
+		}
+	})
+
+	mt.Run("non-duplicate write error passes through", func(mt *mtest.T) {
+		b, err := NewBackendMongoDBE(mt.Client, -1)
+		if err != nil {
+			mt.Fatalf("NewBackendMongoDBE() error = %v", err)
+		}
+		mt.AddMockResponses(mtest.CreateWriteErrorsResponse(mtest.WriteError{
+			Index:   0,
+			Code:    121, // DocumentValidationFailure
+			Message: "Document failed validation",
+		}))
+		err = b.GroupTakeOver("group-1", "group", "task-1")
+		if err == nil {
+			mt.Fatal("GroupTakeOver error = nil, want the underlying write error")
+		}
+		if errors.Is(err, backend.ErrGroupAlreadyExists) {
+			mt.Fatalf("GroupTakeOver error = %v, must not map non-duplicate errors to ErrGroupAlreadyExists", err)
+		}
+	})
+}

--- a/distributed/backend/backend_mongodb/mongo.go
+++ b/distributed/backend/backend_mongodb/mongo.go
@@ -52,7 +52,14 @@ func (b *BackendMongoDB) SetResultExpire(expire int64) {
 
 func (b *BackendMongoDB) GroupTakeOver(groupID string, name string, taskIDs ...string) error {
 	group := task.InitGroupMeta(groupID, name, b.resultExpire, taskIDs...)
+	// GroupMeta stores GroupID as the document _id, so MongoDB's implicit
+	// unique index on _id rejects a second takeover with a duplicate key
+	// error. Normalize it to the shared sentinel so callers can tolerate
+	// repeated takeovers with errors.Is across every backend.
 	_, err := b.groupTable.InsertOne(context.Background(), group)
+	if mongo.IsDuplicateKeyError(err) {
+		return fmt.Errorf("take over group %q: %w", groupID, backend.ErrGroupAlreadyExists)
+	}
 	return err
 }
 

--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	github.com/go-sql-driver/mysql v1.7.0 // indirect
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/golang/snappy v0.0.1 // indirect
+	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/uuid v1.3.1 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,7 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gopacket v1.1.19 h1:ves8RnFZPGiFnTS0uPQStjwru6uO6h+nlr9j6fL7kF8=
 github.com/google/gopacket v1.1.19/go.mod h1:iJ8V8n6KS+z2U1A8pUwu8bW5SyEMkXJB8Yo/Vo+TKTo=


### PR DESCRIPTION
## What
The MongoDB backend's `GroupTakeOver` now detects duplicate key errors with `mongo.IsDuplicateKeyError` and wraps them as `take over group %q: backend.ErrGroupAlreadyExists`, matching the SQL and Redis backends. An offline regression test (driver `mtest` mock deployment, no live MongoDB) pins the mapping and verifies non-duplicate write errors pass through unwrapped.

## Why
PR #99 established the shared `backend.ErrGroupAlreadyExists` sentinel and wired the SQL and Redis backends, but MongoDB kept returning the raw E11000 write exception. Callers that tolerate duplicate takeovers via `errors.Is` — e.g. durable chord replays (`backend_redis/durable_chord.go:412`) — silently failed against the MongoDB backend, breaking the cross-backend contract.

## How
`GroupMeta` stores `GroupID` as the document `_id`, so MongoDB's implicit unique index guarantees the duplicate key error on repeated takeovers; no schema change is needed. The MongoDB durable chord path is unaffected: `ReconcileChord` upserts group meta with `$setOnInsert`, and `RegisterChord` checks `mongo.IsDuplicateKeyError` on the raw `chordTable` insert error before any wrapping. `go.mod`/`go.sum` gain the `go-cmp` indirect entry required by the driver's `mtest` package.

## Testing
- New `TestGroupTakeOverDuplicateKeyError` (mtest mock, offline): duplicate key → `errors.Is(err, backend.ErrGroupAlreadyExists)` with the shared message format; non-duplicate write error (code 121) passes through unwrapped. Red before the fix (raw E11000 surfaced).
- `go test -race -count=1 ./distributed/backend/...` passes (backend_mongodb offline tests run; the 3 pre-existing live-MongoDB tests that hang without a local server are addressed separately in #155).


> **Merge order note**: merge #155 (live-test env guard) before or together with this PR — this branch alone still contains the 3 legacy live MongoDB tests that hang the package without a local server.
