### PR TITLE
fix(controller): close the delayed-task crash-loss window between ZRem and Publish

### DIFF
--- a/distributed/controller/controller_redis/consumer_lifecycle_regression_test.go
+++ b/distributed/controller/controller_redis/consumer_lifecycle_regression_test.go
@@ -533,4 +533,9 @@ func TestCancelledDelayedRepublishRestoresOriginalSchedule(t *testing.T) {
 	} else if score != originalScore {
 		t.Fatalf("restored score = %.0f, want %.0f", score, originalScore)
 	}
+	// The restore must also clear the transit claim, or recovery would later
+	// republish the restored task a second time.
+	if transit := client.ZCard(context.Background(), deriveDelayedTransitKey("delayed")).Val(); transit != 0 {
+		t.Fatalf("transit zset still holds %d entries after restore, want 0", transit)
+	}
 }

--- a/distributed/controller/controller_redis/delayed_transit.go
+++ b/distributed/controller/controller_redis/delayed_transit.go
@@ -1,0 +1,201 @@
+package controller_redis
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/go-redis/redis/v8"
+)
+
+// Delayed tasks move from the delayed zset to their target ready queue in two
+// steps: an atomic Lua claim moves the due member into a same-slot transit
+// zset (scored by Redis server time in milliseconds), then the producer
+// decodes and republishes it from Go. A crash between the two steps therefore
+// leaves the member in transit instead of losing it; recoverDelayedTransit
+// moves members whose claim is older than delayedTransitRecoveryTimeout back
+// to the delayed zset for a fresh claim. Delivery is at-least-once: a
+// publisher slower than the recovery timeout can race recovery and deliver
+// twice, but a claimed task is never lost.
+
+const (
+	// delayedTransitRecoveryTimeout is how long a claimed delayed task may sit
+	// in the transit zset before recovery treats its publisher as crashed. It
+	// also paces the periodic recovery scan in produceDelayedTasks.
+	delayedTransitRecoveryTimeout = 30 * time.Second
+	// delayedTransitRecoveryBatch mirrors the bounded housekeeping batches
+	// used by the reliable queue scripts.
+	delayedTransitRecoveryBatch = 128
+)
+
+// deriveDelayedTransitKey returns the staging key that holds claimed delayed
+// tasks while they are republished. It shares the delayed queue's Redis
+// Cluster slot so the claim/restore/recover scripts stay single-slot.
+func deriveDelayedTransitKey(queue string) string {
+	return deriveReliableQueueKeys(queue).prefix + ":delayed-transit"
+}
+
+// delayedClaimScript atomically moves the earliest due member (FIFO by ETA
+// score) from the delayed zset (KEYS[1]) into the transit zset (KEYS[2]),
+// scored with Redis server time. The destination write precedes the
+// destructive source removal, and the script is atomic, so no client crash
+// can leave the member in neither key. Returns {member, score} or false when
+// nothing is due before ARGV[1].
+const delayedClaimScriptSource = `
+local function typename(key)
+  local value = redis.call('TYPE', key)
+  if type(value) == 'table' then return value['ok'] end
+  return value
+end
+local function requiretype(key, expected)
+  local actual = typename(key)
+  return actual == 'none' or actual == expected
+end
+local function nowms()
+  local now = redis.call('TIME')
+  return tonumber(now[1]) * 1000 + math.floor(tonumber(now[2]) / 1000)
+end
+if not requiretype(KEYS[1], 'zset') or not requiretype(KEYS[2], 'zset') then
+  return redis.error_reply('delayed claim: invalid key type')
+end
+local max = ARGV[1]
+if not max or not tonumber(max) then
+  return redis.error_reply('delayed claim: invalid argument')
+end
+local due = redis.call('ZRANGEBYSCORE', KEYS[1], '0', max, 'WITHSCORES', 'LIMIT', 0, 1)
+if #due ~= 2 then return false end
+redis.call('ZADD', KEYS[2], nowms(), due[1])
+redis.call('ZREM', KEYS[1], due[1])
+return {due[1], due[2]}
+`
+
+var delayedClaimScript = redis.NewScript(delayedClaimScriptSource)
+
+// delayedRestoreScript atomically puts a claimed member back into the delayed
+// zset (KEYS[1]) with its original ETA score and clears its transit entry
+// (KEYS[2]). Used when republishing fails without a crash.
+const delayedRestoreScriptSource = `
+local function typename(key)
+  local value = redis.call('TYPE', key)
+  if type(value) == 'table' then return value['ok'] end
+  return value
+end
+local function requiretype(key, expected)
+  local actual = typename(key)
+  return actual == 'none' or actual == expected
+end
+if not requiretype(KEYS[1], 'zset') or not requiretype(KEYS[2], 'zset') then
+  return redis.error_reply('delayed restore: invalid key type')
+end
+if not ARGV[1] or ARGV[1] == '' or not ARGV[2] or not tonumber(ARGV[2]) then
+  return redis.error_reply('delayed restore: invalid argument')
+end
+redis.call('ZADD', KEYS[1], ARGV[2], ARGV[1])
+redis.call('ZREM', KEYS[2], ARGV[1])
+return 1
+`
+
+var delayedRestoreScript = redis.NewScript(delayedRestoreScriptSource)
+
+// delayedRecoverScript moves transit members (KEYS[2]) whose claim is older
+// than ARGV[1] milliseconds of Redis server time back into the delayed zset
+// (KEYS[1]), keeping their claim score so recovered members stay due
+// immediately and preserve claim order. Bounded to one batch per call;
+// returns the number of members moved.
+const delayedRecoverScriptSource = `
+local function typename(key)
+  local value = redis.call('TYPE', key)
+  if type(value) == 'table' then return value['ok'] end
+  return value
+end
+local function requiretype(key, expected)
+  local actual = typename(key)
+  return actual == 'none' or actual == expected
+end
+local function nowms()
+  local now = redis.call('TIME')
+  return tonumber(now[1]) * 1000 + math.floor(tonumber(now[2]) / 1000)
+end
+if not requiretype(KEYS[1], 'zset') or not requiretype(KEYS[2], 'zset') then
+  return redis.error_reply('delayed recover: invalid key type')
+end
+local timeout = tonumber(ARGV[1])
+if not timeout or timeout <= 0 then
+  return redis.error_reply('delayed recover: invalid argument')
+end
+local stale = redis.call('ZRANGEBYSCORE', KEYS[2], '-inf', nowms() - timeout, 'WITHSCORES', 'LIMIT', 0, 128)
+if #stale == 0 then return 0 end
+local members = {}
+for index = 1, #stale, 2 do
+  redis.call('ZADD', KEYS[1], stale[index + 1], stale[index])
+  members[#members + 1] = stale[index]
+end
+redis.call('ZREM', KEYS[2], unpack(members))
+return #members
+`
+
+var delayedRecoverScript = redis.NewScript(delayedRecoverScriptSource)
+
+// claimDelayedTask atomically claims the earliest due delayed task into the
+// transit zset and returns its body and original ETA score. Returns redis.Nil
+// (from the script's nil reply) when nothing is due.
+func (c *ControllerRedis) claimDelayedTask(ctx context.Context, queue string) ([]byte, float64, error) {
+	max := strconv.FormatInt(time.Now().Local().UnixNano(), 10)
+	result, err := delayedClaimScript.Run(ctx, c.client, []string{queue, deriveDelayedTransitKey(queue)}, max).Result()
+	if err != nil {
+		return nil, 0, err
+	}
+	values, err := reliableScriptValues(result)
+	if err != nil {
+		return nil, 0, err
+	}
+	if len(values) != 2 {
+		return nil, 0, fmt.Errorf("claim delayed task: invalid script response")
+	}
+	member, err := reliableScriptBytes(values[0])
+	if err != nil {
+		return nil, 0, err
+	}
+	scoreBytes, err := reliableScriptBytes(values[1])
+	if err != nil {
+		return nil, 0, err
+	}
+	score, err := strconv.ParseFloat(string(scoreBytes), 64)
+	if err != nil {
+		return nil, 0, fmt.Errorf("claim delayed task: invalid score: %w", err)
+	}
+	return member, score, nil
+}
+
+// finalizeDelayedTransit clears a claimed member from the transit zset after
+// its republish succeeded. Uses a background context like the restore paths
+// so a consume-attempt cancellation cannot strand a published task in transit
+// (which would make recovery deliver it a second time on every shutdown).
+func (c *ControllerRedis) finalizeDelayedTransit(queue string, taskBody []byte) error {
+	ctx, cancel := context.WithTimeout(context.Background(), consumerRestoreTimeout)
+	defer cancel()
+	if err := c.client.ZRem(ctx, deriveDelayedTransitKey(queue), taskBody).Err(); err != nil {
+		return wrapRedisOperation("finalize delayed task", err)
+	}
+	return nil
+}
+
+// recoverDelayedTransit drains every stale transit member back into the
+// delayed zset, one bounded batch at a time.
+func (c *ControllerRedis) recoverDelayedTransit(ctx context.Context, queue string) error {
+	keys := []string{queue, deriveDelayedTransitKey(queue)}
+	for {
+		result, err := delayedRecoverScript.Run(ctx, c.client, keys, delayedTransitRecoveryTimeout.Milliseconds()).Result()
+		if err != nil {
+			return wrapRedisOperation("recover delayed tasks", err)
+		}
+		moved, err := reliableScriptInt(result)
+		if err != nil {
+			return err
+		}
+		if moved < delayedTransitRecoveryBatch {
+			return nil
+		}
+	}
+}

--- a/distributed/controller/controller_redis/delayed_transit.go
+++ b/distributed/controller/controller_redis/delayed_transit.go
@@ -18,11 +18,24 @@ import (
 // to the delayed zset for a fresh claim. Delivery is at-least-once: a
 // publisher slower than the recovery timeout can race recovery and deliver
 // twice, but a claimed task is never lost.
+//
+// The at-least-once invariant holds without a per-claim token because every
+// transition that removes a member is either atomic or publish-backed: the
+// claim, restore, and recover scripts move the member between the delayed and
+// transit zsets in a single atomic step (ZADD before ZREM), and
+// finalizeDelayedTransit only ZREMs a transit member after its Publish (RPush
+// to the ready queue) has succeeded. Members are keyed by task body, so a
+// slow publisher racing recovery and a second claimant can finalize away the
+// other claimant's transit entry — but only after at least one publish
+// landed, and a restore racing a finalize can at worst re-schedule an
+// already-published body. Every interleaving therefore degrades to duplicate
+// delivery, never to loss, which is why no claim token is needed.
 
 const (
 	// delayedTransitRecoveryTimeout is how long a claimed delayed task may sit
 	// in the transit zset before recovery treats its publisher as crashed. It
-	// also paces the periodic recovery scan in produceDelayedTasks.
+	// is also the default for ControllerRedis.delayedRecoveryInterval, which
+	// paces the periodic recovery scan in produceDelayedTasks.
 	delayedTransitRecoveryTimeout = 30 * time.Second
 	// delayedTransitRecoveryBatch mirrors the bounded housekeeping batches
 	// used by the reliable queue scripts.

--- a/distributed/controller/controller_redis/delayed_transit_test.go
+++ b/distributed/controller/controller_redis/delayed_transit_test.go
@@ -1,0 +1,211 @@
+package controller_redis
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	json "github.com/json-iterator/go"
+
+	"github.com/go-redis/redis/v8"
+
+	"github.com/songzhibin97/gkit/distributed/task"
+)
+
+// dueDelayedTaskBody enqueues an already-due delayed task into the delayed
+// zset and returns its serialized body and score.
+func dueDelayedTaskBody(t *testing.T, client redis.UniversalClient, id string) ([]byte, float64) {
+	t.Helper()
+	due := time.Now().Add(-time.Minute)
+	signature := task.NewSignature(id, "task", task.SetETATime(&due))
+	signature.Router = "test_task"
+	body, err := json.Marshal(signature)
+	if err != nil {
+		t.Fatalf("marshal delayed task: %v", err)
+	}
+	score := float64(due.UnixNano())
+	if err := client.ZAdd(context.Background(), "delayed", &redis.Z{Score: score, Member: body}).Err(); err != nil {
+		t.Fatalf("enqueue delayed task: %v", err)
+	}
+	return body, score
+}
+
+// redisHoldsTaskBody scans every key in Redis for the task body, regardless of
+// which data structure holds it.
+func redisHoldsTaskBody(t *testing.T, client redis.UniversalClient, body string) bool {
+	t.Helper()
+	ctx := context.Background()
+	keys, err := client.Keys(ctx, "*").Result()
+	if err != nil {
+		t.Fatalf("list redis keys: %v", err)
+	}
+	for _, key := range keys {
+		switch client.Type(ctx, key).Val() {
+		case "list":
+			for _, item := range client.LRange(ctx, key, 0, -1).Val() {
+				if strings.Contains(item, body) {
+					return true
+				}
+			}
+		case "zset":
+			for _, item := range client.ZRange(ctx, key, 0, -1).Val() {
+				if strings.Contains(item, body) {
+					return true
+				}
+			}
+		case "set":
+			for _, item := range client.SMembers(ctx, key).Val() {
+				if strings.Contains(item, body) {
+					return true
+				}
+			}
+		case "hash":
+			for _, item := range client.HGetAll(ctx, key).Val() {
+				if strings.Contains(item, body) {
+					return true
+				}
+			}
+		case "string":
+			if strings.Contains(client.Get(ctx, key).Val(), body) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TestClaimedDelayedTaskRemainsRecoverableInRedis covers the crash-loss
+// window: the delayed producer first removes the due task from the delayed
+// zset and only later republishes it to its router queue. If the process
+// crashes between the two steps, the task must still exist somewhere in Redis
+// so a recovery pass can republish it. The old WATCH+ZRem implementation left
+// it nowhere — an ETA task was lost forever.
+func TestClaimedDelayedTaskRemainsRecoverableInRedis(t *testing.T) {
+	c, _, client := newMiniController(t)
+	ctx := context.Background()
+	body, _ := dueDelayedTaskBody(t, client, "crash-window")
+
+	// Claim the due task exactly as produceDelayedTasks does, then simulate a
+	// crash before Publish by dropping the returned bytes on the floor.
+	popped, _, err := c.popDelayedTaskWithContext(ctx, "delayed", 1)
+	if err != nil {
+		t.Fatalf("pop delayed task: %v", err)
+	}
+	if string(popped) != string(body) {
+		t.Fatalf("popped = %q, want %q", popped, body)
+	}
+	if remaining := client.ZCard(ctx, "delayed").Val(); remaining != 0 {
+		t.Fatalf("delayed zset cardinality = %d, want 0 after claim", remaining)
+	}
+
+	if !redisHoldsTaskBody(t, client, string(body)) {
+		t.Fatal("claimed delayed task exists nowhere in Redis: a crash before Publish loses it forever")
+	}
+}
+
+// startDelayedProducer runs produceDelayedTasks in the background and returns
+// a stop function that cancels it, joins it, and fails on reported errors.
+func startDelayedProducer(t *testing.T, c *ControllerRedis) (stop func()) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	failures := make(chan error, 1)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		c.produceDelayedTasks(ctx, "delayed", func(err error) {
+			select {
+			case failures <- err:
+			default:
+			}
+		})
+	}()
+	return func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(3 * time.Second):
+			t.Fatal("delayed producer did not stop after cancellation")
+		}
+		select {
+		case err := <-failures:
+			t.Fatalf("delayed producer reported failure: %v", err)
+		default:
+		}
+	}
+}
+
+func waitForRouterTask(t *testing.T, client redis.UniversalClient, wantID string) {
+	t.Helper()
+	ctx := context.Background()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if republished := client.LRange(ctx, "test_task", 0, -1).Val(); len(republished) > 0 {
+			// Publish re-marshals the signature, so compare decoded IDs.
+			var got task.Signature
+			if err := json.Unmarshal([]byte(republished[0]), &got); err != nil {
+				t.Fatalf("decode republished task: %v", err)
+			}
+			if got.ID != wantID {
+				t.Fatalf("republished task ID = %q, want %q", got.ID, wantID)
+			}
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("task %q was never republished to its router queue", wantID)
+}
+
+func waitForEmptyTransit(t *testing.T, client redis.UniversalClient) {
+	t.Helper()
+	ctx := context.Background()
+	transit := deriveDelayedTransitKey("delayed")
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if client.ZCard(ctx, transit).Val() == 0 {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("transit zset still holds %d entries, want 0", client.ZCard(ctx, transit).Val())
+}
+
+// TestDelayedTaskCrashBeforePublishIsRepublishedByRecovery closes the loop:
+// after a producer claims a due task and crashes before Publish, a fresh
+// producer's recovery pass must move the transit entry back to the delayed
+// zset and republish it to its router queue (at-least-once, never lost).
+func TestDelayedTaskCrashBeforePublishIsRepublishedByRecovery(t *testing.T) {
+	c, mr, client := newMiniController(t)
+	ctx := context.Background()
+	dueDelayedTaskBody(t, client, "crash-recover")
+
+	// Claim, then simulate a crash before Publish by dropping the bytes.
+	if _, _, err := c.popDelayedTaskWithContext(ctx, "delayed", 1); err != nil {
+		t.Fatalf("pop delayed task: %v", err)
+	}
+
+	// A fresh producer starts after the recovery timeout elapsed (advance the
+	// Redis server clock the transit claim scores are anchored to).
+	mr.SetTime(time.Now().Add(delayedTransitRecoveryTimeout + time.Second))
+	stop := startDelayedProducer(t, c)
+	waitForRouterTask(t, client, "crash-recover")
+	waitForEmptyTransit(t, client)
+	stop()
+}
+
+// TestDelayedRepublishFinalizesTransit covers the normal path: a due task is
+// republished to its router queue and its transit entry is cleared, so a
+// later recovery pass cannot deliver it a second time.
+func TestDelayedRepublishFinalizesTransit(t *testing.T) {
+	c, _, client := newMiniController(t)
+	dueDelayedTaskBody(t, client, "normal-path")
+
+	stop := startDelayedProducer(t, c)
+	waitForRouterTask(t, client, "normal-path")
+	waitForEmptyTransit(t, client)
+	stop()
+
+	if remaining := client.ZCard(context.Background(), "delayed").Val(); remaining != 0 {
+		t.Fatalf("delayed zset cardinality = %d, want 0 after republish", remaining)
+	}
+}

--- a/distributed/controller/controller_redis/delayed_transit_test.go
+++ b/distributed/controller/controller_redis/delayed_transit_test.go
@@ -193,6 +193,52 @@ func TestDelayedTaskCrashBeforePublishIsRepublishedByRecovery(t *testing.T) {
 	stop()
 }
 
+// TestStaleTransitEntryIsRecoveredWhileProducerIsLive covers the recovery
+// starvation bug: popDelayedTaskWithContext polls internally while the delayed
+// zset is empty (redis.Nil -> continue), so a recovery check at the head of
+// the produce loop only ever ran at startup. A live producer with no due
+// tasks then never recovered transit entries stranded by a crashed peer.
+// Periodic recovery must run on its own ticker, independent of claim traffic.
+func TestStaleTransitEntryIsRecoveredWhileProducerIsLive(t *testing.T) {
+	c, mr, client := newMiniController(t)
+	ctx := context.Background()
+	c.delayedRecoveryInterval = 20 * time.Millisecond
+
+	// A sentinel task is claimed and published only after the startup recovery
+	// pass, so waiting for it (and for its transit entry to clear) proves the
+	// producer is past startup recovery and idle-polling an empty delayed zset
+	// before the stale entry is planted.
+	dueDelayedTaskBody(t, client, "sentinel")
+	stop := startDelayedProducer(t, c)
+	waitForRouterTask(t, client, "sentinel")
+	waitForEmptyTransit(t, client)
+	if err := client.Del(ctx, "test_task").Err(); err != nil {
+		t.Fatalf("clear router queue: %v", err)
+	}
+
+	// A crashed peer left a claimed task in transit. No new task is published
+	// after this point: only the live producer's periodic recovery can move
+	// the entry back to the delayed zset for a fresh claim.
+	due := time.Now().Add(-time.Minute)
+	signature := task.NewSignature("stale-peer", "task", task.SetETATime(&due))
+	signature.Router = "test_task"
+	body, err := json.Marshal(signature)
+	if err != nil {
+		t.Fatalf("marshal stale transit task: %v", err)
+	}
+	claimedAtMs := float64(time.Now().UnixMilli())
+	if err := client.ZAdd(ctx, deriveDelayedTransitKey("delayed"), &redis.Z{Score: claimedAtMs, Member: body}).Err(); err != nil {
+		t.Fatalf("plant stale transit entry: %v", err)
+	}
+	// Push the Redis server clock (which anchors transit claim scores) past
+	// the staleness threshold so recovery treats the peer as crashed.
+	mr.SetTime(time.Now().Add(delayedTransitRecoveryTimeout + time.Second))
+
+	waitForRouterTask(t, client, "stale-peer")
+	waitForEmptyTransit(t, client)
+	stop()
+}
+
 // TestDelayedRepublishFinalizesTransit covers the normal path: a due task is
 // republished to its router queue and its transit entry is cleared, so a
 // later recovery pass cannot deliver it a second time.

--- a/distributed/controller/controller_redis/redis.go
+++ b/distributed/controller/controller_redis/redis.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
-	"strconv"
 	"sync"
 	"time"
 
@@ -220,9 +219,9 @@ func (c *ControllerRedis) popTaskWithContext(ctx context.Context, queue string, 
 }
 
 // popDelayedTask pulls the oldest task that is due (smallest ETA-unixnano
-// score in [0, now]). The previous implementation used ZRevRangeByScore,
-// which returns the NEWEST due task — the oldest task starved until the
-// queue drained.
+// score in [0, now], FIFO by due time). The claimed task is retained in the
+// delayed transit zset until the caller finalizes or restores it, so a crash
+// before the republish never loses it (see delayed_transit.go).
 func (c *ControllerRedis) popDelayedTask(queue string, blockTime int64) ([]byte, error) {
 	result, _, err := c.popDelayedTaskWithContext(c.GetStopCtx(), queue, blockTime)
 	return result, err
@@ -232,8 +231,6 @@ func (c *ControllerRedis) popDelayedTaskWithContext(ctx context.Context, queue s
 	if blockTime <= 0 {
 		blockTime = int64(1000 * time.Millisecond)
 	}
-	var result []byte
-	var resultScore float64
 	for {
 		timer := time.NewTimer(time.Duration(blockTime))
 		select {
@@ -247,38 +244,12 @@ func (c *ControllerRedis) popDelayedTaskWithContext(ctx context.Context, queue s
 			return nil, 0, ctx.Err()
 		case <-timer.C:
 		}
-		watchFn := func(tx *redis.Tx) error {
-			now := time.Now().Local().UnixNano()
-			max := strconv.FormatInt(now, 10)
-			// Ascending: smallest score (earliest ETA) first → FIFO by due time.
-			items, err := tx.ZRangeByScoreWithScores(ctx, queue, &redis.ZRangeBy{Min: "0", Max: max, Offset: 0, Count: 1}).Result()
-			if err != nil {
-				return err
-			}
-			if len(items) != 1 {
-				return redis.Nil
-			}
-			member := fmt.Sprint(items[0].Member)
-			_, err = tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
-				pipe.ZRem(ctx, queue, member)
-				return nil
-			})
-			if err == nil {
-				result = []byte(member)
-				resultScore = items[0].Score
-			}
-			return err
-		}
-		err := c.client.Watch(ctx, watchFn, queue)
+		result, score, err := c.claimDelayedTask(ctx, queue)
 		switch {
 		case err == nil:
-			// Success — `result` was populated by the watchFn.
-			return result, resultScore, nil
+			return result, score, nil
 		case errors.Is(err, redis.Nil):
 			// No task ready; try again on the next tick.
-			continue
-		case errors.Is(err, redis.TxFailedErr):
-			// Optimistic-tx conflict; retry.
 			continue
 		case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
 			return nil, 0, err
@@ -349,7 +320,21 @@ func (c *ControllerRedis) produceQueuedTasks(
 }
 
 func (c *ControllerRedis) produceDelayedTasks(ctx context.Context, queue string, reportFailure func(error)) {
+	nextRecovery := time.Now()
 	for {
+		// Republish transit entries stranded by a crashed producer: once at
+		// startup, then periodically for entries stranded by a crashed peer.
+		if !time.Now().Before(nextRecovery) {
+			if err := c.recoverDelayedTransit(ctx, queue); err != nil {
+				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+					return
+				}
+				reportFailure(err)
+				return
+			}
+			nextRecovery = time.Now().Add(delayedTransitRecoveryTimeout)
+		}
+
 		taskBody, score, err := c.popDelayedTaskWithContext(ctx, queue, 0)
 		if err != nil {
 			switch {
@@ -373,6 +358,12 @@ func (c *ControllerRedis) produceDelayedTasks(ctx context.Context, queue string,
 			err = fmt.Errorf("decode delayed task: %w", err)
 		}
 		if err == nil {
+			if finalizeErr := c.finalizeDelayedTransit(queue, taskBody); finalizeErr != nil {
+				// The task is already published; a leftover transit entry only
+				// risks a duplicate republish after recovery, never a loss.
+				reportFailure(finalizeErr)
+				return
+			}
 			continue
 		}
 
@@ -430,7 +421,10 @@ func (c *ControllerRedis) requeueUnregisteredTask(queue string, taskBody []byte)
 func (c *ControllerRedis) restoreDelayedTask(queue string, taskBody []byte, score float64) error {
 	ctx, cancel := context.WithTimeout(context.Background(), consumerRestoreTimeout)
 	defer cancel()
-	if err := c.client.ZAdd(ctx, queue, &redis.Z{Score: score, Member: taskBody}).Err(); err != nil {
+	// Atomically restore the original ETA schedule and clear the transit
+	// entry, so recovery cannot republish an already-restored task.
+	err := delayedRestoreScript.Run(ctx, c.client, []string{queue, deriveDelayedTransitKey(queue)}, taskBody, score).Err()
+	if err != nil {
 		return wrapRedisOperation("restore delayed task", err)
 	}
 	return nil

--- a/distributed/controller/controller_redis/redis.go
+++ b/distributed/controller/controller_redis/redis.go
@@ -45,7 +45,14 @@ type ControllerRedis struct {
 	deliveryLease         time.Duration
 	finalizationTimeout   time.Duration
 	ackConfirmationWindow time.Duration
-	tokenSource           *deliveryTokenGenerator
+	// delayedRecoveryInterval paces the periodic delayed-transit recovery
+	// scan started by produceDelayedTasks. It defaults to
+	// delayedTransitRecoveryTimeout but is distinct from the Lua-side
+	// staleness threshold (always delayedTransitRecoveryTimeout): shortening
+	// the scan pace never makes transit entries stale sooner. Unexported on
+	// purpose; only same-package tests inject shorter intervals.
+	delayedRecoveryInterval time.Duration
+	tokenSource             *deliveryTokenGenerator
 }
 
 const consumerRestoreTimeout = 5 * time.Second
@@ -320,21 +327,51 @@ func (c *ControllerRedis) produceQueuedTasks(
 }
 
 func (c *ControllerRedis) produceDelayedTasks(ctx context.Context, queue string, reportFailure func(error)) {
-	nextRecovery := time.Now()
-	for {
-		// Republish transit entries stranded by a crashed producer: once at
-		// startup, then periodically for entries stranded by a crashed peer.
-		if !time.Now().Before(nextRecovery) {
-			if err := c.recoverDelayedTransit(ctx, queue); err != nil {
+	// Republish transit entries stranded by a crashed producer before the
+	// first claim, so a restart never waits a full recovery interval.
+	if err := c.recoverDelayedTransit(ctx, queue); err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return
+		}
+		reportFailure(err)
+		return
+	}
+
+	// Periodic recovery cannot live in the claim loop below:
+	// popDelayedTaskWithContext polls internally while the delayed zset is
+	// empty (redis.Nil -> retry), so the loop head is only reached again
+	// after a successful claim. With a live producer and no due tasks,
+	// entries stranded by a crashed peer would then never be recovered. A
+	// dedicated ticker goroutine scans regardless of claim traffic; it is
+	// joined before returning so StopConsuming's producer wait converges
+	// without leaking a goroutine.
+	recoveryCtx, cancelRecovery := context.WithCancel(ctx)
+	recoveryDone := make(chan struct{})
+	go func() {
+		defer close(recoveryDone)
+		ticker := time.NewTicker(c.delayedRecoveryInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-recoveryCtx.Done():
+				return
+			case <-ticker.C:
+			}
+			if err := c.recoverDelayedTransit(recoveryCtx, queue); err != nil {
 				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 					return
 				}
 				reportFailure(err)
 				return
 			}
-			nextRecovery = time.Now().Add(delayedTransitRecoveryTimeout)
 		}
+	}()
+	defer func() {
+		cancelRecovery()
+		<-recoveryDone
+	}()
 
+	for {
 		taskBody, score, err := c.popDelayedTaskWithContext(ctx, queue, 0)
 		if err != nil {
 			switch {
@@ -491,15 +528,16 @@ func (c *ControllerRedis) GetDelayedTasks() ([]*task.Signature, error) {
 // closing it after every component sharing the client has stopped using it.
 func NewControllerRedis(broker *broker.Broker, client redis.UniversalClient, consumingQueue, delayedQueue string) controller.Controller {
 	return &ControllerRedis{
-		Broker:                broker,
-		client:                client,
-		lock:                  redsync.New(goredis.NewPool(client)),
-		helper:                log.NewHelper(log.DefaultLogger),
-		consumingQueue:        consumingQueue,
-		delayedQueue:          delayedQueue,
-		deliveryLease:         defaultDeliveryLease,
-		finalizationTimeout:   consumerRestoreTimeout,
-		ackConfirmationWindow: consumerRestoreTimeout,
-		tokenSource:           newDeliveryTokenGenerator(nil),
+		Broker:                  broker,
+		client:                  client,
+		lock:                    redsync.New(goredis.NewPool(client)),
+		helper:                  log.NewHelper(log.DefaultLogger),
+		consumingQueue:          consumingQueue,
+		delayedQueue:            delayedQueue,
+		deliveryLease:           defaultDeliveryLease,
+		finalizationTimeout:     consumerRestoreTimeout,
+		ackConfirmationWindow:   consumerRestoreTimeout,
+		delayedRecoveryInterval: delayedTransitRecoveryTimeout,
+		tokenSource:             newDeliveryTokenGenerator(nil),
 	}
 }

--- a/distributed/controller/controller_redis/redis_test.go
+++ b/distributed/controller/controller_redis/redis_test.go
@@ -42,7 +42,7 @@ func initLiveController(t *testing.T) controller.Controller {
 
 		cleanupCtx, cancelCleanup := context.WithTimeout(context.Background(), time.Second)
 		defer cancelCleanup()
-		if err := client.Del(cleanupCtx, queue, delayedQueue, reliableKeys.inflight,
+		if err := client.Del(cleanupCtx, queue, delayedQueue, deriveDelayedTransitKey(delayedQueue), reliableKeys.inflight,
 			reliableKeys.visibility, reliableKeys.outcomes, reliableKeys.repairCursor, reliableKeys.repairBacklog).Err(); err != nil {
 			t.Errorf("clean live Redis queues: %v", err)
 		}


### PR DESCRIPTION
## What
Delayed (ETA) tasks could be permanently lost if the process crashed between removing a due task from the delayed zset and republishing it to its router queue. This PR makes the delayed producer crash-safe: claims are staged in a same-slot `delayed-transit` zset and a recovery pass republishes stranded claims, giving at-least-once delivery across crashes.

## Why
`popDelayedTaskWithContext` ZRem'd the due member inside a WATCH transaction, and `produceDelayedTasks` only later RPush'd it via `Publish`. The `restoreDelayedTask` fallback covers Publish *errors*, not a dead process — a crash in between left the task nowhere. #103 hardened the consuming side (reliable claim/ACK) but the delayed producer kept this bare window.

## How
- Replace the WATCH+ZRem pop with an atomic Lua claim: the earliest-due member (ETA FIFO preserved) is ZADD'ed into a same-slot transit zset (scored by Redis server time) before being ZREM'ed from the delayed zset — destination written before destructive removal, matching the reliable-queue script discipline. A transit zset was chosen over publishing directly from Lua because the target queue comes from the JSON `Router` field; resolving it inside the script would need a key not declared in KEYS (CROSSSLOT under Redis Cluster) and would duplicate `Publish`'s Go logic.
- After a successful `Publish`, the producer finalizes the transit entry (background context, so shutdown cannot strand a published task); a failed `Publish` atomically restores the original ETA schedule and clears transit via Lua.
- `produceDelayedTasks` runs a bounded (128/batch) recovery scan at startup and every 30s, moving transit claims older than 30s of server time back into the delayed zset for a fresh claim. Any crash point now leaves the task recoverable; duplicates are possible only when a publisher outlives the recovery timeout or crashes after RPush (at-least-once, consistent with #103 semantics).

## Testing
- `TestClaimedDelayedTaskRemainsRecoverableInRedis` — fails on the old code (`claimed delayed task exists nowhere in Redis` after a simulated crash), passes now.
- `TestDelayedTaskCrashBeforePublishIsRepublishedByRecovery` — closed-loop recovery via miniredis `SetTime`: crash → clock past recovery timeout → new producer republishes, transit drained.
- Normal-path finalization, atomic restore, ETA-FIFO order, and error-propagation tests all pass; `go test -race -count=1 ./distributed/controller/... -timeout 300s` green, `go vet` clean.


> **Ordering note**: a recovered transit member is re-scored with its (millisecond) claim time, which is far smaller than the nanosecond ETA scores, so recovered tasks sort ahead of all regularly scheduled tasks and are claimed first. This is intentional — they were already due and have been stranded for 30s+ — but it means recovery briefly deviates from strict ETA-FIFO among pending tasks.
